### PR TITLE
Add package READMEs and repository/homepage/bugs metadata

### DIFF
--- a/.changeset/package-readmes-metadata.md
+++ b/.changeset/package-readmes-metadata.md
@@ -1,0 +1,9 @@
+---
+"vaultkeeper": patch
+"@vaultkeeper/cli": patch
+"@vaultkeeper/wasm": patch
+"@vaultkeeper/test-helpers": patch
+"@vaultkeeper/cli-test-helpers": patch
+---
+
+Ship a package-specific README.md and `repository`/`homepage`/`bugs` metadata with every published package, so registry consumers get install instructions and a quick start without leaving npm.

--- a/packages/cli-test-helpers/README.md
+++ b/packages/cli-test-helpers/README.md
@@ -15,19 +15,22 @@ pnpm add -D @vaultkeeper/cli-test-helpers
 ## Quick start
 
 ```ts
+import { expect, it } from 'vitest'
 import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
 
-const env = await createCliTestEnv()
+it('stores a secret and passes doctor checks', async () => {
+  const env = await createCliTestEnv()
 
-try {
-  const stored = await env.runWithStdin(['store', '--name', 'MY_SECRET'], 'hunter2')
-  expect(stored.exitCode).toBe(0)
+  try {
+    const stored = await env.runWithStdin(['store', '--name', 'MY_SECRET'], 'hunter2')
+    expect(stored.exitCode).toBe(0)
 
-  const result = await env.run(['doctor'])
-  expect(result.exitCode).toBe(0)
-} finally {
-  await env.cleanup()
-}
+    const result = await env.run(['doctor'])
+    expect(result.exitCode).toBe(0)
+  } finally {
+    await env.cleanup()
+  }
+})
 ```
 
 Each `createCliTestEnv()` call produces its own isolated `configDir` — tests can run in parallel

--- a/packages/cli-test-helpers/README.md
+++ b/packages/cli-test-helpers/README.md
@@ -1,0 +1,43 @@
+# @vaultkeeper/cli-test-helpers
+
+CLI test harness for [@vaultkeeper/cli](https://www.npmjs.com/package/@vaultkeeper/cli) consumers:
+spins up an isolated temp config directory with a file backend and runs the CLI binary as a
+subprocess.
+
+## Installation
+
+```sh
+pnpm add -D @vaultkeeper/cli-test-helpers
+```
+
+**Requirements:** Node >= 20
+
+## Quick start
+
+```ts
+import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
+
+const env = await createCliTestEnv()
+
+try {
+  const stored = await env.runWithStdin(['store', '--name', 'MY_SECRET'], 'hunter2')
+  expect(stored.exitCode).toBe(0)
+
+  const result = await env.run(['doctor'])
+  expect(result.exitCode).toBe(0)
+} finally {
+  await env.cleanup()
+}
+```
+
+Each `createCliTestEnv()` call produces its own isolated `configDir` — tests can run in parallel
+without interfering with each other or the host machine's real vaultkeeper config.
+
+## Full documentation
+
+See the [repository README](https://github.com/mike-north/vaultkeeper#readme) for the CLI command
+reference this harness exercises.
+
+## License
+
+MIT

--- a/packages/cli-test-helpers/package.json
+++ b/packages/cli-test-helpers/package.json
@@ -2,6 +2,13 @@
   "name": "@vaultkeeper/cli-test-helpers",
   "version": "0.2.0",
   "description": "CLI test utilities for vaultkeeper",
+  "homepage": "https://github.com/mike-north/vaultkeeper#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mike-north/vaultkeeper.git",
+    "directory": "packages/cli-test-helpers"
+  },
+  "bugs": "https://github.com/mike-north/vaultkeeper/issues",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/cli-tests/test/packaging/packaging.test.ts
+++ b/packages/cli-tests/test/packaging/packaging.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Packaging tests for every publishable package: asserts that `npm pack` would
+ * include a README.md and that package.json carries repository/homepage/bugs
+ * metadata. See https://github.com/mike-north/vaultkeeper/issues/63.
+ *
+ * Uses `npm pack --dry-run --json` specifically because it is the tool that
+ * simulates the registry's tarball-inclusion rules (README/LICENSE are always
+ * included regardless of the `files` field) — pnpm has no dry-run equivalent.
+ * This does not install or run anything from the npm registry.
+ */
+import { describe, it, expect } from 'vitest'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { readFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const execFileAsync = promisify(execFile)
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..')
+
+interface NpmPackFileEntry {
+  path: string
+}
+
+interface NpmPackResult {
+  files: NpmPackFileEntry[]
+}
+
+interface RepositoryField {
+  type: string
+  url: string
+  directory?: string
+}
+
+interface PackageJson {
+  name: string
+  homepage?: string
+  bugs?: unknown
+  repository?: RepositoryField | string
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype &&
+    Object.getOwnPropertySymbols(value).length === 0
+  )
+}
+
+function isNpmPackFileEntry(value: unknown): value is NpmPackFileEntry {
+  return isPlainObject(value) && typeof value.path === 'string'
+}
+
+function isNpmPackResult(value: unknown): value is NpmPackResult {
+  return isPlainObject(value) && Array.isArray(value.files) && value.files.every(isNpmPackFileEntry)
+}
+
+function isRepositoryField(value: unknown): value is RepositoryField {
+  return (
+    isPlainObject(value) &&
+    typeof value.type === 'string' &&
+    typeof value.url === 'string' &&
+    (value.directory === undefined || typeof value.directory === 'string')
+  )
+}
+
+function isPackageJson(value: unknown): value is PackageJson {
+  if (!isPlainObject(value)) {
+    return false
+  }
+  if (typeof value.name !== 'string') {
+    return false
+  }
+  if (value.homepage !== undefined && typeof value.homepage !== 'string') {
+    return false
+  }
+  if (
+    value.repository !== undefined &&
+    typeof value.repository !== 'string' &&
+    !isRepositoryField(value.repository)
+  ) {
+    return false
+  }
+  return true
+}
+
+const publishablePackageDirs = [
+  'vaultkeeper',
+  'cli',
+  'vaultkeeper-wasm',
+  'test-helpers',
+  'cli-test-helpers',
+]
+
+async function readPackageJson(packageDir: string): Promise<PackageJson> {
+  const raw = await readFile(path.join(repoRoot, 'packages', packageDir, 'package.json'), 'utf8')
+  const parsed: unknown = JSON.parse(raw)
+  if (!isPackageJson(parsed)) {
+    throw new Error(`Malformed package.json for ${packageDir}`)
+  }
+  return parsed
+}
+
+async function runNpmPackDryRun(packageDir: string): Promise<NpmPackResult> {
+  const cwd = path.join(repoRoot, 'packages', packageDir)
+  const { stdout } = await execFileAsync('npm', ['pack', '--dry-run', '--json'], { cwd })
+  const parsed: unknown = JSON.parse(stdout)
+  const first: unknown = Array.isArray(parsed) ? parsed[0] : undefined
+  if (!isNpmPackResult(first)) {
+    throw new Error(`Unexpected npm pack output for ${packageDir}: ${stdout}`)
+  }
+  return first
+}
+
+describe.each(publishablePackageDirs)('packaging: packages/%s', (packageDir) => {
+  it('includes README.md in the published tarball', async () => {
+    const pack = await runNpmPackDryRun(packageDir)
+    const filePaths = pack.files.map((f) => f.path)
+    expect(filePaths).toContain('README.md')
+  })
+
+  it('sets repository (with directory), homepage, and bugs in package.json', async () => {
+    const pkg = await readPackageJson(packageDir)
+
+    expect(pkg.homepage).toBeDefined()
+    expect(pkg.homepage).toMatch(/^https:\/\/github\.com\/mike-north\/vaultkeeper/)
+
+    expect(pkg.bugs).toBeDefined()
+
+    if (typeof pkg.repository !== 'object') {
+      throw new Error(
+        `Expected repository to be an object with a directory field for ${packageDir}`,
+      )
+    }
+    expect(pkg.repository.directory).toBe(`packages/${packageDir}`)
+  })
+})

--- a/packages/cli-tests/test/packaging/packaging.test.ts
+++ b/packages/cli-tests/test/packaging/packaging.test.ts
@@ -37,7 +37,7 @@ interface RepositoryField {
 interface PackageJson {
   name: string
   homepage?: string
-  bugs?: unknown
+  bugs?: string
   repository?: RepositoryField | string
 }
 
@@ -76,6 +76,9 @@ function isPackageJson(value: unknown): value is PackageJson {
     return false
   }
   if (value.homepage !== undefined && typeof value.homepage !== 'string') {
+    return false
+  }
+  if (value.bugs !== undefined && typeof value.bugs !== 'string') {
     return false
   }
   if (
@@ -126,16 +129,16 @@ describe.each(publishablePackageDirs)('packaging: packages/%s', (packageDir) => 
   it('sets repository (with directory), homepage, and bugs in package.json', async () => {
     const pkg = await readPackageJson(packageDir)
 
-    expect(pkg.homepage).toBeDefined()
-    expect(pkg.homepage).toMatch(/^https:\/\/github\.com\/mike-north\/vaultkeeper/)
-
-    expect(pkg.bugs).toBeDefined()
+    expect(pkg.homepage).toBe('https://github.com/mike-north/vaultkeeper#readme')
+    expect(pkg.bugs).toBe('https://github.com/mike-north/vaultkeeper/issues')
 
     if (typeof pkg.repository !== 'object') {
       throw new Error(
         `Expected repository to be an object with a directory field for ${packageDir}`,
       )
     }
+    expect(pkg.repository.type).toBe('git')
+    expect(pkg.repository.url).toBe('git+https://github.com/mike-north/vaultkeeper.git')
     expect(pkg.repository.directory).toBe(`packages/${packageDir}`)
   })
 })

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,58 @@
+# @vaultkeeper/cli
+
+Command-line interface for [vaultkeeper](https://www.npmjs.com/package/vaultkeeper) — store,
+retrieve, and inject secrets with policy-enforced access control, backed by your OS credential
+store.
+
+## Installation
+
+```sh
+pnpm add -g @vaultkeeper/cli
+# or
+npm install -g @vaultkeeper/cli
+```
+
+**Requirements:** Node >= 20
+
+## Quick start
+
+```sh
+# Run preflight checks
+vaultkeeper doctor
+
+# Initialize configuration
+vaultkeeper config init
+
+# Store a secret (reads from stdin)
+echo "my-secret-value" | vaultkeeper store --name MY_API_KEY
+
+# Pre-approve an executable (TOFU) so it isn't prompted on first use
+vaultkeeper approve --script /usr/local/bin/my-tool
+
+# Run a command with the secret injected as an env var
+vaultkeeper exec --secret MY_API_KEY --env MY_API_TOKEN --caller /usr/local/bin/my-tool -- my-tool --flag
+
+# Toggle development mode for a script under active development
+vaultkeeper dev-mode enable --script /path/to/script
+
+# Delete a secret
+vaultkeeper delete --name MY_API_KEY
+```
+
+Run `vaultkeeper <command> --help` for full flag reference on any subcommand — the CLI's own
+`--help` output is the source of truth for its flags.
+
+## Available commands
+
+`doctor`, `config init` / `config show`, `store`, `delete`, `exec`, `approve`, `dev-mode`,
+`rotate-key`, `revoke-key`. The native Rust CLI (`vaultkeeper-cli`, installable via
+`cargo install vaultkeeper-cli`) shares this same command surface.
+
+## Full documentation
+
+See the [repository README](https://github.com/mike-north/vaultkeeper#readme) for the TypeScript
+library API, access patterns, key rotation, trust tiers, and configuration reference.
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,13 @@
   "name": "@vaultkeeper/cli",
   "version": "0.1.9",
   "description": "Command-line interface for vaultkeeper — store, retrieve, and inject secrets with policy-enforced access control",
+  "homepage": "https://github.com/mike-north/vaultkeeper#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mike-north/vaultkeeper.git",
+    "directory": "packages/cli"
+  },
+  "bugs": "https://github.com/mike-north/vaultkeeper/issues",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/test-helpers/README.md
+++ b/packages/test-helpers/README.md
@@ -1,0 +1,43 @@
+# @vaultkeeper/test-helpers
+
+Test utilities for consumers of [vaultkeeper](https://www.npmjs.com/package/vaultkeeper):
+an in-memory backend and a pre-configured `TestVault` for fast, hermetic tests with zero OS
+dependencies.
+
+## Installation
+
+```sh
+pnpm add -D @vaultkeeper/test-helpers
+```
+
+**Requirements:** Node >= 20
+
+## Quick start
+
+```ts
+import { TestVault } from '@vaultkeeper/test-helpers'
+
+const { keeper, backend } = await TestVault.create()
+await backend.store('MY_SECRET', 'hunter2')
+
+const jwe = await keeper.setup('MY_SECRET')
+const { token } = await keeper.authorize(jwe)
+const { result } = await keeper.exec(token, {
+  command: 'echo',
+  args: ['done'],
+  env: { SECRET: '{{secret}}' },
+})
+```
+
+`TestVault` wraps a real `VaultKeeper` backed by `InMemoryBackend` — no OS keychain, no
+filesystem, no doctor preflight checks. Use `InMemoryBackend` directly if you need a bare backend
+without the pre-configured vault.
+
+## Full documentation
+
+See the [repository README](https://github.com/mike-north/vaultkeeper#readme) for the full
+`vaultkeeper` API this package is built to test against.
+
+## License
+
+MIT

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -2,6 +2,13 @@
   "name": "@vaultkeeper/test-helpers",
   "version": "0.2.7",
   "description": "Test utilities for vaultkeeper consumers",
+  "homepage": "https://github.com/mike-north/vaultkeeper#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mike-north/vaultkeeper.git",
+    "directory": "packages/test-helpers"
+  },
+  "bugs": "https://github.com/mike-north/vaultkeeper/issues",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/vaultkeeper-wasm/README.md
+++ b/packages/vaultkeeper-wasm/README.md
@@ -1,0 +1,54 @@
+# @vaultkeeper/wasm
+
+WASM-backed [vaultkeeper](https://www.npmjs.com/package/vaultkeeper) SDK for Node.js. Wraps the
+Rust `vaultkeeper-core` compiled to WebAssembly, with a Node.js host platform bridge for file I/O
+and subprocess execution.
+
+The public API is not a drop-in replacement for the TypeScript library — some function signatures
+differ (e.g. `setup(secretName, secretValue, ...)` here, vs. the TS library's
+`setup(secretName, options?)`).
+
+## Installation
+
+```sh
+pnpm add @vaultkeeper/wasm
+```
+
+**Requirements:** Node >= 20.13.0
+
+## Quick start
+
+```ts
+import { createVaultKeeper } from '@vaultkeeper/wasm'
+
+const vault = await createVaultKeeper()
+
+// Store a secret
+await vault.store('MY_API_KEY', 'my-secret-value')
+
+// Mint a JWE token
+const jwe = vault.setup('MY_API_KEY', 'my-secret-value')
+
+// Authorize: decrypt and validate
+const result = vault.authorize(jwe)
+
+// Rotate or revoke keys
+vault.rotateKey()
+vault.revokeKey()
+
+// Clean up
+vault.dispose()
+```
+
+This package ships a committed `.wasm` binary — no `wasm-pack` install step required to consume it.
+
+## Full documentation
+
+See the [repository README](https://github.com/mike-north/vaultkeeper#readme) for the delegated
+access patterns (fetch/exec) available in the pure TypeScript `vaultkeeper` library, which are
+recommended over this package's lower-level `store()`/`retrieve()` APIs when avoiding raw secret
+exposure in application memory matters.
+
+## License
+
+MIT

--- a/packages/vaultkeeper-wasm/package.json
+++ b/packages/vaultkeeper-wasm/package.json
@@ -2,6 +2,13 @@
   "name": "@vaultkeeper/wasm",
   "version": "0.2.1",
   "description": "WASM-backed vaultkeeper SDK for Node.js — Rust core with JS host bridge",
+  "homepage": "https://github.com/mike-north/vaultkeeper#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mike-north/vaultkeeper.git",
+    "directory": "packages/vaultkeeper-wasm"
+  },
+  "bugs": "https://github.com/mike-north/vaultkeeper/issues",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -1,0 +1,61 @@
+# vaultkeeper
+
+Unified, policy-enforced secret storage across OS credential backends. Secrets are stored in the
+native credential store for the current platform and accessed through short-lived JWE tokens — the
+raw secret never appears in a return value.
+
+## Installation
+
+```sh
+pnpm add vaultkeeper
+```
+
+**Requirements:** Node >= 20
+
+## Quick start
+
+```ts
+import { VaultKeeper } from 'vaultkeeper'
+
+// 1. Initialize (runs doctor preflight checks)
+const vault = await VaultKeeper.init()
+
+// 2. Store a secret in the configured backend
+await vault.store('MY_API_KEY', 'my-secret-value')
+
+// 3. Mint a JWE token for the stored secret
+const jwe = await vault.setup('MY_API_KEY')
+
+// 4. Authorize: decrypt and validate the token
+const { token, vaultResponse } = await vault.authorize(jwe)
+
+// 5. Delegated fetch — secret injected into the request, never returned
+const { response } = await vault.fetch(token, {
+  url: 'https://api.example.com/data',
+  headers: { Authorization: 'Bearer {{secret}}' },
+})
+```
+
+Other access patterns — delegated `exec()` (secret injected via env var) and controlled direct
+access via `getSecret()` (auto-zeroing buffer) — are documented in the repo README linked below.
+
+## Backends
+
+The first enabled backend in the configuration is used: `keychain` (macOS), `dpapi` (Windows),
+`secret-tool` (Linux, via `libsecret`), or `file` (AES-256-GCM encrypted file, all platforms, no
+system dependencies). Plugin backends for 1Password and YubiKey are also available.
+
+## Testing against this library
+
+Use [`@vaultkeeper/test-helpers`](https://www.npmjs.com/package/@vaultkeeper/test-helpers) for an
+in-memory backend with zero OS dependencies in your own test suite.
+
+## Full documentation
+
+Access patterns, key rotation, trust tiers, development mode, configuration reference, and the
+full error hierarchy are documented in the
+[repository README](https://github.com/mike-north/vaultkeeper#readme).
+
+## License
+
+MIT

--- a/packages/vaultkeeper/package.json
+++ b/packages/vaultkeeper/package.json
@@ -2,6 +2,13 @@
   "name": "vaultkeeper",
   "version": "0.6.0",
   "description": "Unified, policy-enforced secret storage across OS backends",
+  "homepage": "https://github.com/mike-north/vaultkeeper#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mike-north/vaultkeeper.git",
+    "directory": "packages/vaultkeeper"
+  },
+  "bugs": "https://github.com/mike-north/vaultkeeper/issues",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Every publishable package (`vaultkeeper`, `@vaultkeeper/cli`, `@vaultkeeper/wasm`, `@vaultkeeper/test-helpers`, `@vaultkeeper/cli-test-helpers`) shipped zero registry documentation — `npm view <pkg> readme` returned nothing, and no `package.json` set `repository`, `homepage`, or `bugs`.

- Adds a package-specific `README.md` to each publishable package: install command, a copy-pasteable quick start for that package, and a link back to the repo. Content is sourced from the root README but not duplicated wholesale.
- **CLI examples were verified against the actual built CLI's `--help` output**, not copied from the root README — the root README's `exec`/`approve`/`dev-mode` examples use `--token`/`--path` flags that don't exist on the real CLI (`exec` takes `--secret`/`--env`/`--caller`; `approve`/`dev-mode` take `--script`; `dev-mode` takes an `enable|disable` positional arg, not `--enable`). The new `packages/cli/README.md` uses the corrected flags. The root README itself is out of scope for this PR (non-goal — see issue #63).
- Adds `repository` (with `directory`), `homepage`, and `bugs` to each publishable package's `package.json`.
- Adds `packages/cli-tests/test/packaging/packaging.test.ts`, a data-driven packaging test (`describe.each` over all 5 publishable packages) that runs `npm pack --dry-run --json` per package and asserts README.md is included in the tarball file list and asserts the metadata fields are set in `package.json`. This runs as part of the existing `pnpm test` (nx `test` target) — no CI workflow changes were needed since `cli-tests` is already wired into CI.
- Adds a changeset with a patch bump for all 5 published packages.

Refs #63

## Acceptance criteria mapping

1. Package-appropriate README (install + quick start + repo link) for each publishable package → `packages/{vaultkeeper,cli,vaultkeeper-wasm,test-helpers,cli-test-helpers}/README.md`
2. `npm pack` includes the README → verified below and by `packaging.test.ts`'s "includes README.md in the published tarball" test (one per package)
3. `repository`/`homepage`/`bugs` set on every publishable `package.json` → verified by `packaging.test.ts`'s "sets repository (with directory), homepage, and bugs in package.json" test (one per package)
4. CI packaging test → `packages/cli-tests/test/packaging/packaging.test.ts`, runs via the existing `pnpm test` CI step
5. Changesets for a patch release → `.changeset/package-readmes-metadata.md`
6. No internal codenames/wave numbers/agent attribution in the READMEs → confirmed by inspection

## Proof: `npm pack --dry-run` file list per package

```
=== packages/vaultkeeper ===
README.md
dist/index.cjs
dist/index.cjs.map
dist/index.d.cts
dist/index.d.ts
dist/index.js
dist/index.js.map
dist/one-password-worker.js
dist/one-password-worker.js.map
dist/vaultkeeper-alpha.d.ts
dist/vaultkeeper-beta.d.ts
dist/vaultkeeper-public.d.ts
dist/vaultkeeper-unstripped.d.ts
package.json

=== packages/cli ===
README.md
dist/*.js (+ .map files)
dist/index.d.ts
package.json

=== packages/vaultkeeper-wasm ===
README.md
dist/*.js, dist/*.d.ts (+ .map files)
package.json
wasm/package.json
wasm/vaultkeeper_wasm_bg.wasm
wasm/vaultkeeper_wasm_bg.wasm.d.ts
wasm/vaultkeeper_wasm.d.ts
wasm/vaultkeeper_wasm.js

=== packages/test-helpers ===
README.md
dist/index.{cjs,js} (+ .d.ts, .map)
package.json

=== packages/cli-test-helpers ===
README.md
dist/index.{cjs,js} (+ .d.ts, .map)
package.json
```

## Test plan

- [x] `pnpm build` — all 5 publishable packages build clean
- [x] `pnpm check` (typecheck + lint + API report) — green
- [x] `pnpm test` — green, including the new `packaging.test.ts` (10/10 passing: 2 tests × 5 packages)
- [x] Regression-proofed the packaging test by temporarily removing a README and confirming the "includes README.md" assertion fails with a clear message, then restored it
- [x] Manually diffed CLI README examples against `node packages/cli/dist/bin.js <cmd> --help` for every subcommand referenced