### PR TITLE
Add multi-secret support for delegated exec and fetch

### DIFF
--- a/.changeset/multi-secret-placeholders.md
+++ b/.changeset/multi-secret-placeholders.md
@@ -1,0 +1,5 @@
+---
+"vaultkeeper": minor
+---
+
+Add multi-secret support for delegated exec and fetch via `SecretTokenMap` and `{{secret:name}}` placeholders.

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -210,6 +210,9 @@ export class SecretNotFoundError extends VaultError {
 }
 
 // @public
+export type SecretTokenMap = Record<string, CapabilityToken>;
+
+// @public
 export interface SetupChoice {
     readonly label: string;
     readonly value: string;
@@ -302,11 +305,11 @@ export class VaultKeeper {
     }>;
     delete(name: string): Promise<void>;
     static doctor(options?: RunDoctorOptions): Promise<PreflightResult>;
-    exec(token: CapabilityToken, request: ExecRequest): Promise<{
+    exec(token: CapabilityToken | SecretTokenMap, request: ExecRequest): Promise<{
         result: ExecResult;
         vaultResponse: VaultResponse;
     }>;
-    fetch(token: CapabilityToken, request: FetchRequest): Promise<{
+    fetch(token: CapabilityToken | SecretTokenMap, request: FetchRequest): Promise<{
         response: Response;
         vaultResponse: VaultResponse;
     }>;

--- a/packages/vaultkeeper/src/access/delegated-exec.ts
+++ b/packages/vaultkeeper/src/access/delegated-exec.ts
@@ -1,53 +1,46 @@
 /**
  * Delegated command execution access pattern.
  *
- * Replaces `{{secret}}` placeholders in command args and environment values,
- * then executes the command.
+ * Replaces `{{secret}}` or `{{secret:name}}` placeholders in command args
+ * and environment values, then executes the command.
  */
 
 import { spawn } from 'node:child_process'
 import type { ExecRequest, ExecResult } from '../types.js'
 import { ExecError } from '../errors.js'
-
-const PLACEHOLDER = '{{secret}}'
-
-function replacePlaceholder(value: string, secret: string): string {
-  return value.replaceAll(PLACEHOLDER, secret)
-}
-
-function replaceInRecord(
-  record: Record<string, string>,
-  secret: string,
-): Record<string, string> {
-  const result: Record<string, string> = {}
-  for (const [key, value] of Object.entries(record)) {
-    result[key] = replacePlaceholder(value, secret)
-  }
-  return result
-}
+import {
+  ANY_PLACEHOLDER_RE,
+  resolvePlaceholders,
+  resolvePlaceholdersInRecord,
+} from './placeholder.js'
 
 /**
- * Execute a delegated command with the secret injected into args and env.
+ * Execute a delegated command with secrets injected into args and env.
  *
- * @param secret - The secret value to inject
- * @param request - The exec request template with `{{secret}}` placeholders
+ * @param secrets - A single secret string (replaces `{{secret}}`) or a
+ *   name-to-value map (replaces `{{secret:name}}`)
+ * @param request - The exec request template with placeholders
  * @returns The command result (stdout, stderr, exitCode)
  * @internal
  */
 export function delegatedExec(
-  secret: string,
+  secrets: string | Record<string, string>,
   request: ExecRequest,
 ): Promise<ExecResult> {
-  if (request.command.includes(PLACEHOLDER)) {
+  if (ANY_PLACEHOLDER_RE.test(request.command)) {
     throw new ExecError(
-      `The {{secret}} placeholder is not supported in the command field. Use args or env instead.`,
+      `Secret placeholders are not supported in the command field. Use args or env instead.`,
       request.command,
     )
   }
 
-  const args = (request.args ?? []).map((arg) => replacePlaceholder(arg, secret))
+  const args = (request.args ?? []).map((arg) =>
+    resolvePlaceholders(arg, secrets),
+  )
   const env =
-    request.env !== undefined ? replaceInRecord(request.env, secret) : undefined
+    request.env !== undefined
+      ? resolvePlaceholdersInRecord(request.env, secrets)
+      : undefined
 
   return new Promise((resolve, reject) => {
     const spawnOptions: Parameters<typeof spawn>[2] = {

--- a/packages/vaultkeeper/src/access/delegated-fetch.ts
+++ b/packages/vaultkeeper/src/access/delegated-fetch.ts
@@ -1,49 +1,37 @@
 /**
  * Delegated HTTP fetch access pattern.
  *
- * Replaces `{{secret}}` placeholders in the request URL, headers, and body
- * with the actual secret value, then executes the fetch.
+ * Replaces `{{secret}}` or `{{secret:name}}` placeholders in the request
+ * URL, headers, and body with actual secret values, then executes the fetch.
  */
 
 import type { FetchRequest } from '../types.js'
-
-const PLACEHOLDER = '{{secret}}'
-
-function replacePlaceholder(value: string, secret: string): string {
-  return value.replaceAll(PLACEHOLDER, secret)
-}
-
-function replaceInRecord(
-  record: Record<string, string>,
-  secret: string,
-): Record<string, string> {
-  const result: Record<string, string> = {}
-  for (const [key, value] of Object.entries(record)) {
-    result[key] = replacePlaceholder(value, secret)
-  }
-  return result
-}
+import {
+  resolvePlaceholders,
+  resolvePlaceholdersInRecord,
+} from './placeholder.js'
 
 /**
- * Execute a delegated HTTP fetch with the secret injected into the request.
+ * Execute a delegated HTTP fetch with secrets injected into the request.
  *
- * @param secret - The secret value to inject
- * @param request - The fetch request template with `{{secret}}` placeholders
+ * @param secrets - A single secret string (replaces `{{secret}}`) or a
+ *   name-to-value map (replaces `{{secret:name}}`)
+ * @param request - The fetch request template with placeholders
  * @returns The fetch Response
  * @internal
  */
 export async function delegatedFetch(
-  secret: string,
+  secrets: string | Record<string, string>,
   request: FetchRequest,
 ): Promise<Response> {
-  const url = replacePlaceholder(request.url, secret)
+  const url = resolvePlaceholders(request.url, secrets)
   const headers =
     request.headers !== undefined
-      ? replaceInRecord(request.headers, secret)
+      ? resolvePlaceholdersInRecord(request.headers, secrets)
       : undefined
   const body =
     request.body !== undefined
-      ? replacePlaceholder(request.body, secret)
+      ? resolvePlaceholders(request.body, secrets)
       : undefined
 
   const init: RequestInit = {}

--- a/packages/vaultkeeper/src/access/placeholder.ts
+++ b/packages/vaultkeeper/src/access/placeholder.ts
@@ -1,0 +1,71 @@
+/**
+ * Placeholder replacement utilities for delegated access patterns.
+ *
+ * Supports two modes:
+ * - **Single-secret:** `{{secret}}` is replaced with a single secret value
+ * - **Named-secret:** `{{secret:name}}` is replaced with the corresponding
+ *   named secret from a `Record<string, string>` map
+ */
+
+import { VaultError } from '../errors.js'
+
+/** Literal placeholder for single-secret mode. */
+export const PLACEHOLDER = '{{secret}}'
+
+/** Regex matching `{{secret:name}}` named placeholders. */
+const NAMED_PLACEHOLDER_RE = /\{\{secret:([^}]+)\}\}/g
+
+/** Regex matching any secret placeholder (named or unnamed). */
+export const ANY_PLACEHOLDER_RE = /\{\{secret(?::[^}]+)?\}\}/
+
+/**
+ * Replace placeholders in a string with secret values.
+ *
+ * When `secrets` is a `string`, every `{{secret}}` occurrence is replaced.
+ * When `secrets` is a `Record`, every `{{secret:name}}` occurrence is
+ * resolved from the corresponding map entry.
+ *
+ * @param value - The string containing placeholders
+ * @param secrets - A single secret string (replaces `{{secret}}`) or a
+ *   name-to-value map (replaces `{{secret:name}}`)
+ * @returns The string with all matching placeholders resolved
+ * @throws {VaultError} If a named placeholder references a name not in the map
+ * @internal
+ */
+export function resolvePlaceholders(
+  value: string,
+  secrets: string | Record<string, string>,
+): string {
+  if (typeof secrets === 'string') {
+    return value.replaceAll(PLACEHOLDER, secrets)
+  }
+  return value.replace(NAMED_PLACEHOLDER_RE, (_match, name: string) => {
+    const secret = secrets[name]
+    if (secret === undefined) {
+      const available = Object.keys(secrets).join(', ')
+      throw new VaultError(
+        `Unknown secret name in placeholder: {{secret:${name}}}. Available names: ${available}`,
+      )
+    }
+    return secret
+  })
+}
+
+/**
+ * Replace placeholders in all values of a string record.
+ *
+ * @param record - Key-value pairs whose values may contain placeholders
+ * @param secrets - A single secret string or a name-to-value map
+ * @returns A new record with all placeholders in values resolved
+ * @internal
+ */
+export function resolvePlaceholdersInRecord(
+  record: Record<string, string>,
+  secrets: string | Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const [key, value] of Object.entries(record)) {
+    result[key] = resolvePlaceholders(value, secrets)
+  }
+  return result
+}

--- a/packages/vaultkeeper/src/index.ts
+++ b/packages/vaultkeeper/src/index.ts
@@ -60,7 +60,7 @@ export { BackendRegistry, isListableBackend } from './backend/index.js'
 export { CapabilityToken } from './identity/index.js'
 
 export { VaultKeeper } from './vault.js'
-export type { VaultKeeperOptions, SetupOptions } from './vault.js'
+export type { VaultKeeperOptions, SetupOptions, SecretTokenMap } from './vault.js'
 
 export { runDoctor } from './doctor/runner.js'
 export type { RunDoctorOptions } from './doctor/runner.js'

--- a/packages/vaultkeeper/src/types.ts
+++ b/packages/vaultkeeper/src/types.ts
@@ -74,25 +74,27 @@ export interface VaultResponse {
  * Request for delegated HTTP fetch.
  *
  * String values in `url`, `headers`, and `body` may include the placeholder
- * `{{secret}}`, which is replaced with the actual secret value immediately
- * before the request is sent.
+ * `{{secret}}` (single-token mode) or `{{secret:name}}` (multi-token mode),
+ * which are replaced with actual secret values immediately before the request
+ * is sent.
  */
 export interface FetchRequest {
   /**
-   * The target URL. May contain `{{secret}}` which is replaced with the secret
-   * value before the fetch is executed (e.g. for API-key-in-URL patterns).
+   * The target URL. May contain `{{secret}}` or `{{secret:name}}` which is
+   * replaced with the secret value before the fetch is executed.
    */
   url: string
   /** HTTP method (defaults to `'GET'` when omitted). */
   method?: string | undefined
   /**
-   * Request headers. Any header value may contain `{{secret}}`, which is
-   * replaced with the secret value before the request is sent.
+   * Request headers. Any header value may contain `{{secret}}` or
+   * `{{secret:name}}`, which is replaced with the secret value before
+   * the request is sent.
    */
   headers?: Record<string, string> | undefined
   /**
-   * Request body. May contain `{{secret}}`, which is replaced with the secret
-   * value before the request is sent.
+   * Request body. May contain `{{secret}}` or `{{secret:name}}`, which is
+   * replaced with the secret value before the request is sent.
    */
   body?: string | undefined
 }
@@ -100,22 +102,23 @@ export interface FetchRequest {
 /**
  * Request for delegated command execution.
  *
- * String values in `args` and `env` may include the placeholder `{{secret}}`,
- * which is replaced with the actual secret value immediately before the command
- * is spawned.
+ * String values in `args` and `env` may include the placeholder `{{secret}}`
+ * (single-token mode) or `{{secret:name}}` (multi-token mode), which are
+ * replaced with actual secret values immediately before the command is spawned.
  */
 export interface ExecRequest {
   /** The command (binary) to execute. */
   command: string
   /**
-   * Command-line arguments. Any argument may contain `{{secret}}`, which is
-   * replaced with the secret value before the command is spawned.
+   * Command-line arguments. Any argument may contain `{{secret}}` or
+   * `{{secret:name}}`, which is replaced with the secret value before the
+   * command is spawned.
    */
   args?: string[] | undefined
   /**
    * Additional environment variables to merge into the child process
-   * environment. Any value may contain `{{secret}}`, which is replaced with
-   * the secret value before the command is spawned.
+   * environment. Any value may contain `{{secret}}` or `{{secret:name}}`,
+   * which is replaced with the secret value before the command is spawned.
    */
   env?: Record<string, string> | undefined
   /** Working directory for the spawned process. */

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -42,6 +42,28 @@ import {
   KeyRevokedError,
 } from './errors.js'
 
+/**
+ * Map of named secrets to their capability tokens.
+ *
+ * Use with `exec()` or `fetch()` to inject multiple secrets into a single
+ * request. Each key becomes the name referenced in `{{secret:name}}`
+ * placeholders.
+ *
+ * @example
+ * ```ts
+ * const { token: apiToken } = await vault.authorize(apiJwe)
+ * const { token: dbToken } = await vault.authorize(dbJwe)
+ *
+ * await vault.exec(
+ *   { apiKey: apiToken, dbPass: dbToken },
+ *   { command: 'deploy', env: { API_KEY: '{{secret:apiKey}}', DB: '{{secret:dbPass}}' } },
+ * )
+ * ```
+ *
+ * @public
+ */
+export type SecretTokenMap = Record<string, CapabilityToken>
+
 /** Options for initializing VaultKeeper. */
 export interface VaultKeeperOptions {
   /** Override the config directory. */
@@ -268,26 +290,30 @@ export class VaultKeeper {
   }
 
   /**
-   * Execute a delegated HTTP fetch, injecting the secret from the token.
+   * Execute a delegated HTTP fetch, injecting secrets from the token(s).
    *
-   * The secret value is substituted for every `{{secret}}` placeholder found
-   * in `request.url`, `request.headers`, and `request.body` before the fetch
-   * is executed. The raw secret is never exposed in the return value.
+   * **Single token:** every `{{secret}}` placeholder in `request.url`,
+   * `request.headers`, and `request.body` is replaced with the secret value.
    *
-   * @param token - A `CapabilityToken` obtained from `authorize()`.
-   * @param request - The fetch request template. Use `{{secret}}` as a
-   *   placeholder wherever the secret value should be injected.
+   * **Token map ({@link SecretTokenMap}):** every `{{secret:name}}` placeholder
+   * is replaced with the secret from the corresponding named token.
+   *
+   * The raw secret is never exposed in the return value.
+   *
+   * @param token - A single `CapabilityToken` or a `SecretTokenMap` mapping
+   *   names to tokens obtained from `authorize()`.
+   * @param request - The fetch request template with placeholders.
    * @returns The `Response` from the underlying `fetch()` call, together with
    *   the vault metadata (`vaultResponse`).
-   * @throws {Error} If `token` is invalid or was not created by this vault
-   *   instance.
+   * @throws {AuthorizationDeniedError} If any token is invalid or was not
+   *   created by this vault instance.
    */
   async fetch(
-    token: CapabilityToken,
+    token: CapabilityToken | SecretTokenMap,
     request: FetchRequest,
   ): Promise<{ response: Response; vaultResponse: VaultResponse }> {
-    const claims = validateCapabilityToken(token)
-    const response = await delegatedFetch(claims.val, request)
+    const secrets = VaultKeeper.#resolveSecrets(token)
+    const response = await delegatedFetch(secrets, request)
     return {
       response,
       vaultResponse: { keyStatus: 'current' },
@@ -295,26 +321,30 @@ export class VaultKeeper {
   }
 
   /**
-   * Execute a delegated command, injecting the secret from the token.
+   * Execute a delegated command, injecting secrets from the token(s).
    *
-   * The secret value is substituted for every `{{secret}}` placeholder found
-   * in `request.args` and `request.env` values before the process is spawned.
+   * **Single token:** every `{{secret}}` placeholder in `request.args` and
+   * `request.env` values is replaced with the secret value.
+   *
+   * **Token map ({@link SecretTokenMap}):** every `{{secret:name}}` placeholder
+   * is replaced with the secret from the corresponding named token.
+   *
    * The raw secret is never exposed in the return value.
    *
-   * @param token - A `CapabilityToken` obtained from `authorize()`.
-   * @param request - The exec request template. Use `{{secret}}` as a
-   *   placeholder wherever the secret value should be injected.
+   * @param token - A single `CapabilityToken` or a `SecretTokenMap` mapping
+   *   names to tokens obtained from `authorize()`.
+   * @param request - The exec request template with placeholders.
    * @returns The command result (`stdout`, `stderr`, `exitCode`) together with
    *   the vault metadata (`vaultResponse`).
-   * @throws {Error} If `token` is invalid or was not created by this vault
-   *   instance.
+   * @throws {AuthorizationDeniedError} If any token is invalid or was not
+   *   created by this vault instance.
    */
   async exec(
-    token: CapabilityToken,
+    token: CapabilityToken | SecretTokenMap,
     request: ExecRequest,
   ): Promise<{ result: ExecResult; vaultResponse: VaultResponse }> {
-    const claims = validateCapabilityToken(token)
-    const result = await delegatedExec(claims.val, request)
+    const secrets = VaultKeeper.#resolveSecrets(token)
+    const result = await delegatedExec(secrets, request)
     return {
       result,
       vaultResponse: { keyStatus: 'current' },
@@ -455,6 +485,19 @@ export class VaultKeeper {
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
+
+  static #resolveSecrets(
+    token: CapabilityToken | SecretTokenMap,
+  ): string | Record<string, string> {
+    if (token instanceof CapabilityToken) {
+      return validateCapabilityToken(token).val
+    }
+    const result: Record<string, string> = {}
+    for (const [name, t] of Object.entries(token)) {
+      result[name] = validateCapabilityToken(t).val
+    }
+    return result
+  }
 
   static #validateSecretName(name: string): void {
     if (name.trim() === '') {

--- a/packages/vaultkeeper/test/unit/access/delegated-exec.test.ts
+++ b/packages/vaultkeeper/test/unit/access/delegated-exec.test.ts
@@ -148,6 +148,49 @@ describe('delegatedExec', () => {
     })
   })
 
+  describe('named-secret mode (Record)', () => {
+    it('replaces {{secret:name}} in args', async () => {
+      const request: ExecRequest = {
+        command: 'sh',
+        args: ['-c', 'echo {{secret:greeting}}'],
+      }
+
+      const result = await delegatedExec({ greeting: 'hello' }, request)
+
+      expect(result.stdout.trim()).toBe('hello')
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('replaces multiple named secrets in args', async () => {
+      const request: ExecRequest = {
+        command: 'sh',
+        args: ['-c', 'echo {{secret:a}}-{{secret:b}}'],
+      }
+
+      const result = await delegatedExec({ a: 'x', b: 'y' }, request)
+
+      expect(result.stdout.trim()).toBe('x-y')
+    })
+
+    it('replaces named secrets in env values', async () => {
+      const request: ExecRequest = {
+        command: 'sh',
+        args: ['-c', 'echo $API_KEY $DB_PASS'],
+        env: {
+          API_KEY: '{{secret:apiKey}}',
+          DB_PASS: '{{secret:dbPass}}',
+        },
+      }
+
+      const result = await delegatedExec(
+        { apiKey: 'key123', dbPass: 'pass456' },
+        request,
+      )
+
+      expect(result.stdout.trim()).toBe('key123 pass456')
+    })
+  })
+
   describe('negative cases', () => {
     it('rejects with ExecError when the command is not found', async () => {
       const request: ExecRequest = { command: 'nonexistent-command-xyz-123' }
@@ -163,7 +206,16 @@ describe('delegatedExec', () => {
 
       expect(() => delegatedExec('s', request)).toThrow(ExecError)
       expect(() => delegatedExec('s', request)).toThrow(
-        /placeholder is not supported in the command field/,
+        /placeholders are not supported in the command field/,
+      )
+    })
+
+    it('throws ExecError when {{secret:name}} is used in the command field', () => {
+      const request: ExecRequest = { command: '{{secret:apiKey}}' }
+
+      expect(() => delegatedExec({ apiKey: 'val' }, request)).toThrow(ExecError)
+      expect(() => delegatedExec({ apiKey: 'val' }, request)).toThrow(
+        /placeholders are not supported in the command field/,
       )
     })
   })

--- a/packages/vaultkeeper/test/unit/access/delegated-fetch.test.ts
+++ b/packages/vaultkeeper/test/unit/access/delegated-fetch.test.ts
@@ -155,6 +155,86 @@ describe('delegatedFetch', () => {
     })
   })
 
+  describe('named-secret mode (Record)', () => {
+    it('replaces {{secret:name}} in the URL', async () => {
+      mockFetch.mockResolvedValueOnce(makeOkResponse())
+      const request: FetchRequest = {
+        url: 'https://example.com/{{secret:apiKey}}/data',
+      }
+
+      await delegatedFetch({ apiKey: 'key123' }, request)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/key123/data',
+        expect.any(Object),
+      )
+    })
+
+    it('replaces multiple named secrets in headers', async () => {
+      mockFetch.mockResolvedValueOnce(makeOkResponse())
+      const request: FetchRequest = {
+        url: 'https://example.com',
+        headers: {
+          Authorization: 'Bearer {{secret:token}}',
+          'X-Api-Key': '{{secret:apiKey}}',
+        },
+      }
+
+      await delegatedFetch({ token: 'tok', apiKey: 'key' }, request)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com',
+        expect.objectContaining({
+          headers: {
+            Authorization: 'Bearer tok',
+            'X-Api-Key': 'key',
+          },
+        }),
+      )
+    })
+
+    it('replaces named secrets in body', async () => {
+      mockFetch.mockResolvedValueOnce(makeOkResponse())
+      const request: FetchRequest = {
+        url: 'https://example.com',
+        method: 'POST',
+        body: '{"user":"{{secret:user}}","pass":"{{secret:pass}}"}',
+      }
+
+      await delegatedFetch({ user: 'alice', pass: 'p@ss' }, request)
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com',
+        expect.objectContaining({
+          body: '{"user":"alice","pass":"p@ss"}',
+        }),
+      )
+    })
+
+    it('replaces named secrets across url, headers, and body', async () => {
+      mockFetch.mockResolvedValueOnce(makeOkResponse())
+      const request: FetchRequest = {
+        url: 'https://{{secret:host}}/api',
+        method: 'POST',
+        headers: { Authorization: 'Bearer {{secret:token}}' },
+        body: '{"key":"{{secret:apiKey}}"}',
+      }
+
+      await delegatedFetch(
+        { host: 'secure.example.com', token: 'jwt', apiKey: 'k' },
+        request,
+      )
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://secure.example.com/api',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer jwt' },
+          body: '{"key":"k"}',
+        }),
+      )
+    })
+  })
+
   describe('negative cases', () => {
     it('propagates fetch rejection', async () => {
       mockFetch.mockRejectedValueOnce(new Error('network error'))

--- a/packages/vaultkeeper/test/unit/access/placeholder.test.ts
+++ b/packages/vaultkeeper/test/unit/access/placeholder.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolvePlaceholders,
+  resolvePlaceholdersInRecord,
+  PLACEHOLDER,
+  ANY_PLACEHOLDER_RE,
+} from '../../../src/access/placeholder.js'
+import { VaultError } from '../../../src/errors.js'
+
+describe('resolvePlaceholders', () => {
+  describe('single-secret mode (string)', () => {
+    it('replaces {{secret}} with the secret value', () => {
+      expect(resolvePlaceholders('Bearer {{secret}}', 'tok123')).toBe(
+        'Bearer tok123',
+      )
+    })
+
+    it('replaces multiple occurrences', () => {
+      expect(resolvePlaceholders('{{secret}}-{{secret}}', 'x')).toBe('x-x')
+    })
+
+    it('returns the original string when no placeholder is present', () => {
+      expect(resolvePlaceholders('no placeholder', 'secret')).toBe(
+        'no placeholder',
+      )
+    })
+
+    it('leaves {{secret:name}} placeholders unreplaced', () => {
+      expect(resolvePlaceholders('{{secret:apiKey}}', 'val')).toBe(
+        '{{secret:apiKey}}',
+      )
+    })
+  })
+
+  describe('named-secret mode (Record)', () => {
+    it('replaces {{secret:name}} with the corresponding value', () => {
+      const secrets = { apiKey: 'key123', dbPass: 'pass456' }
+      expect(
+        resolvePlaceholders('key={{secret:apiKey}} pass={{secret:dbPass}}', secrets),
+      ).toBe('key=key123 pass=pass456')
+    })
+
+    it('replaces multiple occurrences of the same name', () => {
+      const secrets = { tok: 'abc' }
+      expect(
+        resolvePlaceholders('{{secret:tok}}-{{secret:tok}}', secrets),
+      ).toBe('abc-abc')
+    })
+
+    it('returns the original string when no named placeholder is present', () => {
+      const secrets = { tok: 'abc' }
+      expect(resolvePlaceholders('no placeholder', secrets)).toBe(
+        'no placeholder',
+      )
+    })
+
+    it('leaves {{secret}} unreplaced in named mode', () => {
+      const secrets = { tok: 'abc' }
+      expect(resolvePlaceholders('{{secret}}', secrets)).toBe('{{secret}}')
+    })
+
+    it('throws VaultError for unknown secret name', () => {
+      const secrets = { apiKey: 'key123' }
+      expect(() =>
+        resolvePlaceholders('{{secret:unknown}}', secrets),
+      ).toThrow(VaultError)
+      expect(() =>
+        resolvePlaceholders('{{secret:unknown}}', secrets),
+      ).toThrow(/Unknown secret name.*unknown/)
+    })
+
+    it('includes available names in error message', () => {
+      const secrets = { apiKey: 'key', dbPass: 'pass' }
+      expect(() =>
+        resolvePlaceholders('{{secret:missing}}', secrets),
+      ).toThrow(/apiKey, dbPass/)
+    })
+  })
+})
+
+describe('resolvePlaceholdersInRecord', () => {
+  it('replaces placeholders in all values (single-secret)', () => {
+    const record = { AUTH: 'Bearer {{secret}}', PLAIN: 'static' }
+    const result = resolvePlaceholdersInRecord(record, 'tok')
+    expect(result).toEqual({ AUTH: 'Bearer tok', PLAIN: 'static' })
+  })
+
+  it('replaces named placeholders in all values', () => {
+    const record = { A: '{{secret:x}}', B: '{{secret:y}}' }
+    const result = resolvePlaceholdersInRecord(record, { x: '1', y: '2' })
+    expect(result).toEqual({ A: '1', B: '2' })
+  })
+
+  it('does not mutate the original record', () => {
+    const record = { KEY: '{{secret}}' }
+    resolvePlaceholdersInRecord(record, 'val')
+    expect(record.KEY).toBe('{{secret}}')
+  })
+})
+
+describe('PLACEHOLDER constant', () => {
+  it('is the literal {{secret}} string', () => {
+    expect(PLACEHOLDER).toBe('{{secret}}')
+  })
+})
+
+describe('ANY_PLACEHOLDER_RE', () => {
+  it('matches {{secret}}', () => {
+    expect(ANY_PLACEHOLDER_RE.test('{{secret}}')).toBe(true)
+  })
+
+  it('matches {{secret:name}}', () => {
+    expect(ANY_PLACEHOLDER_RE.test('{{secret:apiKey}}')).toBe(true)
+  })
+
+  it('does not match plain text', () => {
+    expect(ANY_PLACEHOLDER_RE.test('no placeholder')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Introduces `{{secret:name}}` named placeholders so that `exec()` and `fetch()` can inject **multiple independently-authorized secrets** into a single request
- New `SecretTokenMap` type (`Record<string, CapabilityToken>`) accepted by `exec()` and `fetch()` alongside single `CapabilityToken`
- Extracts shared `placeholder.ts` module from duplicated logic in `delegated-exec.ts` and `delegated-fetch.ts`
- Existing `{{secret}}` single-token usage is fully backward-compatible

### Usage example

```ts
const { token: apiToken } = await vault.authorize(apiJwe)
const { token: dbToken } = await vault.authorize(dbJwe)

// Named placeholders resolved from the token map
await vault.exec(
  { apiKey: apiToken, dbPass: dbToken },
  {
    command: 'deploy',
    env: {
      API_KEY: '{{secret:apiKey}}',
      DB_PASS: '{{secret:dbPass}}',
    },
  },
)
```

## Test plan

- [x] 17 new unit tests for `placeholder.ts` (single-secret, named-secret, error cases)
- [x] 3 new named-secret tests for `delegated-exec`
- [x] 4 new named-secret tests for `delegated-fetch`
- [x] Updated command-field validation tests for `{{secret:name}}` in command field
- [x] All 573 existing tests continue to pass
- [x] Clean build, typecheck, lint, and API report validation pass