### PR TITLE
Make CLI TOFU trust functional: approve records the manifest, exec honors it

### DIFF
--- a/.changeset/tofu-approve-exec.md
+++ b/.changeset/tofu-approve-exec.md
@@ -1,0 +1,6 @@
+---
+'vaultkeeper': minor
+'@vaultkeeper/cli': patch
+---
+
+Make the CLI's trust-on-first-use (TOFU) model functional. `vaultkeeper approve --script <path>` now computes the script's SHA-256 and records it in the trust manifest (idempotently), and `vaultkeeper exec` consults the manifest before prompting: a caller whose current hash is already approved runs without an interactive prompt and reports a verified trust state, while a modified or unapproved caller is treated as untrusted. The library gains two public methods on `VaultKeeper` — `approveExecutable()` and `checkExecutableTrust()` — plus the `ExecutableTrustStatus` type, which back this behavior.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ echo "my-secret-value" | vaultkeeper store --name MY_API_KEY
 # Delete a secret
 vaultkeeper delete --name MY_API_KEY
 
-# Pre-approve an executable (TOFU)
-vaultkeeper approve --path /usr/local/bin/my-tool
+# Pre-approve an executable (TOFU): records its SHA-256 in the trust manifest
+vaultkeeper approve --script /usr/local/bin/my-tool
 
 # Toggle development mode for a script
 vaultkeeper dev-mode --path /path/to/script --enable
@@ -191,23 +191,23 @@ vault.dispose()
 
 The first enabled backend in the configuration is used.
 
-| Type | Platform | Notes |
-|------|----------|-------|
-| `keychain` | macOS | macOS Keychain (built-in) |
-| `dpapi` | Windows | Windows DPAPI (built-in) |
-| `secret-tool` | Linux | `libsecret` / `secret-tool` (built-in) |
-| `file` | All | AES-256-GCM encrypted file fallback (built-in) |
-| `1password` | All | 1Password `op` CLI (plugin) |
-| `yubikey` | All | YubiKey `ykman` (plugin) |
+| Type          | Platform | Notes                                          |
+| ------------- | -------- | ---------------------------------------------- |
+| `keychain`    | macOS    | macOS Keychain (built-in)                      |
+| `dpapi`       | Windows  | Windows DPAPI (built-in)                       |
+| `secret-tool` | Linux    | `libsecret` / `secret-tool` (built-in)         |
+| `file`        | All      | AES-256-GCM encrypted file fallback (built-in) |
+| `1password`   | All      | 1Password `op` CLI (plugin)                    |
+| `yubikey`     | All      | YubiKey `ykman` (plugin)                       |
 
 ## Platforms
 
-| Platform | Default backend | Required dependencies |
-|----------|----------------|----------------------|
-| macOS | `keychain` | `security` (built-in) |
-| Linux | `file` | None (AES-256-GCM encrypted file, no OS credential store needed) |
-| Windows | `dpapi` | PowerShell (built-in) |
-| Any | `file` | None (AES-256-GCM encrypted file, no OS credential store needed) |
+| Platform | Default backend | Required dependencies                                            |
+| -------- | --------------- | ---------------------------------------------------------------- |
+| macOS    | `keychain`      | `security` (built-in)                                            |
+| Linux    | `file`          | None (AES-256-GCM encrypted file, no OS credential store needed) |
+| Windows  | `dpapi`         | PowerShell (built-in)                                            |
+| Any      | `file`          | None (AES-256-GCM encrypted file, no OS credential store needed) |
 
 The `file` backend works on all platforms and requires no system dependencies. Use it as a fallback or in environments without a native credential store (CI, Docker, etc.).
 
@@ -267,10 +267,10 @@ const result = await VaultKeeper.doctor()
 // Or standalone
 const result = await runDoctor()
 
-console.log(result.ready)      // boolean
-console.log(result.checks)     // PreflightCheck[]
-console.log(result.warnings)   // string[]
-console.log(result.nextSteps)  // string[]
+console.log(result.ready) // boolean
+console.log(result.checks) // PreflightCheck[]
+console.log(result.warnings) // string[]
+console.log(result.nextSteps) // string[]
 ```
 
 Pass `skipDoctor: true` to bypass preflight on init:
@@ -303,11 +303,11 @@ Executable identity is verified during `setup()`. A `trustTier` value can be att
 
 > **Note:** In the current implementation, `trustTier` is recorded in the token claims but does not change which verification mechanism is used. Future versions may introduce tier-specific verification behavior.
 
-| Tier | Intended method |
-|------|-----------------|
-| `1` | Sigstore transparency log |
-| `2` | Registry signature |
-| `3` | TOFU (Trust On First Use) — hash stored in trust manifest |
+| Tier | Intended method                                           |
+| ---- | --------------------------------------------------------- |
+| `1`  | Sigstore transparency log                                 |
+| `2`  | Registry signature                                        |
+| `3`  | TOFU (Trust On First Use) — hash stored in trust manifest |
 
 Pass `trustTier` in setup options to override the configured default:
 
@@ -382,8 +382,8 @@ Config is loaded from `~/.config/vaultkeeper/config.json` by default. Override w
 
 ```ts
 const jwe = await vault.setup('SECRET_NAME', {
-  ttlMinutes: 30,          // token TTL (default: from config)
-  useLimit: 1,             // null for unlimited
+  ttlMinutes: 30, // token TTL (default: from config)
+  useLimit: 1, // null for unlimited
   executablePath: '/path/to/caller', // or 'dev' to skip identity check
   trustTier: 3,
   backendType: 'keychain',
@@ -394,41 +394,41 @@ const jwe = await vault.setup('SECRET_NAME', {
 
 All errors extend `VaultError`.
 
-| Class | When thrown |
-|-------|-------------|
-| `BackendLockedError` | Keychain or credential store is locked |
-| `DeviceNotPresentError` | Required hardware device not connected |
-| `AuthorizationDeniedError` | User denied an OS permission dialog |
-| `BackendUnavailableError` | No configured backend is reachable |
-| `PluginNotFoundError` | A required plugin binary is not installed |
-| `SecretNotFoundError` | Secret does not exist in the backend |
-| `TokenExpiredError` | JWE has passed its `exp` claim |
-| `KeyRotatedError` | Key exited grace period; JWE is permanently unreadable |
-| `KeyRevokedError` | Key was explicitly revoked |
-| `TokenRevokedError` | Token has been blocked (e.g. single-use token already consumed) |
-| `UsageLimitExceededError` | Token presented more times than its `use` limit allows |
-| `IdentityMismatchError` | Executable hash changed since TOFU approval |
-| `ExecError` | `exec()` request was invalid (e.g. `{{secret}}` in the command field) or the command could not be started (not found or failed to spawn) |
-| `InvalidTokenError` | JWE could not be decrypted or validated (e.g. structurally malformed, tampered, or failed decryption) |
-| `AccessorConsumedError` | `SecretAccessor.read()` called after already consumed |
-| `InvalidAlgorithmError` | Signing/verifying with a disallowed algorithm (e.g. `md5`) |
-| `SetupError` | Required system dependency missing or incompatible at init |
-| `FilesystemError` | Config directory not readable or writable |
-| `RotationInProgressError` | `rotateKey()` called while previous key is still in grace period |
+| Class                      | When thrown                                                                                                                              |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `BackendLockedError`       | Keychain or credential store is locked                                                                                                   |
+| `DeviceNotPresentError`    | Required hardware device not connected                                                                                                   |
+| `AuthorizationDeniedError` | User denied an OS permission dialog                                                                                                      |
+| `BackendUnavailableError`  | No configured backend is reachable                                                                                                       |
+| `PluginNotFoundError`      | A required plugin binary is not installed                                                                                                |
+| `SecretNotFoundError`      | Secret does not exist in the backend                                                                                                     |
+| `TokenExpiredError`        | JWE has passed its `exp` claim                                                                                                           |
+| `KeyRotatedError`          | Key exited grace period; JWE is permanently unreadable                                                                                   |
+| `KeyRevokedError`          | Key was explicitly revoked                                                                                                               |
+| `TokenRevokedError`        | Token has been blocked (e.g. single-use token already consumed)                                                                          |
+| `UsageLimitExceededError`  | Token presented more times than its `use` limit allows                                                                                   |
+| `IdentityMismatchError`    | Executable hash changed since TOFU approval                                                                                              |
+| `ExecError`                | `exec()` request was invalid (e.g. `{{secret}}` in the command field) or the command could not be started (not found or failed to spawn) |
+| `InvalidTokenError`        | JWE could not be decrypted or validated (e.g. structurally malformed, tampered, or failed decryption)                                    |
+| `AccessorConsumedError`    | `SecretAccessor.read()` called after already consumed                                                                                    |
+| `InvalidAlgorithmError`    | Signing/verifying with a disallowed algorithm (e.g. `md5`)                                                                               |
+| `SetupError`               | Required system dependency missing or incompatible at init                                                                               |
+| `FilesystemError`          | Config directory not readable or writable                                                                                                |
+| `RotationInProgressError`  | `rotateKey()` called while previous key is still in grace period                                                                         |
 
 ## Architecture
 
 vaultkeeper is a polyglot monorepo with TypeScript and Rust implementations sharing the same crypto primitives and wire format:
 
-| Component | Package | Description |
-|-----------|---------|-------------|
-| Rust core | `vaultkeeper-core` (crate) | All business logic, crypto (JWE, AES-256-GCM), backends, key management |
-| Native CLI | `vaultkeeper-cli` (crate) | Standalone binary using clap |
-| WASM bindings | `vaultkeeper-wasm` (crate) | wasm-bindgen wrapper over core |
-| TypeScript library | `vaultkeeper` (npm) | Pure TypeScript implementation |
-| WASM SDK | `@vaultkeeper/wasm` (npm) | Node.js wrapper around the WASM binary |
-| Node.js CLI | `@vaultkeeper/cli` (npm) | CLI using the TypeScript library |
-| Conformance tests | `vaultkeeper-conformance` (crate) | Data-driven tests ensuring both CLIs match |
+| Component          | Package                           | Description                                                             |
+| ------------------ | --------------------------------- | ----------------------------------------------------------------------- |
+| Rust core          | `vaultkeeper-core` (crate)        | All business logic, crypto (JWE, AES-256-GCM), backends, key management |
+| Native CLI         | `vaultkeeper-cli` (crate)         | Standalone binary using clap                                            |
+| WASM bindings      | `vaultkeeper-wasm` (crate)        | wasm-bindgen wrapper over core                                          |
+| TypeScript library | `vaultkeeper` (npm)               | Pure TypeScript implementation                                          |
+| WASM SDK           | `@vaultkeeper/wasm` (npm)         | Node.js wrapper around the WASM binary                                  |
+| Node.js CLI        | `@vaultkeeper/cli` (npm)          | CLI using the TypeScript library                                        |
+| Conformance tests  | `vaultkeeper-conformance` (crate) | Data-driven tests ensuring both CLIs match                              |
 
 JWE tokens created by the Rust core and the TypeScript library are wire-compatible — a token minted by one can be decrypted by the other.
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -63,6 +63,7 @@ export default tseslint.config(
       '**/tsup.config.ts',
       '**/vitest.config.ts',
       'packages/vaultkeeper/scripts/**',
+      'scripts/**',
       'vitest.workspace.ts',
       'eslint.config.ts',
       'prettier.config.js',

--- a/packages/cli-tests/test/e2e/approve.test.ts
+++ b/packages/cli-tests/test/e2e/approve.test.ts
@@ -1,9 +1,46 @@
 /**
- * UATs for the approve command.
+ * UATs for the approve command — the real CLI subprocess contract.
+ *
+ * approve records a script's SHA-256 in the TOFU trust manifest
+ * (trust-manifest.json) under the isolated config dir.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/57
  */
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
 import { describe, it, expect, afterEach } from 'vitest'
 import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
 import type { CliTestEnv } from '@vaultkeeper/cli-test-helpers'
+
+/** Independent SHA-256 reference (the spec) — not the implementation under test. */
+function sha256Hex(bytes: string): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex')
+}
+
+interface RawManifest {
+  version: number
+  entries: Record<string, { hashes: string[]; trustTier: number }>
+}
+
+function isRawManifest(value: unknown): value is RawManifest {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'entries' in value &&
+    typeof value.entries === 'object' &&
+    value.entries !== null
+  )
+}
+
+async function readManifest(configDir: string): Promise<RawManifest> {
+  const raw = await fs.readFile(path.join(configDir, 'trust-manifest.json'), 'utf8')
+  const parsed: unknown = JSON.parse(raw)
+  if (!isRawManifest(parsed)) {
+    throw new Error('unexpected manifest shape')
+  }
+  return parsed
+}
 
 describe('approve command', () => {
   let env: CliTestEnv | undefined
@@ -17,9 +54,56 @@ describe('approve command', () => {
 
   it('should approve a script and exit 0', async () => {
     env = await createCliTestEnv()
-    const result = await env.run(['approve', '--script', './test.sh'])
+    const script = path.join(env.configDir, 'test.sh')
+    await fs.writeFile(script, '#!/bin/sh\necho hi\n', { mode: 0o755 })
+
+    const result = await env.run(['approve', '--script', script])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Script approved')
+    expect(result.stdout).toContain('Approved')
   })
 
+  // Criterion 1 + Criterion 7 (approve writes the manifest file):
+  it('writes the script SHA-256 into trust-manifest.json', async () => {
+    env = await createCliTestEnv()
+    const contents = '#!/bin/sh\necho deploy\n'
+    const script = path.join(env.configDir, 'deploy.sh')
+    await fs.writeFile(script, contents, { mode: 0o755 })
+
+    const result = await env.run(['approve', '--script', script])
+    expect(result.exitCode).toBe(0)
+
+    const manifest = await readManifest(env.configDir)
+    const entry = manifest.entries[path.resolve(script)]
+    expect(entry).toBeDefined()
+    expect(entry?.hashes).toEqual([sha256Hex(contents)])
+  })
+
+  // Criterion 1: idempotent — twice exits 0 both times, one entry, one hash.
+  it('is idempotent across repeated approvals', async () => {
+    env = await createCliTestEnv()
+    const contents = 'payload\n'
+    const script = path.join(env.configDir, 'tool.sh')
+    await fs.writeFile(script, contents, { mode: 0o755 })
+
+    const first = await env.run(['approve', '--script', script])
+    const second = await env.run(['approve', '--script', script])
+    expect(first.exitCode).toBe(0)
+    expect(second.exitCode).toBe(0)
+
+    const manifest = await readManifest(env.configDir)
+    const entry = manifest.entries[path.resolve(script)]
+    expect(entry?.hashes).toEqual([sha256Hex(contents)])
+  })
+
+  // Criterion 2: nonexistent path exits non-zero, error names the path.
+  it('exits non-zero and names the missing path', async () => {
+    env = await createCliTestEnv()
+    const missing = path.join(env.configDir, 'nope.sh')
+
+    const result = await env.run(['approve', '--script', missing])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain(path.resolve(missing))
+    // No manifest is written for a failed approval.
+    await expect(readManifest(env.configDir)).rejects.toThrow()
+  })
 })

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -99,10 +99,11 @@ describe('exec trust gate', () => {
     expect(second.stderr).not.toMatch(/Allow\?|\[y\/N\]/)
   })
 
-  // Criterion 5: a caller modified after approval is NOT silently trusted — it
-  // falls through to the interactive prompt (which fails on non-TTY stdin),
-  // never reporting a verified/trusted state.
-  it('treats a modified caller as untrusted (no silent trust inheritance)', async () => {
+  // Criterion 5: a caller modified after approval is NOT silently trusted. A
+  // hash mismatch fails directly with an identity-mismatch error and re-approval
+  // guidance (no interactive prompt, since setup() would reject the same hash
+  // conflict regardless of the answer), never reporting a verified state.
+  it('rejects a modified caller with an identity-mismatch error (no silent trust inheritance)', async () => {
     if (env === undefined) throw new Error('env not initialized')
     const caller = await writeCaller('#!/bin/sh\necho original\n')
     await env.run(['approve', '--script', caller])
@@ -113,7 +114,10 @@ describe('exec trust gate', () => {
     const result = await env.run(execArgs(caller))
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).not.toContain('Trust: verified')
-    expect(result.stderr).toContain('interactive approval')
+    // Fails on the hash mismatch, not the interactive prompt.
+    expect(result.stderr).not.toContain('interactive approval')
+    expect(result.stderr).toContain('has changed since it was approved')
+    expect(result.stderr).toContain(`vaultkeeper approve --script ${caller}`)
     expect(result.stdout).not.toContain('ready=yes')
   })
 

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -1,0 +1,131 @@
+/**
+ * UATs for the exec command's TOFU trust gate — the real CLI subprocess
+ * contract with non-TTY stdin.
+ *
+ * The definitive proof for "trusted callers are not re-prompted": once the
+ * caller's hash is in the trust manifest, exec must proceed WITHOUT an
+ * interactive prompt. Because these run with a piped (non-TTY) stdin, any code
+ * path that reached the interactive prompt would fail — so a clean exit proves
+ * the prompt was skipped, and a prompt-required failure proves it was not.
+ *
+ * Secrets use the file backend under an isolated HOME so no OS credential
+ * store is touched.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/57
+ */
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
+import type { CliTestEnv } from '@vaultkeeper/cli-test-helpers'
+
+const SECRET_NAME = 'API_KEY'
+const SECRET_VALUE = 's3cr3t-value'
+
+let env: CliTestEnv | undefined
+let homeDir: string
+
+beforeEach(async () => {
+  homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-exec-home-'))
+  env = await createCliTestEnv({
+    env: { HOME: homeDir, VAULTKEEPER_SKIP_DOCTOR: '1' },
+  })
+  // Store the secret in the file backend (rooted at the isolated HOME).
+  const stored = await env.runWithStdin(['store', '--name', SECRET_NAME], `${SECRET_VALUE}\n`)
+  expect(stored.exitCode).toBe(0)
+})
+
+afterEach(async () => {
+  if (env !== undefined) {
+    await env.cleanup()
+    env = undefined
+  }
+  await fs.rm(homeDir, { recursive: true, force: true })
+})
+
+async function writeCaller(contents: string): Promise<string> {
+  const caller = path.join(homeDir, 'caller.sh')
+  await fs.writeFile(caller, contents, { mode: 0o755 })
+  return caller
+}
+
+function execArgs(caller: string): string[] {
+  return [
+    'exec',
+    '--secret',
+    SECRET_NAME,
+    '--env',
+    'INJECTED',
+    '--caller',
+    caller,
+    '--',
+    'sh',
+    '-c',
+    'printf "ready=%s" "${INJECTED:+yes}"',
+  ]
+}
+
+describe('exec trust gate', () => {
+  // Criterion 3: after approve, exec with a matching caller does NOT prompt
+  // and reports a trusted state — proven on non-TTY stdin.
+  it('does not prompt for an approved caller and injects the secret', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+
+    const approved = await env.run(['approve', '--script', caller])
+    expect(approved.exitCode).toBe(0)
+
+    const result = await env.run(execArgs(caller))
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('ready=yes')
+    expect(result.stderr).toContain('Trust: verified')
+    expect(result.stderr).not.toContain('Pending verification')
+    expect(result.stderr).not.toMatch(/Allow\?|\[y\/N\]/)
+  })
+
+  // Criterion 4 (observable CLI outcome): repeated exec invocations with the
+  // same, unmodified approved caller never re-prompt.
+  it('does not re-prompt on subsequent invocations of the same caller', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+    await env.run(['approve', '--script', caller])
+
+    const first = await env.run(execArgs(caller))
+    const second = await env.run(execArgs(caller))
+    expect(first.exitCode).toBe(0)
+    expect(second.exitCode).toBe(0)
+    expect(second.stderr).toContain('Trust: verified')
+    expect(second.stderr).not.toMatch(/Allow\?|\[y\/N\]/)
+  })
+
+  // Criterion 5: a caller modified after approval is NOT silently trusted — it
+  // falls through to the interactive prompt (which fails on non-TTY stdin),
+  // never reporting a verified/trusted state.
+  it('treats a modified caller as untrusted (no silent trust inheritance)', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho original\n')
+    await env.run(['approve', '--script', caller])
+
+    // Tamper with the caller after approval — its hash no longer matches.
+    await fs.writeFile(caller, '#!/bin/sh\necho tampered\n', { mode: 0o755 })
+
+    const result = await env.run(execArgs(caller))
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).not.toContain('Trust: verified')
+    expect(result.stderr).toContain('interactive approval')
+    expect(result.stdout).not.toContain('ready=yes')
+  })
+
+  // Criterion 3/5 contrast: an unapproved caller is also untrusted and reaches
+  // the prompt gate (fails on non-TTY stdin).
+  it('treats a never-approved caller as untrusted', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+
+    const result = await env.run(execArgs(caller))
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).not.toContain('Trust: verified')
+    expect(result.stderr).toContain('interactive approval')
+  })
+})

--- a/packages/cli/src/commands/approve.ts
+++ b/packages/cli/src/commands/approve.ts
@@ -40,7 +40,10 @@ export async function approveCommand(args: string[]): Promise<number> {
   const scriptPath = path.resolve(values.script)
 
   try {
-    // Approving a hash does not need backend health, so skip doctor preflight.
+    // Approving a hash is a trust-only operation: it touches the config dir and
+    // trust manifest, never the secret backend. Skip the doctor preflight, and
+    // VaultKeeper.init() itself resolves the backend lazily, so approve works
+    // even when the configured backend or plugin is unavailable.
     const vault = await VaultKeeper.init({ skipDoctor: true })
     const status = await vault.approveExecutable(scriptPath)
     process.stdout.write(`Approved ${scriptPath} (hash: ${status.hash})\n`)

--- a/packages/cli/src/commands/approve.ts
+++ b/packages/cli/src/commands/approve.ts
@@ -1,18 +1,21 @@
 import { parseArgs } from 'node:util'
 import * as path from 'node:path'
+import { VaultKeeper } from 'vaultkeeper'
+import { formatError } from '../output.js'
 
 function printApproveHelp(): void {
   process.stdout.write(
     'Usage: vaultkeeper approve --script <path>\n\n' +
-      'Pre-record a script hash in the TOFU manifest so the first\n' +
-      'invocation via vaultkeeper exec does not prompt for trust.\n\n' +
+      'Record a script hash in the TOFU trust manifest so that invoking it via\n' +
+      'vaultkeeper exec does not prompt for trust. Running this on an already\n' +
+      'approved, unchanged script is idempotent.\n\n' +
       'Options:\n' +
       '  --script <path>   Path to the script to approve\n' +
       '  -h, --help        Show this help message\n',
   )
 }
 
-export function approveCommand(args: string[]): number {
+export async function approveCommand(args: string[]): Promise<number> {
   // Handle --help / -h before strict parseArgs.
   if (args.includes('--help') || args.includes('-h')) {
     printApproveHelp()
@@ -36,13 +39,15 @@ export function approveCommand(args: string[]): number {
 
   const scriptPath = path.resolve(values.script)
 
-  // The TOFU manifest records the executable hash on first use via setup().
-  // Direct manifest manipulation is not part of the public vaultkeeper API.
-  // The hash will be recorded automatically the first time this script
-  // runs `vaultkeeper exec`.
-  process.stdout.write(`Script approved: ${scriptPath}\n`)
-  process.stdout.write(
-    'The script hash will be recorded on first use with vaultkeeper exec.\n',
-  )
-  return 0
+  try {
+    // Approving a hash does not need backend health, so skip doctor preflight.
+    const vault = await VaultKeeper.init({ skipDoctor: true })
+    const status = await vault.approveExecutable(scriptPath)
+    process.stdout.write(`Approved ${scriptPath} (hash: ${status.hash})\n`)
+    return 0
+  } catch (err) {
+    process.stderr.write(`${formatError(err)}\n`)
+    // Exit code 1: runtime error (e.g. missing script, unwritable manifest)
+    return 1
+  }
 }

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -66,10 +66,14 @@ async function enforceTrustGate(
   }
 
   if (trust.hashMismatch) {
+    // On a mismatch the manifest holds at least one prior approved hash; report
+    // the most recently approved one as previousHash and the on-disk hash as
+    // currentHash so the error payload is accurate for diagnosis.
+    const previousHash = trust.approvedHashes.at(-1) ?? trust.hash
     throw new IdentityMismatchError(
       `Executable at ${callerPath} has changed since it was approved. ` +
         `If this change is expected, re-approve it with: vaultkeeper approve --script ${callerPath}`,
-      'previously-approved',
+      previousHash,
       trust.hash,
     )
   }

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -30,6 +30,37 @@ import { RedactingStream } from '../redact.js'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
 
+/**
+ * Ensure the caller is authorized to access `secret`, consulting the TOFU
+ * trust manifest first.
+ *
+ * When the caller's current hash is already approved in the manifest, the
+ * caller is trusted and no interactive prompt is shown (so trusted callers
+ * work on non-TTY stdin). Otherwise an interactive approval prompt is shown;
+ * a hash that changed from a previously approved value is surfaced as such.
+ *
+ * @returns `true` if access is authorized, `false` if the user declined.
+ */
+async function ensureApproved(
+  vault: VaultKeeper,
+  callerPath: string,
+  secret: string,
+  reason: string | undefined,
+): Promise<boolean> {
+  const trust = await vault.checkExecutableTrust(callerPath)
+  if (trust.trusted) {
+    process.stderr.write('Trust: verified (hash matches trust manifest)\n')
+    return true
+  }
+
+  return promptApproval({
+    caller: callerPath,
+    trustInfo: trust.hashMismatch ? 'Hash changed — re-approval required' : 'Pending verification',
+    secret,
+    reason,
+  })
+}
+
 function printExecHelp(): void {
   process.stdout.write(
     'Usage: vaultkeeper exec --secret <name> --env <VAR> --caller <path> [options] -- <command...>\n\n' +
@@ -114,15 +145,10 @@ export async function execCommand(args: string[]): Promise<number> {
     }
 
     if (jwe === undefined) {
-      // [C1 fix] Prompt for approval BEFORE retrieving the secret.
-      // vault.setup() retrieves the secret from the backend and embeds it
-      // in a JWE, so we must get user consent first.
-      const approved = await promptApproval({
-        caller: callerPath,
-        trustInfo: 'Pending verification',
-        secret,
-        reason: values.reason,
-      })
+      // [C1 fix] Gate access BEFORE retrieving the secret. vault.setup()
+      // retrieves the secret from the backend and embeds it in a JWE, so we
+      // must confirm trust (manifest match) or user consent first.
+      const approved = await ensureApproved(vault, callerPath, secret, values.reason)
 
       if (!approved) {
         process.stderr.write('Access denied by user.\n')
@@ -153,12 +179,7 @@ export async function execCommand(args: string[]): Promise<number> {
         // [C2 fix] Retry by toggling the useCache flag off internally
         // rather than filtering args (which could corrupt the wrapped command).
         jwe = undefined
-        const approved = await promptApproval({
-          caller: callerPath,
-          trustInfo: 'Pending verification',
-          secret,
-          reason: values.reason,
-        })
+        const approved = await ensureApproved(vault, callerPath, secret, values.reason)
         if (!approved) {
           process.stderr.write('Access denied by user.\n')
           return 1

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -3,8 +3,10 @@
  *
  * Flow:
  * 1. Parse flags and the command after `--`
- * 2. If `--cache`, check for a cached JWE token
- * 3. If no cached token: prompt for approval, THEN retrieve and setup the secret
+ * 2. Enforce the TOFU trust gate for the caller (runs on every invocation,
+ *    including `--cache` hits, so a cached token never bypasses trust)
+ * 3. If `--cache`, check for a cached JWE token; otherwise retrieve and setup
+ *    the secret into a fresh JWE
  * 4. Authorize the JWE → obtain a CapabilityToken
  * 5. Read the secret value via the accessor
  * 6. Spawn the child process with the secret injected as an env var
@@ -23,7 +25,7 @@
 import { parseArgs } from 'node:util'
 import { spawn } from 'node:child_process'
 import * as path from 'node:path'
-import { VaultKeeper } from 'vaultkeeper'
+import { VaultKeeper, IdentityMismatchError } from 'vaultkeeper'
 import { promptApproval } from '../approval.js'
 import { readCachedToken, writeCachedToken, invalidateCache } from '../cache.js'
 import { RedactingStream } from '../redact.js'
@@ -31,17 +33,27 @@ import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
 
 /**
- * Ensure the caller is authorized to access `secret`, consulting the TOFU
- * trust manifest first.
+ * Enforce the TOFU trust gate for `callerPath` before any secret is retrieved
+ * or any cached token is used.
  *
- * When the caller's current hash is already approved in the manifest, the
- * caller is trusted and no interactive prompt is shown (so trusted callers
- * work on non-TTY stdin). Otherwise an interactive approval prompt is shown;
- * a hash that changed from a previously approved value is surfaced as such.
+ * Behavior depends on the caller's current trust status:
+ *
+ * - **Trusted** (current hash approved in the manifest): returns `true` without
+ *   an interactive prompt, so trusted callers work on non-TTY stdin.
+ * - **Hash mismatch** (caller is known to the manifest but its hash changed
+ *   since approval): throws {@link IdentityMismatchError} with re-approval
+ *   guidance. It does not prompt — `VaultKeeper.setup()` rejects the same hash
+ *   conflict regardless of the user's answer, so prompting would waste it.
+ * - **Never approved**: shows an interactive approval prompt and returns its
+ *   result (`false` if the user declines).
  *
  * @returns `true` if access is authorized, `false` if the user declined.
+ * @throws {IdentityMismatchError} When the caller's hash changed from a
+ *   previously approved value.
+ * @throws When interactive approval is required but stdin is not a TTY, or when
+ *   the caller path cannot be read for hashing.
  */
-async function ensureApproved(
+async function enforceTrustGate(
   vault: VaultKeeper,
   callerPath: string,
   secret: string,
@@ -53,9 +65,18 @@ async function ensureApproved(
     return true
   }
 
+  if (trust.hashMismatch) {
+    throw new IdentityMismatchError(
+      `Executable at ${callerPath} has changed since it was approved. ` +
+        `If this change is expected, re-approve it with: vaultkeeper approve --script ${callerPath}`,
+      'previously-approved',
+      trust.hash,
+    )
+  }
+
   return promptApproval({
     caller: callerPath,
-    trustInfo: trust.hashMismatch ? 'Hash changed — re-approval required' : 'Pending verification',
+    trustInfo: 'Pending verification',
     secret,
     reason,
   })
@@ -138,23 +159,24 @@ export async function execCommand(args: string[]): Promise<number> {
   try {
     const vault = await VaultKeeper.init({ skipDoctor })
 
-    // Check cache first if --cache
+    // Enforce the trust gate BEFORE touching the cache or retrieving the
+    // secret. This runs on every invocation — including a `--cache` hit — so a
+    // previously cached JWE can never let a modified or never-approved caller
+    // inherit trust it no longer (or never) held. A modified caller surfaces an
+    // identity-mismatch error here rather than silently reusing a cached token.
+    const approved = await enforceTrustGate(vault, callerPath, secret, values.reason)
+    if (!approved) {
+      process.stderr.write('Access denied by user.\n')
+      return 1
+    }
+
+    // Check cache only after the caller has cleared the trust gate.
     let jwe: string | undefined
     if (useCache) {
       jwe = await readCachedToken(callerPath, secret)
     }
 
     if (jwe === undefined) {
-      // [C1 fix] Gate access BEFORE retrieving the secret. vault.setup()
-      // retrieves the secret from the backend and embeds it in a JWE, so we
-      // must confirm trust (manifest match) or user consent first.
-      const approved = await ensureApproved(vault, callerPath, secret, values.reason)
-
-      if (!approved) {
-        process.stderr.write('Access denied by user.\n')
-        return 1
-      }
-
       jwe = await vault.setup(secret, { executablePath: callerPath })
 
       // Cache if requested
@@ -172,18 +194,11 @@ export async function execCommand(args: string[]): Promise<number> {
         secretValue = buf.toString('utf8')
       })
     } catch (err) {
-      // If cached token failed, invalidate and retry without cache
+      // If the cached token failed (e.g. expired), invalidate and mint a fresh
+      // one. Trust was already enforced above, so no re-prompt is needed.
       if (useCache) {
         await invalidateCache(callerPath, secret)
         process.stderr.write('Cached token expired, re-authenticating...\n')
-        // [C2 fix] Retry by toggling the useCache flag off internally
-        // rather than filtering args (which could corrupt the wrapped command).
-        jwe = undefined
-        const approved = await ensureApproved(vault, callerPath, secret, values.reason)
-        if (!approved) {
-          process.stderr.write('Access denied by user.\n')
-          return 1
-        }
         jwe = await vault.setup(secret, { executablePath: callerPath })
         // Write the new token back to cache so subsequent invocations benefit
         await writeCachedToken(callerPath, secret, jwe)

--- a/packages/cli/test/unit/commands/approve.test.ts
+++ b/packages/cli/test/unit/commands/approve.test.ts
@@ -1,12 +1,22 @@
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
 import * as path from 'node:path'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { approveCommand } from '../../../src/commands/approve.js'
 
+/** Independent SHA-256 reference (the spec) — not the implementation under test. */
+function sha256Hex(bytes: string): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex')
+}
+
 describe('approveCommand', () => {
   let stderrOutput: string
   let stdoutOutput: string
+  let configDir: string
+  const originalConfigDir = process.env.VAULTKEEPER_CONFIG_DIR
 
-  beforeEach(() => {
+  beforeEach(async () => {
     stderrOutput = ''
     stdoutOutput = ''
     vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
@@ -17,68 +27,93 @@ describe('approveCommand', () => {
       stdoutOutput += String(chunk)
       return true
     })
+    // Isolate the trust manifest to a temp dir; never touch the real config dir.
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-approve-unit-'))
+    process.env.VAULTKEEPER_CONFIG_DIR = configDir
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks()
+    if (originalConfigDir === undefined) {
+      delete process.env.VAULTKEEPER_CONFIG_DIR
+    } else {
+      process.env.VAULTKEEPER_CONFIG_DIR = originalConfigDir
+    }
+    await fs.rm(configDir, { recursive: true, force: true })
   })
 
   describe('--help / -h', () => {
-    it('should print usage and return 0 for --help', () => {
-      const code = approveCommand(['--help'])
+    it('should print usage and return 0 for --help', async () => {
+      const code = await approveCommand(['--help'])
       expect(code).toBe(0)
       expect(stdoutOutput).toContain('Usage: vaultkeeper approve')
     })
 
-    it('should print usage and return 0 for -h', () => {
-      const code = approveCommand(['-h'])
+    it('should print usage and return 0 for -h', async () => {
+      const code = await approveCommand(['-h'])
       expect(code).toBe(0)
       expect(stdoutOutput).toContain('Usage: vaultkeeper approve')
+    })
+
+    // Criterion 6: help describes the real (idempotent, manifest-writing) behavior.
+    it('describes the TOFU manifest behavior accurately', async () => {
+      await approveCommand(['--help'])
+      expect(stdoutOutput).toContain('TOFU trust manifest')
+      expect(stdoutOutput).toContain('idempotent')
     })
   })
 
   describe('--script flag validation', () => {
-    it('should return 2 when --script is missing', () => {
-      const code = approveCommand([])
+    it('should return 2 when --script is missing', async () => {
+      const code = await approveCommand([])
       expect(code).toBe(2)
     })
 
-    it('should write error to stderr when --script is missing', () => {
-      approveCommand([])
+    it('should write error to stderr when --script is missing', async () => {
+      await approveCommand([])
       expect(stderrOutput).toContain('--script is required')
     })
 
-    it('should include usage hint when --script is missing', () => {
-      approveCommand([])
+    it('should include usage hint when --script is missing', async () => {
+      await approveCommand([])
       expect(stderrOutput).toContain('Usage: vaultkeeper approve')
     })
   })
 
   describe('valid --script flag', () => {
-    it('should return 0 when --script is provided', () => {
-      const code = approveCommand(['--script', '/path/to/my-script.sh'])
+    // Criterion 1: approve hashes the target and reports the recorded hash.
+    it('records the hash and reports success', async () => {
+      const contents = '#!/bin/sh\necho hi\n'
+      const script = path.join(configDir, 'my-script.sh')
+      await fs.writeFile(script, contents, { mode: 0o755 })
+
+      const code = await approveCommand(['--script', script])
       expect(code).toBe(0)
+      expect(stdoutOutput).toContain('Approved')
+      expect(stdoutOutput).toContain(sha256Hex(contents))
     })
 
-    it('should write success message to stdout', () => {
-      approveCommand(['--script', '/path/to/my-script.sh'])
-      expect(stdoutOutput).toContain('Script approved:')
-    })
+    it('resolves a relative script path to an absolute path in output', async () => {
+      const contents = 'payload\n'
+      const script = path.join(configDir, 'script.sh')
+      await fs.writeFile(script, contents, { mode: 0o755 })
 
-    it('should write first-use note to stdout', () => {
-      approveCommand(['--script', '/path/to/my-script.sh'])
-      expect(stdoutOutput).toContain('first use')
-    })
-
-    it('should resolve the script path before printing', () => {
-      approveCommand(['--script', 'relative/script.sh'])
-      // resolving makes it absolute — must contain an absolute-path indicator
-      expect(stdoutOutput).toContain('script.sh')
-      // The printed path should be absolute (starts with /)
-      const match = /Script approved: (.+)\n/.exec(stdoutOutput)
+      const code = await approveCommand(['--script', script])
+      expect(code).toBe(0)
+      const match = /Approved (.+) \(hash:/.exec(stdoutOutput)
       const printedPath = match?.[1]
       expect(printedPath).toBeDefined()
       expect(path.isAbsolute(printedPath ?? '')).toBe(true)
+    })
+  })
+
+  describe('missing script', () => {
+    // Criterion 2: a nonexistent path exits non-zero, naming the missing path.
+    it('exits 1 and names the missing path', async () => {
+      const missing = path.join(configDir, 'does-not-exist.sh')
+      const code = await approveCommand(['--script', missing])
+      expect(code).toBe(1)
+      expect(stderrOutput).toContain(path.resolve(missing))
     })
   })
 })

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -1,12 +1,32 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { execCommand } from '../../../src/commands/exec.js'
+import { promptApproval } from '../../../src/approval.js'
+import { readCachedToken } from '../../../src/cache.js'
 
 const mockInit = vi.hoisted(() => vi.fn())
+
+// A real IdentityMismatchError subclass so `.name`/`.message` format exactly as
+// the CLI expects when it constructs and formats the mismatch error. Defined
+// via vi.hoisted so it is initialized before the hoisted vi.mock factory runs.
+const IdentityMismatchError = vi.hoisted(
+  () =>
+    class IdentityMismatchError extends Error {
+      readonly previousHash: string
+      readonly currentHash: string
+      constructor(message: string, previousHash: string, currentHash: string) {
+        super(message)
+        this.name = 'IdentityMismatchError'
+        this.previousHash = previousHash
+        this.currentHash = currentHash
+      }
+    },
+)
 
 vi.mock('vaultkeeper', () => ({
   VaultKeeper: {
     init: mockInit,
   },
+  IdentityMismatchError,
 }))
 
 // Prevent any real approval prompts from blocking tests
@@ -45,7 +65,14 @@ describe('execCommand', () => {
 
   describe('-- separator validation', () => {
     it('should return 2 when -- separator is missing', async () => {
-      const code = await execCommand(['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh'])
+      const code = await execCommand([
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
+      ])
       expect(code).toBe(2)
     })
 
@@ -62,29 +89,69 @@ describe('execCommand', () => {
 
   describe('command after -- validation', () => {
     it('should return 2 when command after -- is empty', async () => {
-      const code = await execCommand(['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--'])
+      const code = await execCommand([
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
+        '--',
+      ])
       expect(code).toBe(2)
     })
 
     it('should write error message when command after -- is empty', async () => {
-      await execCommand(['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--'])
+      await execCommand([
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
+        '--',
+      ])
       expect(stderrOutput).toContain('No command provided after --')
     })
   })
 
   describe('required flag validation', () => {
     it('should return 2 when --secret is missing', async () => {
-      const code = await execCommand(['--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--', 'echo', 'hello'])
+      const code = await execCommand([
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
+        '--',
+        'echo',
+        'hello',
+      ])
       expect(code).toBe(2)
     })
 
     it('should return 2 when --env is missing', async () => {
-      const code = await execCommand(['--secret', 'my-key', '--caller', '/path/to/script.sh', '--', 'echo', 'hello'])
+      const code = await execCommand([
+        '--secret',
+        'my-key',
+        '--caller',
+        '/path/to/script.sh',
+        '--',
+        'echo',
+        'hello',
+      ])
       expect(code).toBe(2)
     })
 
     it('should return 2 when --caller is missing', async () => {
-      const code = await execCommand(['--secret', 'my-key', '--env', 'MY_VAR', '--', 'echo', 'hello'])
+      const code = await execCommand([
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--',
+        'echo',
+        'hello',
+      ])
       expect(code).toBe(2)
     })
 
@@ -94,7 +161,15 @@ describe('execCommand', () => {
     })
 
     it('should write error message when required flags are missing', async () => {
-      await execCommand(['--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--', 'echo', 'hello'])
+      await execCommand([
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
+        '--',
+        'echo',
+        'hello',
+      ])
       expect(stderrOutput).toContain('--secret, --env, and --caller are required')
     })
   })
@@ -104,11 +179,15 @@ describe('execCommand', () => {
       // promptApproval returns false, so init will be called but the command exits at denial
       mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
       await execCommand([
-        '--secret', 'my-key',
-        '--env', 'MY_VAR',
-        '--caller', '/path/to/script.sh',
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
         '--',
-        'echo', 'hello',
+        'echo',
+        'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
     })
@@ -117,11 +196,15 @@ describe('execCommand', () => {
       mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
       await execCommand([
         '--skip-doctor',
-        '--secret', 'my-key',
-        '--env', 'MY_VAR',
-        '--caller', '/path/to/script.sh',
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
         '--',
-        'echo', 'hello',
+        'echo',
+        'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
     })
@@ -130,11 +213,15 @@ describe('execCommand', () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '1'
       mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
       await execCommand([
-        '--secret', 'my-key',
-        '--env', 'MY_VAR',
-        '--caller', '/path/to/script.sh',
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
         '--',
-        'echo', 'hello',
+        'echo',
+        'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
     })
@@ -143,11 +230,15 @@ describe('execCommand', () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '0'
       mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
       await execCommand([
-        '--secret', 'my-key',
-        '--env', 'MY_VAR',
-        '--caller', '/path/to/script.sh',
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
         '--',
-        'echo', 'hello',
+        'echo',
+        'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
     })
@@ -156,11 +247,15 @@ describe('execCommand', () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = 'true'
       mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
       await execCommand([
-        '--secret', 'my-key',
-        '--env', 'MY_VAR',
-        '--caller', '/path/to/script.sh',
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
         '--',
-        'echo', 'hello',
+        'echo',
+        'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
     })
@@ -169,13 +264,111 @@ describe('execCommand', () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = ''
       mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
       await execCommand([
-        '--secret', 'my-key',
-        '--env', 'MY_VAR',
-        '--caller', '/path/to/script.sh',
+        '--secret',
+        'my-key',
+        '--env',
+        'MY_VAR',
+        '--caller',
+        '/path/to/script.sh',
         '--',
-        'echo', 'hello',
+        'echo',
+        'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+    })
+  })
+
+  describe('trust gate', () => {
+    const EXEC_ARGS = [
+      '--secret',
+      'my-key',
+      '--env',
+      'MY_VAR',
+      '--caller',
+      '/path/to/script.sh',
+      '--',
+      'echo',
+      'hello',
+    ]
+
+    // Regression for review thread 3582165381: on a TOFU hash mismatch the CLI
+    // must fail directly with an identity-mismatch error and re-approval
+    // guidance, NOT prompt — setup() would reject the same hash conflict
+    // regardless of the user's answer, so a prompt just wastes it.
+    it('fails with an identity-mismatch error instead of prompting when the caller hash changed', async () => {
+      const setup = vi.fn()
+      const authorize = vi.fn()
+      const getSecret = vi.fn()
+      const checkExecutableTrust = vi.fn().mockResolvedValue({
+        trusted: false,
+        hashMismatch: true,
+        hash: 'newhash',
+        reason: 'changed',
+      })
+      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+
+      const code = await execCommand(EXEC_ARGS)
+
+      expect(code).toBe(1)
+      expect(promptApproval).not.toHaveBeenCalled()
+      expect(setup).not.toHaveBeenCalled()
+      expect(authorize).not.toHaveBeenCalled()
+      expect(stderrOutput).toContain('has changed since it was approved')
+      expect(stderrOutput).toContain('vaultkeeper approve --script /path/to/script.sh')
+    })
+
+    // Regression for review thread 3582165347: a `--cache` hit must NOT bypass
+    // the trust gate. A modified (hash-changed) caller with a previously cached
+    // token must be refused, never silently riding the cached JWE.
+    it('re-verifies caller trust on a --cache hit and refuses a modified caller', async () => {
+      const setup = vi.fn()
+      const authorize = vi.fn()
+      const getSecret = vi.fn()
+      const checkExecutableTrust = vi.fn().mockResolvedValue({
+        trusted: false,
+        hashMismatch: true,
+        hash: 'newhash',
+        reason: 'changed',
+      })
+      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      // A previously cached token exists — but the gate must run before it is used.
+      vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')
+
+      const code = await execCommand(['--cache', ...EXEC_ARGS])
+
+      expect(code).not.toBe(0)
+      // The cached token was never used to authorize or read the secret.
+      expect(authorize).not.toHaveBeenCalled()
+      expect(getSecret).not.toHaveBeenCalled()
+      expect(stderrOutput).toContain('has changed since it was approved')
+    })
+
+    // Complement to the above: a trusted caller with a cache hit reuses the
+    // cached token (no re-mint) and is not prompted.
+    it('uses a cached token for a trusted caller without prompting or re-minting', async () => {
+      const setup = vi.fn()
+      const authorize = vi.fn().mockResolvedValue({ token: {}, vaultResponse: {} })
+      const getSecret = vi.fn().mockReturnValue({
+        read: (cb: (buf: Buffer) => void) => {
+          cb(Buffer.from('s3cr3t'))
+        },
+      })
+      const checkExecutableTrust = vi.fn().mockResolvedValue({
+        trusted: true,
+        hashMismatch: false,
+        hash: 'goodhash',
+        reason: 'trusted',
+      })
+      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')
+
+      const code = await execCommand(['--cache', ...EXEC_ARGS])
+
+      expect(code).toBe(0)
+      expect(promptApproval).not.toHaveBeenCalled()
+      expect(setup).not.toHaveBeenCalled()
+      expect(authorize).toHaveBeenCalledWith('cached.jwe.token')
+      expect(stderrOutput).toContain('Trust: verified')
     })
   })
 

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -8,9 +8,12 @@ const mockInit = vi.hoisted(() => vi.fn())
 // A real IdentityMismatchError subclass so `.name`/`.message` format exactly as
 // the CLI expects when it constructs and formats the mismatch error. Defined
 // via vi.hoisted so it is initialized before the hoisted vi.mock factory runs.
+// Each constructed instance is recorded so tests can assert the CLI populated
+// previousHash/currentHash with the real hashes (not a placeholder).
 const IdentityMismatchError = vi.hoisted(
   () =>
     class IdentityMismatchError extends Error {
+      static readonly instances: IdentityMismatchError[] = []
       readonly previousHash: string
       readonly currentHash: string
       constructor(message: string, previousHash: string, currentHash: string) {
@@ -18,6 +21,7 @@ const IdentityMismatchError = vi.hoisted(
         this.name = 'IdentityMismatchError'
         this.previousHash = previousHash
         this.currentHash = currentHash
+        IdentityMismatchError.instances.push(this)
       }
     },
 )
@@ -47,6 +51,7 @@ describe('execCommand', () => {
   beforeEach(() => {
     stderrOutput = ''
     stdoutOutput = ''
+    IdentityMismatchError.instances.length = 0
     vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
       stderrOutput += String(chunk)
       return true
@@ -303,6 +308,7 @@ describe('execCommand', () => {
         trusted: false,
         hashMismatch: true,
         hash: 'newhash',
+        approvedHashes: ['oldhash'],
         reason: 'changed',
       })
       mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
@@ -315,6 +321,14 @@ describe('execCommand', () => {
       expect(authorize).not.toHaveBeenCalled()
       expect(stderrOutput).toContain('has changed since it was approved')
       expect(stderrOutput).toContain('vaultkeeper approve --script /path/to/script.sh')
+
+      // Regression for review threads 3582262153 / 3582262187: the constructed
+      // error carries the REAL hashes — the manifest-recorded approved hash and
+      // the on-disk hash — never the old 'previously-approved' placeholder.
+      const err = IdentityMismatchError.instances.at(-1)
+      expect(err?.previousHash).toBe('oldhash')
+      expect(err?.currentHash).toBe('newhash')
+      expect(err?.previousHash).not.toBe('previously-approved')
     })
 
     // Regression for review thread 3582165347: a `--cache` hit must NOT bypass
@@ -328,6 +342,7 @@ describe('execCommand', () => {
         trusted: false,
         hashMismatch: true,
         hash: 'newhash',
+        approvedHashes: ['oldhash'],
         reason: 'changed',
       })
       mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
@@ -357,6 +372,7 @@ describe('execCommand', () => {
         trusted: true,
         hashMismatch: false,
         hash: 'goodhash',
+        approvedHashes: ['goodhash'],
         reason: 'trusted',
       })
       mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -44,6 +44,34 @@ vi.mock('../../../src/cache.js', () => ({
   invalidateCache: vi.fn().mockResolvedValue(undefined),
 }))
 
+/**
+ * Default VaultKeeper mock for tests that drive execCommand end-to-end. It
+ * includes checkExecutableTrust() — which execCommand now calls first, before
+ * any prompt/cache/secret flow — returning a "pending" (never-approved, no
+ * mismatch) status. With promptApproval mocked to decline, this deterministically
+ * exercises the trust gate's "prompt → declined → Access denied" path rather than
+ * short-circuiting on a missing-method TypeError.
+ */
+function pendingVaultMock(): {
+  checkExecutableTrust: ReturnType<typeof vi.fn>
+  setup: ReturnType<typeof vi.fn>
+  authorize: ReturnType<typeof vi.fn>
+  getSecret: ReturnType<typeof vi.fn>
+} {
+  return {
+    checkExecutableTrust: vi.fn().mockResolvedValue({
+      trusted: false,
+      hashMismatch: false,
+      hash: 'pending-hash',
+      approvedHashes: [],
+      reason: 'Executable not yet approved',
+    }),
+    setup: vi.fn(),
+    authorize: vi.fn(),
+    getSecret: vi.fn(),
+  }
+}
+
 describe('execCommand', () => {
   let stderrOutput: string
   let stdoutOutput: string
@@ -180,9 +208,14 @@ describe('execCommand', () => {
   })
 
   describe('--skip-doctor flag', () => {
+    // These drive the full command with a never-approved (pending) caller, so
+    // the trust gate reaches promptApproval (mocked to decline) and the command
+    // exits at "Access denied". Asserting the gate was reached keeps these tests
+    // genuinely exercising the trust path — if the default mock stopped providing
+    // checkExecutableTrust, execCommand would throw before promptApproval and
+    // these assertions would fail.
     it('should pass skipDoctor: false to VaultKeeper.init by default', async () => {
-      // promptApproval returns false, so init will be called but the command exits at denial
-      mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
+      mockInit.mockResolvedValue(pendingVaultMock())
       await execCommand([
         '--secret',
         'my-key',
@@ -195,10 +228,12 @@ describe('execCommand', () => {
         'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      expect(promptApproval).toHaveBeenCalled()
+      expect(stderrOutput).toContain('Access denied by user.')
     })
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
-      mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
+      mockInit.mockResolvedValue(pendingVaultMock())
       await execCommand([
         '--skip-doctor',
         '--secret',
@@ -212,11 +247,12 @@ describe('execCommand', () => {
         'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      expect(promptApproval).toHaveBeenCalled()
     })
 
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '1'
-      mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
+      mockInit.mockResolvedValue(pendingVaultMock())
       await execCommand([
         '--secret',
         'my-key',
@@ -229,11 +265,12 @@ describe('execCommand', () => {
         'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      expect(promptApproval).toHaveBeenCalled()
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '0'
-      mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
+      mockInit.mockResolvedValue(pendingVaultMock())
       await execCommand([
         '--secret',
         'my-key',
@@ -246,11 +283,12 @@ describe('execCommand', () => {
         'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      expect(promptApproval).toHaveBeenCalled()
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=true (non-numeric)', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = 'true'
-      mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
+      mockInit.mockResolvedValue(pendingVaultMock())
       await execCommand([
         '--secret',
         'my-key',
@@ -263,11 +301,12 @@ describe('execCommand', () => {
         'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      expect(promptApproval).toHaveBeenCalled()
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR is empty string', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = ''
-      mockInit.mockResolvedValue({ setup: vi.fn(), authorize: vi.fn(), getSecret: vi.fn() })
+      mockInit.mockResolvedValue(pendingVaultMock())
       await execCommand([
         '--secret',
         'my-key',
@@ -280,6 +319,7 @@ describe('execCommand', () => {
         'hello',
       ])
       expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      expect(promptApproval).toHaveBeenCalled()
     })
   })
 

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -101,9 +101,11 @@ export interface ExecResult {
 }
 
 // @public
-export class FetchError extends VaultError {
-    constructor(message: string, url: string);
-    readonly url: string;
+export interface ExecutableTrustStatus {
+    hash: string;
+    hashMismatch: boolean;
+    reason: string;
+    trusted: boolean;
 }
 
 // @public
@@ -133,11 +135,6 @@ export class InvalidAlgorithmError extends VaultError {
     constructor(message: string, algorithm: string, allowed: string[]);
     readonly algorithm: string;
     readonly allowed: string[];
-}
-
-// @public
-export class InvalidKeyMaterialError extends VaultError {
-    constructor(message: string);
 }
 
 // @public
@@ -320,10 +317,12 @@ export class VaultError extends Error {
 
 // @public
 export class VaultKeeper {
+    approveExecutable(executablePath: string): Promise<ExecutableTrustStatus>;
     authorize(jwe: string): Promise<{
         token: CapabilityToken;
         vaultResponse: VaultResponse;
     }>;
+    checkExecutableTrust(executablePath: string): Promise<ExecutableTrustStatus>;
     delete(name: string): Promise<void>;
     static doctor(options?: RunDoctorOptions): Promise<PreflightResult>;
     exec(token: CapabilityToken | SecretTokenMap, request: ExecRequest): Promise<{

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -102,6 +102,7 @@ export interface ExecResult {
 
 // @public
 export interface ExecutableTrustStatus {
+    approvedHashes: readonly string[];
     hash: string;
     hashMismatch: boolean;
     reason: string;

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -109,6 +109,12 @@ export interface ExecutableTrustStatus {
 }
 
 // @public
+export class FetchError extends VaultError {
+    constructor(message: string, url: string);
+    readonly url: string;
+}
+
+// @public
 export interface FetchRequest {
     body?: string | undefined;
     headers?: Record<string, string> | undefined;
@@ -135,6 +141,11 @@ export class InvalidAlgorithmError extends VaultError {
     constructor(message: string, algorithm: string, allowed: string[]);
     readonly algorithm: string;
     readonly allowed: string[];
+}
+
+// @public
+export class InvalidKeyMaterialError extends VaultError {
+    constructor(message: string);
 }
 
 // @public

--- a/packages/vaultkeeper/src/identity/trust.ts
+++ b/packages/vaultkeeper/src/identity/trust.ts
@@ -59,6 +59,7 @@ export async function verifyTrust(
     return {
       identity: { hash: 'dev', trustTier: 3, verified: false },
       tofuConflict: false,
+      approvedHashes: [],
       reason: 'Dev mode — hash verification skipped',
     }
   }
@@ -72,6 +73,9 @@ export async function verifyTrust(
   // Load the manifest for TOFU and registry checks.
   const manifest = await loadManifest(configDir)
 
+  // Hashes already approved for this namespace (empty on a first encounter).
+  const approvedHashes = manifest.get(namespace)?.hashes ?? []
+
   // --- Tier 1: Sigstore ---
   if (options?.skipSigstore !== true) {
     const sigstoreVerified = await trySigstore(execPath)
@@ -81,6 +85,7 @@ export async function verifyTrust(
       return {
         identity: { hash: currentHash, trustTier: 1, verified: true },
         tofuConflict: false,
+        approvedHashes,
         reason: 'Sigstore bundle verified',
       }
     }
@@ -91,6 +96,7 @@ export async function verifyTrust(
     return {
       identity: { hash: currentHash, trustTier: 2, verified: true },
       tofuConflict: false,
+      approvedHashes,
       reason: 'Hash found in trust manifest',
     }
   }
@@ -102,6 +108,7 @@ export async function verifyTrust(
     return {
       identity: { hash: currentHash, trustTier: 3, verified: false },
       tofuConflict: true,
+      approvedHashes,
       reason: `Hash changed from a previously approved value — re-approval required`,
     }
   }
@@ -112,6 +119,7 @@ export async function verifyTrust(
   return {
     identity: { hash: currentHash, trustTier: 3, verified: false },
     tofuConflict: false,
+    approvedHashes,
     reason: 'First encounter — hash recorded via TOFU',
   }
 }

--- a/packages/vaultkeeper/src/identity/types.ts
+++ b/packages/vaultkeeper/src/identity/types.ts
@@ -31,6 +31,13 @@ export interface TrustVerificationResult {
    * When true, the caller must prompt for re-approval before proceeding.
    */
   tofuConflict: boolean
+  /**
+   * Hashes already recorded in the trust manifest for this namespace at the
+   * time of verification, in approval order (empty on a first encounter). On a
+   * {@link TrustVerificationResult.tofuConflict}, these are the previously
+   * approved values that the current on-disk hash no longer matches.
+   */
+  approvedHashes: string[]
   /** Human-readable description of how trust was established. */
   reason: string
 }

--- a/packages/vaultkeeper/src/index.ts
+++ b/packages/vaultkeeper/src/index.ts
@@ -63,7 +63,12 @@ export { BackendRegistry, isListableBackend } from './backend/index.js'
 export { CapabilityToken } from './identity/index.js'
 
 export { VaultKeeper } from './vault.js'
-export type { VaultKeeperOptions, SetupOptions, SecretTokenMap } from './vault.js'
+export type {
+  VaultKeeperOptions,
+  SetupOptions,
+  SecretTokenMap,
+  ExecutableTrustStatus,
+} from './vault.js'
 
 export { runDoctor } from './doctor/runner.js'
 export type { RunDoctorOptions } from './doctor/runner.js'

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -117,6 +117,14 @@ export interface ExecutableTrustStatus {
    * conflicting executable is never trusted; callers must re-approve or deny.
    */
   hashMismatch: boolean
+  /**
+   * Hashes recorded as approved for this executable in the trust manifest, in
+   * approval order (empty when the executable has never been approved). When
+   * {@link ExecutableTrustStatus.hashMismatch} is `true`, these are the prior
+   * approved values that {@link ExecutableTrustStatus.hash} no longer matches;
+   * the last element is the most recently approved hash.
+   */
+  approvedHashes: readonly string[]
   /** Human-readable description of how trust was (or was not) established. */
   reason: string
 }
@@ -249,9 +257,12 @@ export class VaultKeeper {
         configDir: this.#configDir,
       })
       if (trustResult.tofuConflict) {
+        // On a conflict the manifest holds at least one prior approved hash;
+        // report the most recently approved one as the previous hash.
+        const previousHash = trustResult.approvedHashes.at(-1) ?? trustResult.identity.hash
         throw new IdentityMismatchError(
           'Executable hash changed — re-approval required',
-          'previously-approved',
+          previousHash,
           trustResult.identity.hash,
         )
       }
@@ -557,6 +568,7 @@ export class VaultKeeper {
       trusted: true,
       hash,
       hashMismatch: false,
+      approvedHashes: updated.get(resolved)?.hashes ?? [hash],
       reason: 'Hash recorded in trust manifest',
     }
   }
@@ -580,22 +592,24 @@ export class VaultKeeper {
     const resolved = path.resolve(executablePath)
     const hash = await VaultKeeper.#hashExecutableOrThrow(resolved)
     const manifest = await loadManifest(this.#configDir)
+    const approvedHashes = manifest.get(resolved)?.hashes ?? []
 
     if (isTrusted(manifest, resolved, hash)) {
       return {
         trusted: true,
         hash,
         hashMismatch: false,
+        approvedHashes,
         reason: 'Hash found in trust manifest',
       }
     }
 
-    const existing = manifest.get(resolved)
-    const hashMismatch = existing !== undefined && existing.hashes.length > 0
+    const hashMismatch = approvedHashes.length > 0
     return {
       trusted: false,
       hash,
       hashMismatch,
+      approvedHashes,
       reason: hashMismatch
         ? 'Executable hash changed from a previously approved value — re-approval required'
         : 'Executable not yet approved',

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -3,6 +3,7 @@
  */
 
 import * as crypto from 'node:crypto'
+import * as path from 'node:path'
 import type {
   VaultConfig,
   VaultClaims,
@@ -23,6 +24,8 @@ import { BackendRegistry } from './backend/registry.js'
 import type { SecretBackend } from './backend/types.js'
 import { createToken, decryptToken, extractKid, validateClaims, blockToken } from './jwe/index.js'
 import { verifyTrust } from './identity/trust.js'
+import { hashExecutable } from './identity/hash.js'
+import { loadManifest, saveManifest, addTrustedHash, isTrusted } from './identity/manifest.js'
 import {
   CapabilityToken,
   createCapabilityToken,
@@ -41,6 +44,7 @@ import {
   BackendUnavailableError,
   VaultError,
   KeyRevokedError,
+  FilesystemError,
 } from './errors.js'
 
 /**
@@ -87,6 +91,34 @@ export interface SetupOptions {
   trustTier?: TrustTier | undefined
   /** Backend type to use. */
   backendType?: string | undefined
+}
+
+/**
+ * Trust status of an executable, as recorded in the trust-on-first-use (TOFU)
+ * trust manifest.
+ *
+ * Returned by {@link VaultKeeper.approveExecutable} and
+ * {@link VaultKeeper.checkExecutableTrust}.
+ *
+ * @public
+ */
+export interface ExecutableTrustStatus {
+  /**
+   * Whether the executable's current hash is approved in the trust manifest.
+   * When `false`, callers must obtain approval (e.g. an interactive prompt)
+   * before granting secret access.
+   */
+  trusted: boolean
+  /** SHA-256 hex digest of the executable's current contents. */
+  hash: string
+  /**
+   * `true` when the executable is already known to the manifest but its
+   * current hash does not match any approved value — a TOFU conflict. A
+   * conflicting executable is never trusted; callers must re-approve or deny.
+   */
+  hashMismatch: boolean
+  /** Human-readable description of how trust was (or was not) established. */
+  reason: string
 }
 
 /** Usage tracking for tokens with use limits. */
@@ -490,9 +522,99 @@ export class VaultKeeper {
     await Promise.resolve()
   }
 
+  /**
+   * Approve an executable for trust-on-first-use by recording its current
+   * SHA-256 hash in the trust manifest.
+   *
+   * After approval, {@link VaultKeeper.setup} and
+   * {@link VaultKeeper.checkExecutableTrust} recognize the executable (matched
+   * by its resolved absolute path and content hash) as trusted, so callers can
+   * skip an interactive approval prompt.
+   *
+   * The operation is idempotent: approving the same, unchanged executable more
+   * than once leaves a single manifest entry.
+   *
+   * @param executablePath - Path to the executable to approve. Resolved to an
+   *   absolute path before hashing and recording.
+   * @returns The recorded trust status (always `trusted: true`).
+   * @throws {FilesystemError} If the executable does not exist or cannot be read.
+   * @public
+   */
+  async approveExecutable(executablePath: string): Promise<ExecutableTrustStatus> {
+    const resolved = path.resolve(executablePath)
+    const hash = await VaultKeeper.#hashExecutableOrThrow(resolved)
+    const manifest = await loadManifest(this.#configDir)
+    const updated = addTrustedHash(manifest, resolved, hash)
+    await saveManifest(this.#configDir, updated)
+    return {
+      trusted: true,
+      hash,
+      hashMismatch: false,
+      reason: 'Hash recorded in trust manifest',
+    }
+  }
+
+  /**
+   * Check whether an executable is trusted according to the trust manifest,
+   * without modifying the manifest.
+   *
+   * This is a read-only probe. Unlike {@link VaultKeeper.setup}, it never
+   * records a hash, so it can be used to decide whether an interactive approval
+   * prompt is required before proceeding.
+   *
+   * @param executablePath - Path to the executable to check. Resolved to an
+   *   absolute path before hashing and lookup.
+   * @returns The current trust status. `trusted` is `true` only when the
+   *   executable's current hash matches an approved manifest entry.
+   * @throws {FilesystemError} If the executable does not exist or cannot be read.
+   * @public
+   */
+  async checkExecutableTrust(executablePath: string): Promise<ExecutableTrustStatus> {
+    const resolved = path.resolve(executablePath)
+    const hash = await VaultKeeper.#hashExecutableOrThrow(resolved)
+    const manifest = await loadManifest(this.#configDir)
+
+    if (isTrusted(manifest, resolved, hash)) {
+      return {
+        trusted: true,
+        hash,
+        hashMismatch: false,
+        reason: 'Hash found in trust manifest',
+      }
+    }
+
+    const existing = manifest.get(resolved)
+    const hashMismatch = existing !== undefined && existing.hashes.length > 0
+    return {
+      trusted: false,
+      hash,
+      hashMismatch,
+      reason: hashMismatch
+        ? 'Executable hash changed from a previously approved value — re-approval required'
+        : 'Executable not yet approved',
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Private helpers
   // ---------------------------------------------------------------------------
+
+  /**
+   * Hash the file at `resolvedPath`, converting any read failure (e.g. a
+   * missing file) into a typed {@link FilesystemError} that names the path.
+   */
+  static async #hashExecutableOrThrow(resolvedPath: string): Promise<string> {
+    try {
+      return await hashExecutable(resolvedPath)
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      throw new FilesystemError(
+        `Cannot read executable at ${resolvedPath}: ${detail}`,
+        resolvedPath,
+        'read',
+      )
+    }
+  }
 
   static #resolveSecrets(token: CapabilityToken | SecretTokenMap): string | Record<string, string> {
     if (token instanceof CapabilityToken) {

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -150,6 +150,12 @@ export class VaultKeeper {
   /**
    * Initialize a new VaultKeeper instance.
    * Runs doctor checks (unless skipped), loads config, and sets up the key manager.
+   *
+   * The configured secret backend is resolved lazily on first use, not during
+   * `init()`. Trust-only operations (e.g. {@link VaultKeeper.approveExecutable},
+   * {@link VaultKeeper.checkExecutableTrust}) therefore succeed even when the
+   * configured backend or plugin is unavailable or unregistered; a
+   * misconfigured backend surfaces only when a secret operation is invoked.
    */
   static async init(options?: VaultKeeperOptions): Promise<VaultKeeper> {
     const configDir = options?.configDir ?? getDefaultConfigDir()
@@ -165,10 +171,7 @@ export class VaultKeeper {
     const keyManager = new KeyManager()
     await keyManager.init()
 
-    const vault = new VaultKeeper(config, keyManager, configDir)
-    vault.#backend = vault.#resolveBackend()
-
-    return vault
+    return new VaultKeeper(config, keyManager, configDir)
   }
 
   /**
@@ -238,7 +241,11 @@ export class VaultKeeper {
     if (executablePath === 'dev' || this.#isDevModeExecutable(executablePath)) {
       exeIdentity = 'dev'
     } else {
-      const trustResult = await verifyTrust(executablePath, {
+      // Resolve to an absolute path before verification so the manifest is
+      // keyed consistently with approveExecutable() and checkExecutableTrust(),
+      // both of which resolve. A relative path approved earlier (stored under
+      // its absolute key) therefore matches here too.
+      const trustResult = await verifyTrust(path.resolve(executablePath), {
         configDir: this.#configDir,
       })
       if (trustResult.tofuConflict) {
@@ -657,9 +664,10 @@ export class VaultKeeper {
   }
 
   #requireBackend(): SecretBackend {
-    if (this.#backend === undefined) {
-      throw new VaultError('VaultKeeper backend not initialized')
-    }
+    // Resolve the configured backend lazily on first use so that trust-only
+    // operations never require a healthy/registered backend. #resolveBackend()
+    // throws BackendUnavailableError if none is enabled or it cannot be built.
+    this.#backend ??= this.#resolveBackend()
     return this.#backend
   }
 

--- a/packages/vaultkeeper/test/integration/vault-trust.test.ts
+++ b/packages/vaultkeeper/test/integration/vault-trust.test.ts
@@ -94,9 +94,10 @@ describe('VaultKeeper.approveExecutable', () => {
 
     expect(status.trusted).toBe(true)
     expect(status.hash).toBe(expectedHash)
+    expect(status.approvedHashes).toEqual([expectedHash])
 
-    const entries = readManifestEntries()
-    const entry = (await entries)[path.resolve(exe)]
+    const entries = await readManifestEntries()
+    const entry = entries[path.resolve(exe)]
     expect(entry).toEqual({ hashes: [expectedHash], trustTier: 3 })
   })
 
@@ -134,6 +135,7 @@ describe('VaultKeeper.checkExecutableTrust', () => {
     const status = await vault.checkExecutableTrust(exe)
     expect(status.trusted).toBe(true)
     expect(status.hashMismatch).toBe(false)
+    expect(status.approvedHashes).toEqual([sha256Hex('binary-bytes\n')])
   })
 
   it('reports untrusted for an executable that was never approved', async () => {
@@ -143,6 +145,7 @@ describe('VaultKeeper.checkExecutableTrust', () => {
     const status = await vault.checkExecutableTrust(exe)
     expect(status.trusted).toBe(false)
     expect(status.hashMismatch).toBe(false)
+    expect(status.approvedHashes).toEqual([])
   })
 
   // Criterion 5: a changed hash is untrusted and flagged as a mismatch —
@@ -158,6 +161,8 @@ describe('VaultKeeper.checkExecutableTrust', () => {
     expect(status.trusted).toBe(false)
     expect(status.hashMismatch).toBe(true)
     expect(status.hash).toBe(sha256Hex('tampered\n'))
+    // The prior approved hash is surfaced so callers can report it accurately.
+    expect(status.approvedHashes).toEqual([sha256Hex('original\n')])
   })
 
   it('does not modify the manifest (read-only probe)', async () => {
@@ -201,6 +206,33 @@ describe('exec approval recording (setup) → subsequent trust', () => {
     await expect(vault.setup('API_KEY', { executablePath: caller })).rejects.toBeInstanceOf(
       IdentityMismatchError,
     )
+  })
+
+  // Regression for review threads 3582262153 / 3582262187: the thrown error must
+  // carry the REAL hashes — previousHash = the manifest-recorded approved hash,
+  // currentHash = the on-disk hash — not a placeholder string.
+  it('setup populates IdentityMismatchError with the real previous and current hashes', async () => {
+    await backend.store('API_KEY', 's3cr3t')
+    const caller = await writeExecutable('caller', 'v1\n')
+    const approvedHash = sha256Hex('v1\n')
+    const vault = await createVault()
+
+    await vault.setup('API_KEY', { executablePath: caller })
+    await fs.writeFile(caller, 'v2\n', { mode: 0o755 })
+    const changedHash = sha256Hex('v2\n')
+
+    const err = await vault.setup('API_KEY', { executablePath: caller }).then(
+      () => {
+        throw new Error('expected setup to reject')
+      },
+      (e: unknown) => e,
+    )
+
+    expect(err).toBeInstanceOf(IdentityMismatchError)
+    if (!(err instanceof IdentityMismatchError)) throw new Error('unreachable')
+    expect(err.previousHash).toBe(approvedHash)
+    expect(err.currentHash).toBe(changedHash)
+    expect(err.previousHash).not.toBe('previously-approved')
   })
 
   // Regression for review thread 3582165425: setup() must resolve its

--- a/packages/vaultkeeper/test/integration/vault-trust.test.ts
+++ b/packages/vaultkeeper/test/integration/vault-trust.test.ts
@@ -25,6 +25,7 @@ import {
   BackendRegistry,
   IdentityMismatchError,
   FilesystemError,
+  BackendUnavailableError,
 } from '../../src/index.js'
 import type { VaultConfig, SecretBackend } from '../../src/index.js'
 import { createInMemoryBackend } from '../helpers/backend.js'
@@ -200,5 +201,69 @@ describe('exec approval recording (setup) → subsequent trust', () => {
     await expect(vault.setup('API_KEY', { executablePath: caller })).rejects.toBeInstanceOf(
       IdentityMismatchError,
     )
+  })
+
+  // Regression for review thread 3582165425: setup() must resolve its
+  // executablePath to an absolute path before consulting the manifest, exactly
+  // as approveExecutable() and checkExecutableTrust() do. Otherwise a caller
+  // approved under its absolute key would not match when setup() is handed a
+  // non-normalized (or relative) path referring to the same file.
+  it('setup matches an approved executable given a non-normalized path (no duplicate entry)', async () => {
+    await backend.store('API_KEY', 's3cr3t')
+    const exe = await writeExecutable('caller', 'caller-bytes\n')
+    const vault = await createVault()
+
+    // Approve under the canonical absolute path.
+    await vault.approveExecutable(exe)
+
+    // A non-normalized path (redundant "/./" segment) that resolves to the same
+    // file but whose raw string differs from the manifest key.
+    const rawWithDot = `${scratchDir}/./caller`
+    expect(rawWithDot).not.toBe(path.resolve(exe))
+
+    await vault.setup('API_KEY', { executablePath: rawWithDot })
+
+    // The manifest still holds a single entry keyed by the resolved path — no
+    // duplicate was TOFU-recorded under the raw key.
+    const entries = await readManifestEntries()
+    expect(Object.keys(entries)).toEqual([path.resolve(exe)])
+    // And the executable remains trusted (matched, not recorded anew).
+    expect((await vault.checkExecutableTrust(exe)).trusted).toBe(true)
+  })
+})
+
+describe('trust-only operations without a healthy backend (review thread 3582165455)', () => {
+  const UNAVAILABLE_CONFIG: VaultConfig = {
+    version: 1,
+    // A backend type that is never registered — resolving it would throw.
+    backends: [{ type: 'not-registered', enabled: true }],
+    keyRotation: { gracePeriodDays: 1 },
+    defaults: { ttlMinutes: 5, trustTier: 3 },
+  }
+
+  // approve only needs the config dir + trust manifest, so it must succeed even
+  // when the configured backend cannot be resolved (unavailable/unregistered).
+  it('approveExecutable succeeds even when the configured backend is unregistered', async () => {
+    const exe = await writeExecutable('deploy.sh', '#!/bin/sh\necho hi\n')
+    const vault = await VaultKeeper.init({
+      skipDoctor: true,
+      config: UNAVAILABLE_CONFIG,
+      configDir,
+    })
+
+    const status = await vault.approveExecutable(exe)
+    expect(status.trusted).toBe(true)
+  })
+
+  // A secret operation still surfaces the backend problem — resolution is
+  // deferred, not skipped.
+  it('a secret operation still surfaces BackendUnavailableError', async () => {
+    const vault = await VaultKeeper.init({
+      skipDoctor: true,
+      config: UNAVAILABLE_CONFIG,
+      configDir,
+    })
+
+    await expect(vault.store('API_KEY', 'x')).rejects.toBeInstanceOf(BackendUnavailableError)
   })
 })

--- a/packages/vaultkeeper/test/integration/vault-trust.test.ts
+++ b/packages/vaultkeeper/test/integration/vault-trust.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Integration tests for VaultKeeper's TOFU trust API:
+ * {@link VaultKeeper.approveExecutable} and {@link VaultKeeper.checkExecutableTrust},
+ * plus the recording side effect of {@link VaultKeeper.setup} that an
+ * interactive `exec` approval relies on.
+ *
+ * These exercise the real trust-manifest read/write path (temp config dir) and
+ * the real SHA-256 hashing of on-disk files. Secrets come from an in-memory
+ * backend so no OS credential store is touched.
+ *
+ * Trust manifest format and hashing: SHA-256 hex digest of the file's bytes,
+ * keyed by the executable's resolved absolute path.
+ *
+ * @see ../../src/identity/manifest.ts
+ * @see https://github.com/mike-north/vaultkeeper/issues/57
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import {
+  VaultKeeper,
+  BackendRegistry,
+  IdentityMismatchError,
+  FilesystemError,
+} from '../../src/index.js'
+import type { VaultConfig, SecretBackend } from '../../src/index.js'
+import { createInMemoryBackend } from '../helpers/backend.js'
+
+const TEST_CONFIG: VaultConfig = {
+  version: 1,
+  backends: [{ type: 'memory', enabled: true }],
+  keyRotation: { gracePeriodDays: 1 },
+  defaults: { ttlMinutes: 5, trustTier: 3 },
+}
+
+/** Independent SHA-256 reference (the spec) — not the implementation under test. */
+function sha256Hex(bytes: string): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex')
+}
+
+let backend: SecretBackend
+let configDir: string
+let scratchDir: string
+
+beforeEach(async () => {
+  backend = createInMemoryBackend()
+  BackendRegistry.register('memory', () => backend)
+  configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-trust-cfg-'))
+  scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-trust-exe-'))
+})
+
+afterEach(async () => {
+  await fs.rm(configDir, { recursive: true, force: true })
+  await fs.rm(scratchDir, { recursive: true, force: true })
+})
+
+async function createVault(): Promise<VaultKeeper> {
+  return VaultKeeper.init({ skipDoctor: true, config: TEST_CONFIG, configDir })
+}
+
+async function writeExecutable(name: string, contents: string): Promise<string> {
+  const p = path.join(scratchDir, name)
+  await fs.writeFile(p, contents, { mode: 0o755 })
+  return p
+}
+
+async function readManifestEntries(): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(path.join(configDir, 'trust-manifest.json'), 'utf8')
+  const parsed: unknown = JSON.parse(raw)
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'entries' in parsed &&
+    typeof parsed.entries === 'object' &&
+    parsed.entries !== null
+  ) {
+    return { ...parsed.entries }
+  }
+  throw new Error('manifest has no entries object')
+}
+
+describe('VaultKeeper.approveExecutable', () => {
+  // Criterion 1: approve computes SHA-256 and writes a manifest entry.
+  it('records the executable SHA-256 in the trust manifest', async () => {
+    const exe = await writeExecutable('deploy.sh', '#!/bin/sh\necho hi\n')
+    const expectedHash = sha256Hex('#!/bin/sh\necho hi\n')
+
+    const vault = await createVault()
+    const status = await vault.approveExecutable(exe)
+
+    expect(status.trusted).toBe(true)
+    expect(status.hash).toBe(expectedHash)
+
+    const entries = readManifestEntries()
+    const entry = (await entries)[path.resolve(exe)]
+    expect(entry).toEqual({ hashes: [expectedHash], trustTier: 3 })
+  })
+
+  // Criterion 1: running approve twice is idempotent — one entry, one hash.
+  it('is idempotent when approving the same unchanged executable twice', async () => {
+    const exe = await writeExecutable('deploy.sh', 'payload\n')
+    const expectedHash = sha256Hex('payload\n')
+
+    const vault = await createVault()
+    await vault.approveExecutable(exe)
+    await vault.approveExecutable(exe)
+
+    const entries = await readManifestEntries()
+    expect(Object.keys(entries)).toEqual([path.resolve(exe)])
+    expect(entries[path.resolve(exe)]).toEqual({ hashes: [expectedHash], trustTier: 3 })
+  })
+
+  // Criterion 2: approving a nonexistent path throws, naming the path.
+  it('throws a FilesystemError naming the missing path', async () => {
+    const missing = path.join(scratchDir, 'does-not-exist.sh')
+    const vault = await createVault()
+
+    await expect(vault.approveExecutable(missing)).rejects.toBeInstanceOf(FilesystemError)
+    await expect(vault.approveExecutable(missing)).rejects.toThrow(path.resolve(missing))
+  })
+})
+
+describe('VaultKeeper.checkExecutableTrust', () => {
+  // Criterion 3: after approve, the executable resolves to a trusted state.
+  it('reports trusted after the executable was approved', async () => {
+    const exe = await writeExecutable('tool', 'binary-bytes\n')
+    const vault = await createVault()
+    await vault.approveExecutable(exe)
+
+    const status = await vault.checkExecutableTrust(exe)
+    expect(status.trusted).toBe(true)
+    expect(status.hashMismatch).toBe(false)
+  })
+
+  it('reports untrusted for an executable that was never approved', async () => {
+    const exe = await writeExecutable('tool', 'binary-bytes\n')
+    const vault = await createVault()
+
+    const status = await vault.checkExecutableTrust(exe)
+    expect(status.trusted).toBe(false)
+    expect(status.hashMismatch).toBe(false)
+  })
+
+  // Criterion 5: a changed hash is untrusted and flagged as a mismatch —
+  // trust is never silently inherited by a modified executable.
+  it('reports a hash mismatch when the executable changed after approval', async () => {
+    const exe = await writeExecutable('tool', 'original\n')
+    const vault = await createVault()
+    await vault.approveExecutable(exe)
+
+    await fs.writeFile(exe, 'tampered\n', { mode: 0o755 })
+
+    const status = await vault.checkExecutableTrust(exe)
+    expect(status.trusted).toBe(false)
+    expect(status.hashMismatch).toBe(true)
+    expect(status.hash).toBe(sha256Hex('tampered\n'))
+  })
+
+  it('does not modify the manifest (read-only probe)', async () => {
+    const exe = await writeExecutable('tool', 'bytes\n')
+    const vault = await createVault()
+
+    await vault.checkExecutableTrust(exe)
+    await expect(fs.readFile(path.join(configDir, 'trust-manifest.json'), 'utf8')).rejects.toThrow()
+  })
+})
+
+describe('exec approval recording (setup) → subsequent trust', () => {
+  // Criterion 4: an interactive exec approval records the hash via setup(),
+  // so a subsequent check is trusted (no re-prompt needed).
+  it('setup records the caller hash, making a later check trusted', async () => {
+    await backend.store('API_KEY', 's3cr3t')
+    const caller = await writeExecutable('caller', 'caller-bytes\n')
+    const vault = await createVault()
+
+    // Before approval the caller is untrusted.
+    expect((await vault.checkExecutableTrust(caller)).trusted).toBe(false)
+
+    // setup() is what `exec` runs after the user answers "y" — it records the
+    // caller hash via TOFU.
+    await vault.setup('API_KEY', { executablePath: caller })
+
+    // A subsequent invocation now sees the caller as trusted.
+    expect((await vault.checkExecutableTrust(caller)).trusted).toBe(true)
+  })
+
+  // Criterion 5: setup() rejects a caller whose hash changed after recording,
+  // matching the existing identity-mismatch behavior.
+  it('setup throws IdentityMismatchError when the caller hash changed', async () => {
+    await backend.store('API_KEY', 's3cr3t')
+    const caller = await writeExecutable('caller', 'v1\n')
+    const vault = await createVault()
+
+    await vault.setup('API_KEY', { executablePath: caller })
+    await fs.writeFile(caller, 'v2\n', { mode: 0o755 })
+
+    await expect(vault.setup('API_KEY', { executablePath: caller })).rejects.toBeInstanceOf(
+      IdentityMismatchError,
+    )
+  })
+})

--- a/packages/vaultkeeper/test/unit/identity/trust.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/trust.test.ts
@@ -52,7 +52,11 @@ describe('verifyTrust — Tier 3 (first encounter / TOFU)', () => {
     await withTempDir(async (dir) => {
       const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')
       const configDir = path.join(dir, 'config')
-      const result = await verifyTrust(execPath, { configDir, namespace: 'my-tool', skipSigstore: true })
+      const result = await verifyTrust(execPath, {
+        configDir,
+        namespace: 'my-tool',
+        skipSigstore: true,
+      })
 
       expect(result.identity.trustTier).toBe(3)
       expect(result.identity.verified).toBe(false)
@@ -75,7 +79,11 @@ describe('verifyTrust — Tier 2 (registry / manifest)', () => {
       await verifyTrust(execPath, { configDir, namespace: 'trusted-tool', skipSigstore: true })
 
       // Second call: hash is now known
-      const result = await verifyTrust(execPath, { configDir, namespace: 'trusted-tool', skipSigstore: true })
+      const result = await verifyTrust(execPath, {
+        configDir,
+        namespace: 'trusted-tool',
+        skipSigstore: true,
+      })
       expect(result.identity.trustTier).toBe(2)
       expect(result.identity.verified).toBe(true)
       expect(result.tofuConflict).toBe(false)
@@ -91,16 +99,28 @@ describe('verifyTrust — TOFU conflict', () => {
       const configDir = path.join(dir, 'config')
 
       // Record v1 hash
-      await verifyTrust(execPath, { configDir, namespace: 'changing-tool', skipSigstore: true })
+      const first = await verifyTrust(execPath, {
+        configDir,
+        namespace: 'changing-tool',
+        skipSigstore: true,
+      })
+      const v1Hash = first.identity.hash
 
       // Overwrite with different content (simulating a binary update or tampering)
       await fs.writeFile(execPath, 'version-2', 'utf8')
 
-      const result = await verifyTrust(execPath, { configDir, namespace: 'changing-tool', skipSigstore: true })
+      const result = await verifyTrust(execPath, {
+        configDir,
+        namespace: 'changing-tool',
+        skipSigstore: true,
+      })
       expect(result.tofuConflict).toBe(true)
       expect(result.identity.trustTier).toBe(3)
       expect(result.identity.verified).toBe(false)
       expect(result.reason).toContain('re-approval')
+      // The conflict surfaces the previously approved hash(es), not a placeholder.
+      expect(result.approvedHashes).toEqual([v1Hash])
+      expect(result.identity.hash).not.toBe(v1Hash)
     })
   })
 
@@ -110,7 +130,11 @@ describe('verifyTrust — TOFU conflict', () => {
       const configDir = path.join(dir, 'config')
 
       // Record original
-      const first = await verifyTrust(execPath, { configDir, namespace: 'tampered', skipSigstore: true })
+      const first = await verifyTrust(execPath, {
+        configDir,
+        namespace: 'tampered',
+        skipSigstore: true,
+      })
       const originalHash = first.identity.hash
 
       // Change binary
@@ -159,7 +183,11 @@ describe('verifyTrust — Sigstore skipping', () => {
       const configDir = path.join(dir, 'config')
 
       // Should not throw even if sigstore is unavailable
-      const result = await verifyTrust(execPath, { configDir, namespace: 'sig-skip', skipSigstore: true })
+      const result = await verifyTrust(execPath, {
+        configDir,
+        namespace: 'sig-skip',
+        skipSigstore: true,
+      })
       // Result should be tier 3 (TOFU first use) since we skipped Sigstore
       expect(result.identity.trustTier).toBe(3)
     })


### PR DESCRIPTION
## Summary

The Node CLI's trust-on-first-use (TOFU) model was a functional no-op: `approve --script` wrote nothing to disk, and `exec` never consulted the trust manifest, so every invocation re-showed `Trust: Pending verification` and re-prompted. This makes both real:

- **`approve --script <path>`** now hashes the target (SHA-256) and writes/updates a trust-manifest entry idempotently; a missing path exits non-zero with an error naming the path.
- **`exec`** now consults the manifest before prompting. A caller whose current hash is already approved runs **without** an interactive prompt and reports a verified trust state; a modified or unapproved caller is treated as untrusted (falls through to the prompt / identity-mismatch behavior — never silently trusted).

The Rust CLI (which already hashes and writes the manifest on `approve`) is the behavioral reference; no Rust code was changed. The Node flag name `--script` is preserved.

### Library API

Two `@public` methods on `VaultKeeper` back the CLI behavior, plus a supporting type:

- `approveExecutable(path)` — hash + record in the manifest (idempotent).
- `checkExecutableTrust(path)` — read-only trust probe (no manifest writes).
- `ExecutableTrustStatus` — `{ trusted, hash, hashMismatch, reason }`.

These live on `VaultKeeper` (the policy orchestrator, which already owns the config dir and consults `verifyTrust` during `setup()`) rather than as loose exports, keeping the trust surface in one semantic home. API report regenerated.

## Acceptance criteria → tests

| # | Criterion | Test |
|---|-----------|------|
| 1 | `approve` computes SHA-256, writes/updates manifest; twice is idempotent | `packages/cli-tests/test/e2e/approve.test.ts` — "writes the script SHA-256 into trust-manifest.json", "is idempotent across repeated approvals"; `packages/vaultkeeper/test/integration/vault-trust.test.ts` — "records the executable SHA-256…", "is idempotent…" |
| 2 | `approve <nonexistent>` exits non-zero, names the path | `approve.test.ts` — "exits non-zero and names the missing path"; `vault-trust.test.ts` — "throws a FilesystemError naming the missing path"; `packages/cli/test/unit/commands/approve.test.ts` — "exits 1 and names the missing path" |
| 3 | After `approve`, `exec` does not prompt and reports a trusted state | `packages/cli-tests/test/e2e/exec.test.ts` — "does not prompt for an approved caller and injects the secret" (real subprocess, non-TTY stdin); `vault-trust.test.ts` — "reports trusted after the executable was approved" |
| 4 | After interactive `exec` approval, subsequent `exec` with same caller does not re-prompt | `vault-trust.test.ts` — "setup records the caller hash, making a later check trusted" (exercises the exact `setup()` recording path an interactive approval runs); `exec.test.ts` — "does not re-prompt on subsequent invocations of the same caller" |
| 5 | Hash mismatch → untrusted (prompt/deny), never silent trust | `exec.test.ts` — "treats a modified caller as untrusted (no silent trust inheritance)"; `vault-trust.test.ts` — "reports a hash mismatch when the executable changed after approval", "setup throws IdentityMismatchError when the caller hash changed" |
| 6 | `approve --help` / runtime output describe the real behavior | `approve.test.ts` unit — "describes the TOFU manifest behavior accurately"; help text + README example updated (`--script`) |
| 7 | Regression tests cover approve→exec, exec-approve→exec, hash-mismatch, and manifest writing; integration tests use the real CLI contract (subprocess + stdin) | `exec.test.ts` and `approve.test.ts` spawn the real CLI with piped stdin |

### Note on the interactive-approval proof

`promptApproval` requires a TTY, and Node has no built-in PTY. Rather than add a fragile native `node-pty` dependency (its spawn-helper failed to fork in this environment), criterion 4's interactive-approval half is proven at the library layer against the **exact** `setup()` code path an interactive `exec` runs (record hash → subsequent check trusted), while the subprocess tests prove the trusted-skip and untrusted-prompt CLI contracts on real non-TTY stdin. The critical fix — the TTY gate now honors trusted callers — is what makes the subprocess approve→exec proof possible.

## CLI output changes

### `vaultkeeper approve --help`

```diff
-Pre-record a script hash in the TOFU manifest so the first
-invocation via vaultkeeper exec does not prompt for trust.
+Record a script hash in the TOFU trust manifest so that invoking it via
+vaultkeeper exec does not prompt for trust. Running this on an already
+approved, unchanged script is idempotent.
```

### `vaultkeeper approve --script <path>` (success)

```diff
-Script approved: /abs/path
-The script hash will be recorded on first use with vaultkeeper exec.
+Approved /abs/path (hash: <sha256>)
```

### `vaultkeeper exec` (approved caller)

```diff
+Trust: verified (hash matches trust manifest)
```

Refs #57
