### PR TITLE
Fix release workflow: add repo to changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": "@changesets/changelog-github",
+  "changelog": ["@changesets/changelog-github", { "repo": "mike-north/vaultkeeper" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Summary

- Fix `@changesets/changelog-github` config to include the required `repo` parameter
- Without this, `changeset version` fails with: *"Please provide a repo to this changelog generator"*
- This caused both release workflow runs to fail: [#22263612669](https://github.com/mike-north/vaultkeeper/actions/runs/22263612669), [#22265398194](https://github.com/mike-north/vaultkeeper/actions/runs/22265398194)

## Test plan

- [x] Verified the config change matches the [documented format](https://github.com/changesets/changesets/blob/main/packages/changelog-github/README.md)
- [ ] Release workflow passes on next push to `main`