### PR TITLE
Honor BackendConfig.path: plumb backend config into file-based backends

### DIFF
--- a/.changeset/honor-backend-path.md
+++ b/.changeset/honor-backend-path.md
@@ -4,3 +4,5 @@
 ---
 
 Honor `BackendConfig.path` for file-based backends. Previously the documented `path` option was validated and then silently ignored: secrets always landed in the hardcoded `$HOME/.vaultkeeper/<backend>` location. The `file`, `dpapi`, and `yubikey` backends now store, retrieve, and delete secrets under the configured directory (created on demand) when `path` is set, falling back to the default location when it is not. The CLI `store` and `delete` commands inherit the fix by routing through `VaultKeeper`, which resolves the first enabled backend from config and forwards that backend's configuration.
+
+Config validation now rejects a whitespace-only `path` (e.g. `" "`) with the new `ConfigValidationError`, instead of silently treating it as a real storage directory.

--- a/.changeset/honor-backend-path.md
+++ b/.changeset/honor-backend-path.md
@@ -1,0 +1,6 @@
+---
+"vaultkeeper": patch
+"@vaultkeeper/cli": patch
+---
+
+Honor `BackendConfig.path` for file-based backends. Previously the documented `path` option was validated and then silently ignored: secrets always landed in the hardcoded `$HOME/.vaultkeeper/<backend>` location. The `file`, `dpapi`, and `yubikey` backends now store, retrieve, and delete secrets under the configured directory (created on demand) when `path` is set, falling back to the default location when it is not. The CLI `store` and `delete` commands inherit the fix by routing through `VaultKeeper`, which resolves the first enabled backend from config and forwards that backend's configuration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ Never throw plain `Error` objects — always use a typed subclass from the error
 
 ### Backends
 
-All backends implement `SecretBackend` from `packages/vaultkeeper/src/backend/types.ts`. Register new backends with `BackendRegistry.register(type, factory)`. The factory must be a zero-argument function returning a `SecretBackend` instance.
+All backends implement `SecretBackend` from `packages/vaultkeeper/src/backend/types.ts`. Register new backends with `BackendRegistry.register(type, factory)`. The factory is a `BackendFactory` — it receives the backend's own `BackendConfig` (forwarded by `BackendRegistry.create(type, config)`) and returns a `SecretBackend` instance. A factory that needs no configuration may ignore the argument. File-based backends should honor `BackendConfig.path` as their storage directory (see `FileBackend`, `DpapiBackend`, `YubikeyBackend`).
 
 Plugin backends (1Password, YubiKey) are flagged with `plugin: true` in `BackendConfig`.
 

--- a/packages/cli-tests/test/e2e/store-delete.test.ts
+++ b/packages/cli-tests/test/e2e/store-delete.test.ts
@@ -7,6 +7,9 @@
  * expected — the UATs exercise the real CLI path.
  */
 import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
 import type { CliTestEnv } from '@vaultkeeper/cli-test-helpers'
 
@@ -28,8 +31,49 @@ describe('store and delete lifecycle', () => {
     // doctor check failure (if the system lacks dependencies). Both are valid
     // CLI error paths.
     const matchesExpected =
-      result.stderr.includes('No secret provided on stdin') ||
-      result.stderr.includes('doctor')
+      result.stderr.includes('No secret provided on stdin') || result.stderr.includes('doctor')
     expect(matchesExpected).toBe(true)
+  })
+
+  // Regression: issue #60 — the CLI ignored BackendConfig.path and always wrote
+  // to $HOME/.vaultkeeper/file. Store and delete must honor the configured path.
+  it('honors a custom file backend path for store and delete', async () => {
+    const customDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-cli-custom-'))
+    const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-cli-home-'))
+    try {
+      env = await createCliTestEnv({
+        config: {
+          version: 1,
+          backends: [{ type: 'file', enabled: true, path: customDir }],
+          keyRotation: { gracePeriodDays: 7 },
+          defaults: { ttlMinutes: 60, trustTier: 3 },
+        },
+        env: { HOME: fakeHome },
+      })
+
+      const stored = await env.runWithStdin(
+        ['store', '--name', 'api-key', '--skip-doctor'],
+        'sk-live-abc123',
+      )
+      expect(stored.exitCode).toBe(0)
+
+      // Secret landed under the configured directory...
+      const customEntries = await fs.readdir(customDir)
+      expect(customEntries.some((f) => f.endsWith('.enc'))).toBe(true)
+
+      // ...and NOT under the default $HOME/.vaultkeeper/file location.
+      await expect(fs.readdir(path.join(fakeHome, '.vaultkeeper', 'file'))).rejects.toMatchObject({
+        code: 'ENOENT',
+      })
+
+      // Delete removes the secret from the same configured directory.
+      const deleted = await env.run(['delete', '--name', 'api-key', '--skip-doctor'])
+      expect(deleted.exitCode).toBe(0)
+      const afterDelete = await fs.readdir(customDir)
+      expect(afterDelete.some((f) => f.endsWith('.enc'))).toBe(false)
+    } finally {
+      await fs.rm(customDir, { recursive: true, force: true })
+      await fs.rm(fakeHome, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from 'node:util'
-import { BackendRegistry, VaultKeeper } from 'vaultkeeper'
+import { VaultKeeper } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
 
@@ -41,18 +41,10 @@ export async function deleteCommand(args: string[]): Promise<number> {
   const skipDoctor = shouldSkipDoctor(values['skip-doctor'])
 
   try {
-    // Initialize vault to ensure backends are registered and doctor passes
-    await VaultKeeper.init({ skipDoctor })
-
-    const types = BackendRegistry.getTypes()
-    const firstType = types[0]
-    if (firstType === undefined) {
-      process.stderr.write('Error: No backends available\n')
-      return 1
-    }
-
-    const backend = BackendRegistry.create(firstType)
-    await backend.delete(values.name)
+    // Delete via VaultKeeper, which resolves the first enabled backend from the
+    // loaded config and forwards that backend's config (including `path`).
+    const vault = await VaultKeeper.init({ skipDoctor })
+    await vault.delete(values.name)
     process.stdout.write(`Secret "${values.name}" deleted.\n`)
     return 0
   } catch (err) {

--- a/packages/cli/src/commands/store.ts
+++ b/packages/cli/src/commands/store.ts
@@ -1,5 +1,5 @@
 import { parseArgs } from 'node:util'
-import { BackendRegistry, VaultKeeper } from 'vaultkeeper'
+import { VaultKeeper } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
 
@@ -59,21 +59,10 @@ export async function storeCommand(args: string[]): Promise<number> {
       return 1
     }
 
-    // Initialize vault to run doctor checks and register backends.
-    // The return value is not used — init() is called for its side effects
-    // (doctor checks and backend registration). TODO: VaultKeeper should expose
-    // a public store() method; until then we use BackendRegistry.create() with
-    // the config-resolved type.
-    await VaultKeeper.init({ skipDoctor })
-    const types = BackendRegistry.getTypes()
-    const firstType = types[0]
-    if (firstType === undefined) {
-      process.stderr.write('Error: No backends available\n')
-      return 1
-    }
-
-    const backend = BackendRegistry.create(firstType)
-    await backend.store(values.name, secret)
+    // Store via VaultKeeper, which resolves the first enabled backend from the
+    // loaded config and forwards that backend's config (including `path`).
+    const vault = await VaultKeeper.init({ skipDoctor })
+    await vault.store(values.name, secret)
     process.stdout.write(`Secret "${values.name}" stored successfully.\n`)
     return 0
   } catch (err) {

--- a/packages/cli/test/unit/commands/delete.test.ts
+++ b/packages/cli/test/unit/commands/delete.test.ts
@@ -80,14 +80,14 @@ describe('deleteCommand', () => {
 
   describe('when delete succeeds', () => {
     it('should return 0', async () => {
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       const code = await deleteCommand(['--name', 'my-secret'])
       expect(code).toBe(0)
     })
 
     it('should write success message to stdout', async () => {
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'])
       expect(stdoutOutput).toContain('deleted')
@@ -96,14 +96,14 @@ describe('deleteCommand', () => {
 
   describe('--skip-doctor flag', () => {
     it('should pass skipDoctor: false to VaultKeeper.init by default', async () => {
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
     })
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret', '--skip-doctor'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
@@ -111,7 +111,7 @@ describe('deleteCommand', () => {
 
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '1'
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
@@ -119,7 +119,7 @@ describe('deleteCommand', () => {
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '0'
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
@@ -127,7 +127,7 @@ describe('deleteCommand', () => {
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=true (non-numeric)', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = 'true'
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
@@ -135,7 +135,7 @@ describe('deleteCommand', () => {
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR is empty string', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = ''
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })

--- a/packages/cli/test/unit/commands/store.test.ts
+++ b/packages/cli/test/unit/commands/store.test.ts
@@ -105,7 +105,7 @@ describe('storeCommand', () => {
   describe('when store succeeds', () => {
     it('should return 0', async () => {
       mockStdinWith('my-secret-value')
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
       const code = await storeCommand(['--name', 'my-secret'])
       expect(code).toBe(0)
@@ -113,7 +113,7 @@ describe('storeCommand', () => {
 
     it('should write success message to stdout', async () => {
       mockStdinWith('my-secret-value')
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
       await storeCommand(['--name', 'my-secret'])
       expect(stdoutOutput).toContain('stored successfully')
@@ -123,7 +123,7 @@ describe('storeCommand', () => {
   describe('--skip-doctor flag', () => {
     it('should pass skipDoctor: false to VaultKeeper.init by default', async () => {
       mockStdinWith('my-secret-value')
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
       await storeCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
@@ -131,7 +131,7 @@ describe('storeCommand', () => {
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
       mockStdinWith('my-secret-value')
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
       await storeCommand(['--name', 'my-secret', '--skip-doctor'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
@@ -140,7 +140,7 @@ describe('storeCommand', () => {
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '1'
       mockStdinWith('my-secret-value')
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
       await storeCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
@@ -149,7 +149,7 @@ describe('storeCommand', () => {
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '0'
       mockStdinWith('my-secret-value')
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
       await storeCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
@@ -158,7 +158,7 @@ describe('storeCommand', () => {
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=true (non-numeric)', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = 'true'
       mockStdinWith('my-secret-value')
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
       await storeCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
@@ -167,7 +167,7 @@ describe('storeCommand', () => {
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR is empty string', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = ''
       mockStdinWith('my-secret-value')
-      mockInit.mockResolvedValue(undefined)
+      mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
       await storeCommand(['--name', 'my-secret'])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -64,6 +64,12 @@ export class CapabilityToken {
 }
 
 // @public
+export class ConfigValidationError extends VaultError {
+    constructor(message: string, field: string);
+    readonly field: string;
+}
+
+// @public
 export class DeviceNotPresentError extends VaultError {
     constructor(message: string, timeoutMs: number);
     readonly timeoutMs: number;

--- a/packages/vaultkeeper/src/backend/dpapi-backend.ts
+++ b/packages/vaultkeeper/src/backend/dpapi-backend.ts
@@ -13,7 +13,17 @@ import { execCommand, execCommandFull } from '../util/exec.js'
 import { SecretNotFoundError } from '../errors.js'
 import type { ListableBackend } from './types.js'
 
-function getStoragePath(): string {
+/**
+ * Resolve the storage directory for a DpapiBackend instance.
+ *
+ * When `configuredPath` is provided (from `BackendConfig.path`), encrypted
+ * blobs are stored directly under that directory. Otherwise the default
+ * `$HOME/.vaultkeeper/dpapi` location is used.
+ */
+function resolveStorageDir(configuredPath?: string): string {
+  if (configuredPath !== undefined && configuredPath !== '') {
+    return configuredPath
+  }
   return path.join(os.homedir(), '.vaultkeeper', 'dpapi')
 }
 
@@ -37,6 +47,16 @@ export class DpapiBackend implements ListableBackend {
   readonly type = 'dpapi'
   readonly displayName = 'Windows DPAPI'
 
+  readonly #storageDir: string
+
+  /**
+   * @param storageDir - Directory in which encrypted blobs are stored.
+   *   Sourced from `BackendConfig.path`. Defaults to `$HOME/.vaultkeeper/dpapi`.
+   */
+  constructor(storageDir?: string) {
+    this.#storageDir = resolveStorageDir(storageDir)
+  }
+
   async isAvailable(): Promise<boolean> {
     if (process.platform !== 'win32') {
       return false
@@ -54,7 +74,7 @@ export class DpapiBackend implements ListableBackend {
   }
 
   async store(id: string, secret: string): Promise<void> {
-    const storageDir = getStoragePath()
+    const storageDir = this.#storageDir
     await fs.mkdir(storageDir, { recursive: true })
     const entryPath = getEntryPath(storageDir, id)
 
@@ -71,7 +91,7 @@ export class DpapiBackend implements ListableBackend {
   }
 
   async retrieve(id: string): Promise<string> {
-    const storageDir = getStoragePath()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     try {
@@ -93,7 +113,7 @@ export class DpapiBackend implements ListableBackend {
   }
 
   async delete(id: string): Promise<void> {
-    const storageDir = getStoragePath()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     try {
@@ -107,7 +127,7 @@ export class DpapiBackend implements ListableBackend {
   }
 
   async exists(id: string): Promise<boolean> {
-    const storageDir = getStoragePath()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     try {
@@ -119,7 +139,7 @@ export class DpapiBackend implements ListableBackend {
   }
 
   async list(): Promise<string[]> {
-    const storageDir = getStoragePath()
+    const storageDir = this.#storageDir
     let entries: string[]
     try {
       entries = await fs.readdir(storageDir)

--- a/packages/vaultkeeper/src/backend/dpapi-backend.ts
+++ b/packages/vaultkeeper/src/backend/dpapi-backend.ts
@@ -21,7 +21,9 @@ import type { ListableBackend } from './types.js'
  * `$HOME/.vaultkeeper/dpapi` location is used.
  */
 function resolveStorageDir(configuredPath?: string): string {
-  if (configuredPath !== undefined && configuredPath !== '') {
+  // Config validation (see validateConfig) rejects empty/whitespace-only
+  // paths, so any defined value here is guaranteed non-blank.
+  if (configuredPath !== undefined) {
     return configuredPath
   }
   return path.join(os.homedir(), '.vaultkeeper', 'dpapi')

--- a/packages/vaultkeeper/src/backend/file-backend.ts
+++ b/packages/vaultkeeper/src/backend/file-backend.ts
@@ -32,7 +32,9 @@ const GCM_TAG_LENGTH = 128 // bits
  * `$HOME/.vaultkeeper/file` location is used.
  */
 function resolveStorageDir(configuredPath?: string): string {
-  if (configuredPath !== undefined && configuredPath !== '') {
+  // Config validation (see validateConfig) rejects empty/whitespace-only
+  // paths, so any defined value here is guaranteed non-blank.
+  if (configuredPath !== undefined) {
     return configuredPath
   }
   return path.join(os.homedir(), STORAGE_DIR_NAME)

--- a/packages/vaultkeeper/src/backend/file-backend.ts
+++ b/packages/vaultkeeper/src/backend/file-backend.ts
@@ -24,7 +24,17 @@ const GCM_IV_BYTES = 12
 const GCM_KEY_BYTES = 32
 const GCM_TAG_LENGTH = 128 // bits
 
-function getStorageDir(): string {
+/**
+ * Resolve the storage directory for a FileBackend instance.
+ *
+ * When `configuredPath` is provided (from `BackendConfig.path`), secrets are
+ * stored directly under that directory. Otherwise the default
+ * `$HOME/.vaultkeeper/file` location is used.
+ */
+function resolveStorageDir(configuredPath?: string): string {
+  if (configuredPath !== undefined && configuredPath !== '') {
+    return configuredPath
+  }
   return path.join(os.homedir(), STORAGE_DIR_NAME)
 }
 
@@ -108,11 +118,20 @@ export class FileBackend implements ListableBackend {
   readonly type = 'file'
   readonly displayName = 'Encrypted File Store'
 
+  readonly #storageDir: string
+
+  /**
+   * @param storageDir - Directory in which encrypted secrets are stored.
+   *   Sourced from `BackendConfig.path`. Defaults to `$HOME/.vaultkeeper/file`.
+   */
+  constructor(storageDir?: string) {
+    this.#storageDir = resolveStorageDir(storageDir)
+  }
+
   async isAvailable(): Promise<boolean> {
     // Node.js crypto is always available; check we can create the storage dir.
     try {
-      const storageDir = getStorageDir()
-      await ensureStorageDir(storageDir)
+      await ensureStorageDir(this.#storageDir)
       return true
     } catch {
       return false
@@ -120,7 +139,7 @@ export class FileBackend implements ListableBackend {
   }
 
   async store(id: string, secret: string): Promise<void> {
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     await ensureStorageDir(storageDir)
     const key = await getOrCreateKey(storageDir)
     const entryPath = getEntryPath(storageDir, id)
@@ -129,7 +148,7 @@ export class FileBackend implements ListableBackend {
   }
 
   async retrieve(id: string): Promise<string> {
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     let encoded: string
@@ -153,7 +172,7 @@ export class FileBackend implements ListableBackend {
   }
 
   async delete(id: string): Promise<void> {
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     try {
@@ -167,7 +186,7 @@ export class FileBackend implements ListableBackend {
   }
 
   async exists(id: string): Promise<boolean> {
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     try {
@@ -179,7 +198,7 @@ export class FileBackend implements ListableBackend {
   }
 
   async list(): Promise<string[]> {
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     let entries: string[]
     try {
       entries = await fs.readdir(storageDir)

--- a/packages/vaultkeeper/src/backend/register-builtins.ts
+++ b/packages/vaultkeeper/src/backend/register-builtins.ts
@@ -28,9 +28,9 @@ import { YubikeyBackend } from './yubikey-backend.js'
  * @internal
  */
 export function registerBuiltinBackends(): void {
-  BackendRegistry.register('file', () => new FileBackend())
+  BackendRegistry.register('file', (config?: BackendConfig) => new FileBackend(config?.path))
   BackendRegistry.register('keychain', () => new KeychainBackend())
-  BackendRegistry.register('dpapi', () => new DpapiBackend())
+  BackendRegistry.register('dpapi', (config?: BackendConfig) => new DpapiBackend(config?.path))
   BackendRegistry.register('secret-tool', () => new SecretToolBackend())
   BackendRegistry.register('1password', (config?: BackendConfig) => {
     const opts = config?.options
@@ -50,7 +50,7 @@ export function registerBuiltinBackends(): void {
     }
     return new OnePasswordBackend(opOptions)
   })
-  BackendRegistry.register('yubikey', () => new YubikeyBackend())
+  BackendRegistry.register('yubikey', (config?: BackendConfig) => new YubikeyBackend(config?.path))
 }
 
 registerBuiltinBackends()

--- a/packages/vaultkeeper/src/backend/yubikey-backend.ts
+++ b/packages/vaultkeeper/src/backend/yubikey-backend.ts
@@ -46,7 +46,9 @@ interface YubikeyMetadata {
  * `$HOME/.vaultkeeper/yubikey` location is used.
  */
 function resolveStorageDir(configuredPath?: string): string {
-  if (configuredPath !== undefined && configuredPath !== '') {
+  // Config validation (see validateConfig) rejects empty/whitespace-only
+  // paths, so any defined value here is guaranteed non-blank.
+  if (configuredPath !== undefined) {
     return configuredPath
   }
   return path.join(os.homedir(), STORAGE_DIR_NAME)

--- a/packages/vaultkeeper/src/backend/yubikey-backend.ts
+++ b/packages/vaultkeeper/src/backend/yubikey-backend.ts
@@ -38,7 +38,17 @@ interface YubikeyMetadata {
   entries: Record<string, string>
 }
 
-function getStorageDir(): string {
+/**
+ * Resolve the storage directory for a YubikeyBackend instance.
+ *
+ * When `configuredPath` is provided (from `BackendConfig.path`), encrypted
+ * secrets are stored directly under that directory. Otherwise the default
+ * `$HOME/.vaultkeeper/yubikey` location is used.
+ */
+function resolveStorageDir(configuredPath?: string): string {
+  if (configuredPath !== undefined && configuredPath !== '') {
+    return configuredPath
+  }
   return path.join(os.homedir(), STORAGE_DIR_NAME)
 }
 
@@ -162,8 +172,7 @@ function decryptGcm(key: Buffer, encoded: string): string {
 
   // Determine whether the first segment is a numeric version prefix at all.
   const parsedVersion = parseInt(versionSegment, 10)
-  const isNumericVersion =
-    String(parsedVersion) === versionSegment && !Number.isNaN(parsedVersion)
+  const isNumericVersion = String(parsedVersion) === versionSegment && !Number.isNaN(parsedVersion)
 
   if (!isNumericVersion) {
     // No recognisable version prefix — treat as legacy CBC or corrupt file.
@@ -240,6 +249,17 @@ export class YubikeyBackend implements ListableBackend {
   readonly type = 'yubikey'
   readonly displayName = 'YubiKey'
 
+  readonly #storageDir: string
+
+  /**
+   * @param storageDir - Directory in which encrypted secrets and metadata are
+   *   stored. Sourced from `BackendConfig.path`. Defaults to
+   *   `$HOME/.vaultkeeper/yubikey`.
+   */
+  constructor(storageDir?: string) {
+    this.#storageDir = resolveStorageDir(storageDir)
+  }
+
   async isAvailable(): Promise<boolean> {
     try {
       const result = await execCommandFull('ykman', ['--version'])
@@ -284,7 +304,7 @@ export class YubikeyBackend implements ListableBackend {
   async store(id: string, secret: string): Promise<void> {
     await this.requireDevice()
 
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     await fs.mkdir(storageDir, { recursive: true, mode: 0o700 })
 
     const hmacResponse = await this.challengeResponse(id)
@@ -302,7 +322,7 @@ export class YubikeyBackend implements ListableBackend {
   async retrieve(id: string): Promise<string> {
     await this.requireDevice()
 
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     try {
@@ -321,7 +341,7 @@ export class YubikeyBackend implements ListableBackend {
   async delete(id: string): Promise<void> {
     await this.requireDevice()
 
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     try {
@@ -340,7 +360,7 @@ export class YubikeyBackend implements ListableBackend {
   }
 
   async exists(id: string): Promise<boolean> {
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     const entryPath = getEntryPath(storageDir, id)
 
     try {
@@ -352,7 +372,7 @@ export class YubikeyBackend implements ListableBackend {
   }
 
   async list(): Promise<string[]> {
-    const storageDir = getStorageDir()
+    const storageDir = this.#storageDir
     const metadata = await loadMetadata(storageDir)
     return Object.keys(metadata.entries)
   }

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -48,14 +48,16 @@ function isObject(value: unknown): value is Record<string, unknown> {
  * Validates a backend config entry.
  */
 function validateBackendEntry(entry: unknown, index: number): BackendConfig {
+  const base = `backends[${String(index)}]`
+
   if (!isObject(entry)) {
-    throw new Error(`backends[${String(index)}] must be an object`)
+    throw new ConfigValidationError(`${base} must be an object`, base)
   }
   if (typeof entry.type !== 'string' || entry.type.trim() === '') {
-    throw new Error(`backends[${String(index)}].type must be a non-empty string`)
+    throw new ConfigValidationError(`${base}.type must be a non-empty string`, `${base}.type`)
   }
   if (typeof entry.enabled !== 'boolean') {
-    throw new Error(`backends[${String(index)}].enabled must be a boolean`)
+    throw new ConfigValidationError(`${base}.enabled must be a boolean`, `${base}.enabled`)
   }
 
   const result: BackendConfig = {
@@ -65,19 +67,19 @@ function validateBackendEntry(entry: unknown, index: number): BackendConfig {
 
   if (entry.plugin !== undefined) {
     if (typeof entry.plugin !== 'boolean') {
-      throw new Error(`backends[${String(index)}].plugin must be a boolean`)
+      throw new ConfigValidationError(`${base}.plugin must be a boolean`, `${base}.plugin`)
     }
     result.plugin = entry.plugin
   }
 
   if (entry.path !== undefined) {
     if (typeof entry.path !== 'string') {
-      throw new Error(`backends[${String(index)}].path must be a string`)
+      throw new ConfigValidationError(`${base}.path must be a string`, `${base}.path`)
     }
     if (entry.path.trim() === '') {
       throw new ConfigValidationError(
-        `backends[${String(index)}].path must not be empty or whitespace-only`,
-        `backends[${String(index)}].path`,
+        `${base}.path must not be empty or whitespace-only`,
+        `${base}.path`,
       )
     }
     result.path = entry.path
@@ -85,12 +87,15 @@ function validateBackendEntry(entry: unknown, index: number): BackendConfig {
 
   if (entry.options !== undefined) {
     if (!isObject(entry.options)) {
-      throw new Error(`backends[${String(index)}].options must be an object`)
+      throw new ConfigValidationError(`${base}.options must be an object`, `${base}.options`)
     }
     const opts: Record<string, string> = {}
     for (const [k, v] of Object.entries(entry.options)) {
       if (typeof v !== 'string') {
-        throw new Error(`backends[${String(index)}].options["${k}"] must be a string`)
+        throw new ConfigValidationError(
+          `${base}.options["${k}"] must be a string`,
+          `${base}.options.${k}`,
+        )
       }
       opts[k] = v
     }
@@ -106,15 +111,15 @@ function validateBackendEntry(entry: unknown, index: number): BackendConfig {
  */
 export function validateConfig(config: unknown): VaultConfig {
   if (!isObject(config)) {
-    throw new Error('Config must be an object')
+    throw new ConfigValidationError('Config must be an object', 'config')
   }
 
   if (typeof config.version !== 'number' || config.version !== 1) {
-    throw new Error('Config version must be 1')
+    throw new ConfigValidationError('Config version must be 1', 'version')
   }
 
   if (!Array.isArray(config.backends) || config.backends.length === 0) {
-    throw new Error('Config must have at least one backend')
+    throw new ConfigValidationError('Config must have at least one backend', 'backends')
   }
 
   const backends: BackendConfig[] = config.backends.map((entry: unknown, i: number) =>
@@ -122,20 +127,26 @@ export function validateConfig(config: unknown): VaultConfig {
   )
 
   if (!isObject(config.keyRotation)) {
-    throw new Error('Config keyRotation must be an object')
+    throw new ConfigValidationError('Config keyRotation must be an object', 'keyRotation')
   }
   if (
     typeof config.keyRotation.gracePeriodDays !== 'number' ||
     config.keyRotation.gracePeriodDays <= 0
   ) {
-    throw new Error('Config keyRotation.gracePeriodDays must be a positive number')
+    throw new ConfigValidationError(
+      'Config keyRotation.gracePeriodDays must be a positive number',
+      'keyRotation.gracePeriodDays',
+    )
   }
 
   if (!isObject(config.defaults)) {
-    throw new Error('Config defaults must be an object')
+    throw new ConfigValidationError('Config defaults must be an object', 'defaults')
   }
   if (typeof config.defaults.ttlMinutes !== 'number' || config.defaults.ttlMinutes <= 0) {
-    throw new Error('Config defaults.ttlMinutes must be a positive number')
+    throw new ConfigValidationError(
+      'Config defaults.ttlMinutes must be a positive number',
+      'defaults.ttlMinutes',
+    )
   }
   // Coerce string trust tier values from Rust CLI config (which serializes as "1"/"2"/"3")
   let tier: unknown = config.defaults.trustTier
@@ -146,7 +157,10 @@ export function validateConfig(config: unknown): VaultConfig {
     }
   }
   if (tier !== 1 && tier !== 2 && tier !== 3) {
-    throw new Error('Config defaults.trustTier must be 1, 2, or 3')
+    throw new ConfigValidationError(
+      'Config defaults.trustTier must be 1, 2, or 3',
+      'defaults.trustTier',
+    )
   }
 
   const result: VaultConfig = {
@@ -163,15 +177,21 @@ export function validateConfig(config: unknown): VaultConfig {
 
   if (config.developmentMode !== undefined) {
     if (!isObject(config.developmentMode)) {
-      throw new Error('Config developmentMode must be an object')
+      throw new ConfigValidationError('Config developmentMode must be an object', 'developmentMode')
     }
     if (!Array.isArray(config.developmentMode.executables)) {
-      throw new Error('Config developmentMode.executables must be an array')
+      throw new ConfigValidationError(
+        'Config developmentMode.executables must be an array',
+        'developmentMode.executables',
+      )
     }
     const executables: string[] = []
     for (const [i, exe] of Array.from(config.developmentMode.executables).entries()) {
       if (typeof exe !== 'string') {
-        throw new Error(`Config developmentMode.executables[${String(i)}] must be a string`)
+        throw new ConfigValidationError(
+          `Config developmentMode.executables[${String(i)}] must be a string`,
+          `developmentMode.executables[${String(i)}]`,
+        )
       }
       executables.push(exe)
     }

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -92,9 +92,10 @@ function validateBackendEntry(entry: unknown, index: number): BackendConfig {
     const opts: Record<string, string> = {}
     for (const [k, v] of Object.entries(entry.options)) {
       if (typeof v !== 'string') {
+        const quotedKey = JSON.stringify(k)
         throw new ConfigValidationError(
-          `${base}.options["${k}"] must be a string`,
-          `${base}.options.${k}`,
+          `${base}.options[${quotedKey}] must be a string`,
+          `${base}.options[${quotedKey}]`,
         )
       }
       opts[k] = v

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -6,6 +6,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import type { VaultConfig, BackendConfig, TrustTier } from './types.js'
+import { ConfigValidationError } from './errors.js'
 
 /**
  * Return the platform-appropriate default config directory.
@@ -73,6 +74,12 @@ function validateBackendEntry(entry: unknown, index: number): BackendConfig {
     if (typeof entry.path !== 'string') {
       throw new Error(`backends[${String(index)}].path must be a string`)
     }
+    if (entry.path.trim() === '') {
+      throw new ConfigValidationError(
+        `backends[${String(index)}].path must not be empty or whitespace-only`,
+        `backends[${String(index)}].path`,
+      )
+    }
     result.path = entry.path
   }
 
@@ -83,9 +90,7 @@ function validateBackendEntry(entry: unknown, index: number): BackendConfig {
     const opts: Record<string, string> = {}
     for (const [k, v] of Object.entries(entry.options)) {
       if (typeof v !== 'string') {
-        throw new Error(
-          `backends[${String(index)}].options["${k}"] must be a string`,
-        )
+        throw new Error(`backends[${String(index)}].options["${k}"] must be a string`)
       }
       opts[k] = v
     }

--- a/packages/vaultkeeper/src/errors.ts
+++ b/packages/vaultkeeper/src/errors.ts
@@ -328,6 +328,24 @@ export class FetchError extends VaultError {
 }
 
 /**
+ * Thrown when a config value fails structural or semantic validation (e.g. a
+ * whitespace-only `BackendConfig.path`).
+ */
+export class ConfigValidationError extends VaultError {
+  /**
+   * The dotted/bracketed path to the offending config field (e.g.
+   * `'backends[0].path'`).
+   */
+  readonly field: string
+
+  constructor(message: string, field: string) {
+    super(message)
+    this.name = 'ConfigValidationError'
+    this.field = field
+  }
+}
+
+/**
  * Thrown during initialization when a required system dependency (e.g. OpenSSL
  * or a native credential helper) is missing or incompatible.
  */

--- a/packages/vaultkeeper/src/index.ts
+++ b/packages/vaultkeeper/src/index.ts
@@ -30,6 +30,7 @@ export {
   SetupError,
   FilesystemError,
   RotationInProgressError,
+  ConfigValidationError,
 } from './errors.js'
 
 export type {

--- a/packages/vaultkeeper/test/integration/backend/file-backend-path.test.ts
+++ b/packages/vaultkeeper/test/integration/backend/file-backend-path.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration test for `BackendConfig.path` plumbing (issue #60).
+ *
+ * Verifies that a custom `path` on a file backend config is honored end to end:
+ * secrets land under the configured directory (created on demand) and NOT under
+ * the default `$HOME/.vaultkeeper/file`, and that a second consumer built from
+ * the same config reads and deletes them from that same directory.
+ *
+ * These tests use real temp directories and the real Node crypto file backend.
+ * `$HOME` is redirected to an isolated temp dir so the real home is never
+ * touched and "not under default location" can be asserted hermetically.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/60
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as osModule from 'node:os'
+import * as path from 'node:path'
+
+// Redirect homedir before the backend modules compute any default path.
+let overriddenHome = ''
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof osModule>()
+  return {
+    ...actual,
+    homedir: () => (overriddenHome !== '' ? overriddenHome : actual.homedir()),
+  }
+})
+
+import { VaultKeeper } from '../../../src/vault.js'
+import { BackendRegistry } from '../../../src/backend/registry.js'
+import { registerBuiltinBackends } from '../../../src/backend/register-builtins.js'
+import type { VaultConfig, BackendConfig } from '../../../src/types.js'
+
+let fakeHome = ''
+let customDir = ''
+
+/** Hex-encoded entry filename, matching FileBackend.getEntryPath. */
+function entryFile(id: string): string {
+  return `${Buffer.from(id, 'utf8').toString('hex')}.enc`
+}
+
+function configWithPath(storagePath: string): VaultConfig {
+  const backend: BackendConfig = { type: 'file', enabled: true, path: storagePath }
+  return {
+    version: 1,
+    backends: [backend],
+    keyRotation: { gracePeriodDays: 7 },
+    defaults: { ttlMinutes: 30, trustTier: 3 },
+  }
+}
+
+beforeEach(async () => {
+  // Ensure built-in backends are registered even though this test does not
+  // import the package barrel (which normally triggers registration).
+  registerBuiltinBackends()
+  fakeHome = await fs.mkdtemp(path.join(osModule.tmpdir(), 'vk-home-'))
+  customDir = await fs.mkdtemp(path.join(osModule.tmpdir(), 'vk-custom-'))
+  overriddenHome = fakeHome
+})
+
+afterEach(async () => {
+  overriddenHome = ''
+  await fs.rm(fakeHome, { recursive: true, force: true })
+  await fs.rm(customDir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+describe('BackendConfig.path plumbing (file backend)', () => {
+  it('stores the encrypted secret under the custom path and not the default home location', async () => {
+    const config = configWithPath(customDir)
+    const vault = await VaultKeeper.init({ skipDoctor: true, config, configDir: fakeHome })
+
+    await vault.store('api-key', 'sk-live-abc123')
+
+    // Encrypted entry exists under the configured directory.
+    const customEntries = await fs.readdir(customDir)
+    expect(customEntries).toContain(entryFile('api-key'))
+
+    // Nothing was written to the default $HOME/.vaultkeeper/file location.
+    const defaultDir = path.join(fakeHome, '.vaultkeeper', 'file')
+    await expect(fs.readdir(defaultDir)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('retrieves the secret through a backend built from the same config', async () => {
+    const config = configWithPath(customDir)
+    const vault = await VaultKeeper.init({ skipDoctor: true, config, configDir: fakeHome })
+    await vault.store('api-key', 'sk-live-abc123')
+
+    // #resolveBackend uses BackendRegistry.create(type, config); mirror that
+    // path to read the value back from the custom directory.
+    const backend = BackendRegistry.create('file', config.backends[0])
+    expect(await backend.retrieve('api-key')).toBe('sk-live-abc123')
+  })
+
+  it('lets a second VaultKeeper instance with the same config delete from the custom path', async () => {
+    const config = configWithPath(customDir)
+    const vault1 = await VaultKeeper.init({ skipDoctor: true, config, configDir: fakeHome })
+    await vault1.store('api-key', 'sk-live-abc123')
+    expect(await fs.readdir(customDir)).toContain(entryFile('api-key'))
+
+    const vault2 = await VaultKeeper.init({ skipDoctor: true, config, configDir: fakeHome })
+    await vault2.delete('api-key')
+
+    expect(await fs.readdir(customDir)).not.toContain(entryFile('api-key'))
+  })
+
+  it('uses the default home location when no path is configured', async () => {
+    const config: VaultConfig = {
+      version: 1,
+      backends: [{ type: 'file', enabled: true }],
+      keyRotation: { gracePeriodDays: 7 },
+      defaults: { ttlMinutes: 30, trustTier: 3 },
+    }
+    const vault = await VaultKeeper.init({ skipDoctor: true, config, configDir: fakeHome })
+
+    await vault.store('api-key', 'sk-live-abc123')
+
+    const defaultDir = path.join(fakeHome, '.vaultkeeper', 'file')
+    const entries = await fs.readdir(defaultDir)
+    expect(entries).toContain(entryFile('api-key'))
+  })
+})

--- a/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as path from 'node:path'
 import type { ExecCommandResult } from '../../../src/util/exec.js'
 
 vi.mock('../../../src/util/exec.js', () => ({
@@ -96,6 +97,25 @@ describe('DpapiBackend', () => {
         (arg) => typeof arg === 'string' && arg.includes('my-secret-value'),
       )
       expect(script).toBeDefined()
+    })
+
+    // Regression: issue #60 — BackendConfig.path was silently ignored.
+    it('should honor a custom storage path from config', async () => {
+      const customDir = path.join(path.sep, 'custom', 'dpapi', 'dir')
+      const customBackend = new DpapiBackend(customDir)
+      mockFs.mkdir.mockResolvedValue(undefined)
+      mockExecCommand.mockResolvedValue('')
+
+      await customBackend.store('my-secret', 'secret-value')
+
+      expect(mockFs.mkdir).toHaveBeenCalledWith(
+        customDir,
+        expect.objectContaining({ recursive: true }),
+      )
+      const writePathArg = mockExecCommand.mock.calls[0]?.[1]?.find(
+        (arg) => typeof arg === 'string' && arg.includes(customDir),
+      )
+      expect(writePathArg).toBeDefined()
     })
   })
 

--- a/packages/vaultkeeper/test/unit/backend/file-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/file-backend.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as path from 'node:path'
 
 vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn(),
@@ -61,7 +62,9 @@ describe('FileBackend', () => {
       const encryptedWriteCall = mockFs.writeFile.mock.calls[1]
       expect(encryptedWriteCall?.[0]).toEqual(expect.stringContaining('.enc'))
       // Stored value is a base64:base64:base64 string (iv:authTag:ciphertext)
-      expect(encryptedWriteCall?.[1]).toEqual(expect.stringMatching(/^[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]*$/))
+      expect(encryptedWriteCall?.[1]).toEqual(
+        expect.stringMatching(/^[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]*$/),
+      )
       void keyBytes
     })
 
@@ -75,6 +78,30 @@ describe('FileBackend', () => {
       await backend.store('my-secret', 'secret-value')
 
       expect(mockFs.writeFile).toHaveBeenCalledTimes(1)
+    })
+
+    // Regression: issue #60 — BackendConfig.path was silently ignored.
+    it('should store under a custom path from config, not the default location', async () => {
+      const customDir = path.join(path.sep, 'custom', 'file', 'dir')
+      const customBackend = new FileBackend(customDir)
+      mockFs.mkdir.mockResolvedValue(undefined)
+      const keyBuffer = Buffer.alloc(32, 0xcd)
+      mockFs.readFile.mockResolvedValueOnce(keyBuffer) // key exists
+      mockFs.writeFile.mockResolvedValueOnce(undefined) // write encrypted file
+
+      await customBackend.store('my-secret', 'secret-value')
+
+      expect(mockFs.mkdir).toHaveBeenCalledWith(
+        customDir,
+        expect.objectContaining({ recursive: true }),
+      )
+      const encryptedWriteCall = mockFs.writeFile.mock.calls[0]
+      expect(encryptedWriteCall?.[0]).toEqual(expect.stringContaining(customDir))
+      // Default $HOME/.vaultkeeper location must never be touched.
+      expect(mockFs.mkdir).not.toHaveBeenCalledWith(
+        expect.stringContaining('.vaultkeeper'),
+        expect.anything(),
+      )
     })
   })
 

--- a/packages/vaultkeeper/test/unit/backend/yubikey-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/yubikey-backend.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import * as crypto from 'node:crypto'
+import * as path from 'node:path'
 import type { ExecCommandResult } from '../../../src/util/exec.js'
 
 vi.mock('../../../src/util/exec.js', () => ({
@@ -80,9 +81,12 @@ function makeEncryptedBlob(plaintext: string, id: string): string {
   const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
   const authTag = cipher.getAuthTag()
 
-  return ['1', iv.toString('base64'), authTag.toString('base64'), encrypted.toString('base64')].join(
-    ':',
-  )
+  return [
+    '1',
+    iv.toString('base64'),
+    authTag.toString('base64'),
+    encrypted.toString('base64'),
+  ].join(':')
 }
 
 describe('YubikeyBackend', () => {
@@ -198,6 +202,28 @@ describe('YubikeyBackend', () => {
         DeviceNotPresentError,
       )
     })
+
+    // Regression: issue #60 — BackendConfig.path was silently ignored.
+    it('should honor a custom storage path from config', async () => {
+      const customDir = path.join(path.sep, 'custom', 'yubikey', 'dir')
+      const customBackend = new YubikeyBackend(customDir)
+      mockDeviceAvailable()
+      mockChallengeResponse(FAKE_HMAC_RESPONSE)
+      mockFs.mkdir.mockResolvedValue(undefined)
+      mockFs.readFile.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+      mockFs.writeFile.mockResolvedValue(undefined)
+
+      await customBackend.store('my-secret', 'secret-value')
+
+      expect(mockFs.mkdir).toHaveBeenCalledWith(
+        customDir,
+        expect.objectContaining({ recursive: true }),
+      )
+      const secretFileCall = mockFs.writeFile.mock.calls.find(
+        ([p]) => typeof p === 'string' && p.endsWith('.enc'),
+      )
+      expect(secretFileCall?.[0]).toEqual(expect.stringContaining(customDir))
+    })
   })
 
   // ---------------------------------------------------------------------------
@@ -240,8 +266,7 @@ describe('YubikeyBackend', () => {
       // XOR the first byte to ensure the ciphertext differs from what the auth
       // tag covers — GCM must reject this.
       ciphertextBytes[0] = (ciphertextBytes[0] ?? 0) ^ 0xff
-      const corruptedBlob =
-        blob.slice(0, lastColon + 1) + ciphertextBytes.toString('base64')
+      const corruptedBlob = blob.slice(0, lastColon + 1) + ciphertextBytes.toString('base64')
 
       mockDeviceAvailable()
       mockChallengeResponse(FAKE_HMAC_RESPONSE)
@@ -276,9 +301,7 @@ describe('YubikeyBackend', () => {
       mockFs.access.mockResolvedValue(undefined)
       mockFs.readFile.mockResolvedValue(futureVersionBlob)
 
-      await expect(backend.retrieve('future-secret')).rejects.toThrow(
-        /[Uu]nsupported.*version.*42/,
-      )
+      await expect(backend.retrieve('future-secret')).rejects.toThrow(/[Uu]nsupported.*version.*42/)
     })
 
     it('should give a clear error for an invalid HMAC response (not 40 hex chars)', async () => {

--- a/packages/vaultkeeper/test/unit/config.test.ts
+++ b/packages/vaultkeeper/test/unit/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { validateConfig, loadConfig, getDefaultConfigDir } from '../../src/config.js'
+import { ConfigValidationError } from '../../src/errors.js'
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
@@ -47,9 +48,26 @@ describe('validateConfig', () => {
     expect(result.backends[0]?.path).toBe('/opt/plugin.js')
   })
 
+  it('should reject a whitespace-only backend path (regression: PR #78 review)', () => {
+    // A path of " " previously passed validation and was treated as a real
+    // storage directory by file-based backends instead of being rejected.
+    const input = validConfigJson()
+    input.backends = [{ type: 'file', enabled: true, path: ' ' }]
+    expect(() => validateConfig(input)).toThrow(ConfigValidationError)
+    expect(() => validateConfig(input)).toThrow('must not be empty or whitespace-only')
+  })
+
+  it('should reject an empty-string backend path', () => {
+    const input = validConfigJson()
+    input.backends = [{ type: 'file', enabled: true, path: '' }]
+    expect(() => validateConfig(input)).toThrow(ConfigValidationError)
+  })
+
   it('should accept backend with valid options object', () => {
     const input = validConfigJson()
-    input.backends = [{ type: 'file', enabled: true, options: { region: 'us-east-1', vault: 'my-vault' } }]
+    input.backends = [
+      { type: 'file', enabled: true, options: { region: 'us-east-1', vault: 'my-vault' } },
+    ]
     const result = validateConfig(input)
     expect(result.backends[0]?.options).toEqual({ region: 'us-east-1', vault: 'my-vault' })
   })
@@ -91,9 +109,9 @@ describe('validateConfig', () => {
   })
 
   it('should reject backend with missing type', () => {
-    expect(() =>
-      validateConfig({ ...validConfigJson(), backends: [{ enabled: true }] }),
-    ).toThrow('type must be a non-empty string')
+    expect(() => validateConfig({ ...validConfigJson(), backends: [{ enabled: true }] })).toThrow(
+      'type must be a non-empty string',
+    )
   })
 
   it('should reject backend with non-boolean enabled', () => {

--- a/packages/vaultkeeper/test/unit/config.test.ts
+++ b/packages/vaultkeeper/test/unit/config.test.ts
@@ -63,6 +63,15 @@ describe('validateConfig', () => {
     expect(() => validateConfig(input)).toThrow(ConfigValidationError)
   })
 
+  it('should reject a non-string backend path as ConfigValidationError (consistency: PR #78 review)', () => {
+    // The adjacent type check for `path` previously threw a plain Error while
+    // the whitespace check threw ConfigValidationError — both now agree.
+    const input = validConfigJson()
+    input.backends = [{ type: 'file', enabled: true, path: 42 }]
+    expect(() => validateConfig(input)).toThrow(ConfigValidationError)
+    expect(() => validateConfig(input)).toThrow('path must be a string')
+  })
+
   it('should accept backend with valid options object', () => {
     const input = validConfigJson()
     input.backends = [
@@ -93,12 +102,16 @@ describe('validateConfig', () => {
 
   // Negative tests
   it('should reject non-object', () => {
+    expect(() => validateConfig('string')).toThrow(ConfigValidationError)
     expect(() => validateConfig('string')).toThrow('Config must be an object')
     expect(() => validateConfig(null)).toThrow('Config must be an object')
     expect(() => validateConfig(42)).toThrow('Config must be an object')
   })
 
   it('should reject wrong version', () => {
+    expect(() => validateConfig({ ...validConfigJson(), version: 2 })).toThrow(
+      ConfigValidationError,
+    )
     expect(() => validateConfig({ ...validConfigJson(), version: 2 })).toThrow('version must be 1')
   })
 
@@ -109,6 +122,9 @@ describe('validateConfig', () => {
   })
 
   it('should reject backend with missing type', () => {
+    expect(() => validateConfig({ ...validConfigJson(), backends: [{ enabled: true }] })).toThrow(
+      ConfigValidationError,
+    )
     expect(() => validateConfig({ ...validConfigJson(), backends: [{ enabled: true }] })).toThrow(
       'type must be a non-empty string',
     )

--- a/packages/vaultkeeper/test/unit/config.test.ts
+++ b/packages/vaultkeeper/test/unit/config.test.ts
@@ -100,6 +100,23 @@ describe('validateConfig', () => {
     expect(() => validateConfig(input)).toThrow('must be a string')
   })
 
+  it('should report a bracketed, quoted field path for an invalid option value (PR #78 review)', () => {
+    // Option keys are user-defined and may contain characters that aren't
+    // valid identifier segments (dashes, spaces, dots); the field path must
+    // bracket-and-quote the key rather than dot-append it.
+    const input = validConfigJson()
+    input.backends = [{ type: 'file', enabled: true, options: { 'weird key.name': 42 } }]
+    try {
+      validateConfig(input)
+      expect.unreachable('validateConfig should have thrown')
+    } catch (err) {
+      if (!(err instanceof ConfigValidationError)) {
+        throw err
+      }
+      expect(err.field).toBe('backends[0].options["weird key.name"]')
+    }
+  })
+
   // Negative tests
   it('should reject non-object', () => {
     expect(() => validateConfig('string')).toThrow(ConfigValidationError)


### PR DESCRIPTION
Refs #60

## Summary

`BackendConfig.path` was documented and validated but silently ignored: file-based backends always wrote to the hardcoded `$HOME/.vaultkeeper/<backend>` location. This wires the backend's config through to the backend instance and makes the file-based backends honor `path`.

- `FileBackend`, `DpapiBackend`, and `YubikeyBackend` now take an optional storage directory (sourced from `BackendConfig.path`, forwarded by the registry factories). When `path` is set, secrets are stored / retrieved / deleted under that directory (created on demand); the default location is used when it is absent.
- The CLI `store` and `delete` commands were creating a backend from the first *registered* type with no config — ignoring both `path` and which backend was *enabled*. They now route through `VaultKeeper.store` / `VaultKeeper.delete`, which resolve the first enabled backend from config and forward its configuration. `exec` already went through `VaultKeeper` and inherits the fix.
- `keychain` and `secret-tool` are OS-native stores with no filesystem path; their factories are unchanged (out of scope per the issue).
- Follow-up from review: config validation now rejects a whitespace-only `path` (e.g. `" "`) instead of silently treating it as a real storage directory, and all structural/semantic validation failures in `validateConfig` / `validateBackendEntry` now throw the new `ConfigValidationError` (a typed `VaultError` subclass with a `field` property) instead of a plain `Error`.

## Acceptance criteria → tests

| # | Criterion | Test |
|---|-----------|------|
| 1 | Factories receive `BackendConfig`; `create(type, config)` passes it through; all built-ins migrated | `register-builtins.ts` factories + existing `registry.test.ts`; exercised end-to-end by the tests below |
| 2 | `FileBackend` honors `path` (custom dir created on demand; default unchanged when absent) | `test/integration/backend/file-backend-path.test.ts` — "stores … under the custom path and not the default home location" and "uses the default home location when no path is configured"; unit: `file-backend.test.ts` — "should store under a custom path from config, not the default location" |
| 3 | yubikey and dpapi honor `path` the same way | `dpapi-backend.test.ts` / `yubikey-backend.test.ts` — "should honor a custom storage path from config" |
| 4 | CLI inherits the fix (store/delete/exec against a custom file path) | `cli-tests/test/e2e/store-delete.test.ts` — "honors a custom file backend path for store and delete" (real subprocess, isolated `HOME`) |
| 5 | Integration: store with custom `path`, assert file under custom dir and NOT under `$HOME/.vaultkeeper/file`; second consumer with same config retrieves it | `test/integration/backend/file-backend-path.test.ts` — asserts entry under the custom dir, `ENOENT` on the default dir, retrieval via a backend built from the same config, and delete via a second `VaultKeeper` instance |
| 6 | API report regenerated; changeset included | `.changeset/honor-backend-path.md`; see note below |
| 7 | Whitespace-only `path` is rejected, not silently accepted | `config.test.ts` — "should reject a whitespace-only backend path" and "should reject an empty-string backend path", both asserting `ConfigValidationError` |

## Notes

- **API report diff.** The initial commits made no public API change (`BackendFactory` / `BackendRegistry.create` already accepted an optional `BackendConfig` on `main`, and the backend classes are `@internal`). Review feedback led to a new public export, `ConfigValidationError`, added to replace the plain `Error` throws in config validation — `api-report/vaultkeeper.api.md` has been regenerated via `pnpm generate:api-report` to reflect it. The changeset remains a **patch** for `vaultkeeper` and `@vaultkeeper/cli` since this is a validation-error-type addition, not a breaking behavior change.
- CLAUDE.md's Backends paragraph is updated to describe the config-forwarding factory contract (replacing the old zero-argument-factory convention).

## Verification

`pnpm check` (typecheck + lint + api-report) and `pnpm test` both pass across all packages.
