### PR TITLE
Fix published .d.ts failing to typecheck Buffer in strict consumers

### DIFF
--- a/.changeset/dts-node-buffer-types.md
+++ b/.changeset/dts-node-buffer-types.md
@@ -1,0 +1,5 @@
+---
+'vaultkeeper': patch
+---
+
+Fix the published `.d.ts` failing to typecheck in strict consumer projects that scope `compilerOptions.types` explicitly (`TS2591: Cannot find name 'Buffer'`). `SecretAccessor.read()`, `SignRequest.data`, and `VerifyRequest.data` now resolve `Buffer` via a real `node:buffer` import plus a `/// <reference types="node" />` directive in the published rollup, instead of relying on the ambient global. `@types/node` is now declared as an optional peer dependency.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ vaultkeeper --help
 pnpm add vaultkeeper
 ```
 
+`vaultkeeper`'s public API references Node's `Buffer` type (e.g. `SecretAccessor.read()`, `SignRequest`, `VerifyRequest`). Consuming projects need `@types/node` installed to typecheck against it — `@types/node` is declared as an optional peer dependency, so most setups already have it as a transitive `devDependency`. If your tsconfig scopes `compilerOptions.types` explicitly (e.g. `"types": []`), add it yourself:
+
+```sh
+pnpm add -D @types/node
+```
+
 ### WASM SDK
 
 The WASM SDK wraps the Rust core compiled to WebAssembly. It offers a similar high-level feature set to the TypeScript library, but the public API is not a drop-in replacement — some function signatures differ (e.g., `setup(secretName, secretValue, ...)` vs the TS library's `setup(secretName, options?)`).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ vaultkeeper --help
 pnpm add vaultkeeper
 ```
 
-`vaultkeeper`'s public API references Node's `Buffer` type (e.g. `SecretAccessor.read()`, `SignRequest`, `VerifyRequest`). Consuming projects need `@types/node` installed to typecheck against it — `@types/node` is declared as an optional peer dependency, so most setups already have it as a transitive `devDependency`. If your tsconfig scopes `compilerOptions.types` explicitly (e.g. `"types": []`), add it yourself:
+`vaultkeeper`'s public API references Node's `Buffer` type (e.g. `SecretAccessor.read()`, `SignRequest`, `VerifyRequest`). Install `@types/node` as a devDependency so your project typechecks against it — it's declared as an optional peer dependency, but npm/pnpm/yarn do not install optional peers automatically, so you need to add it yourself:
 
 ```sh
 pnpm add -D @types/node

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -62,7 +62,7 @@ export default tseslint.config(
       '**/coverage/**',
       '**/tsup.config.ts',
       '**/vitest.config.ts',
-      '**/scripts/**',
+      'packages/vaultkeeper/scripts/**',
       'vitest.workspace.ts',
       'eslint.config.ts',
       'prettier.config.js',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -62,6 +62,7 @@ export default tseslint.config(
       '**/coverage/**',
       '**/tsup.config.ts',
       '**/vitest.config.ts',
+      '**/scripts/**',
       'vitest.workspace.ts',
       'eslint.config.ts',
       'prettier.config.js',

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -4,6 +4,10 @@
 
 ```ts
 
+/// <reference types="node" />
+
+import { Buffer as Buffer_2 } from 'node:buffer';
+
 // @public
 export class AccessorConsumedError extends VaultError {
     constructor(message: string);
@@ -190,7 +194,7 @@ export interface RunDoctorOptions {
 
 // @public
 export interface SecretAccessor {
-    read(callback: (buf: Buffer) => void): void;
+    read(callback: (buf: Buffer_2) => void): void;
 }
 
 // @public
@@ -248,7 +252,7 @@ export interface SetupResult {
 // @public
 export interface SignRequest {
     algorithm?: string | undefined;
-    data: string | Buffer;
+    data: string | Buffer_2;
 }
 
 // @public
@@ -343,7 +347,7 @@ export interface VaultResponse {
 // @public
 export interface VerifyRequest {
     algorithm?: string | undefined;
-    data: string | Buffer;
+    data: string | Buffer_2;
     publicKey: string;
     signature: string;
 }

--- a/packages/vaultkeeper/package.json
+++ b/packages/vaultkeeper/package.json
@@ -25,7 +25,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/inject-node-types-reference.mjs",
     "clean": "node -e \"import('node:fs').then(fs=>fs.rmSync('dist',{recursive:true,force:true}))\"",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -44,6 +44,14 @@
   "dependencies": {
     "@1password/sdk": "^0.4.0",
     "jose": "^6.0.0"
+  },
+  "peerDependencies": {
+    "@types/node": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "@types/node": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@microsoft/api-documenter": "^7.0.0",

--- a/packages/vaultkeeper/package.json
+++ b/packages/vaultkeeper/package.json
@@ -46,7 +46,7 @@
     "jose": "^6.0.0"
   },
   "peerDependencies": {
-    "@types/node": ">=18"
+    "@types/node": ">=20"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/packages/vaultkeeper/scripts/inject-node-types-reference.mjs
+++ b/packages/vaultkeeper/scripts/inject-node-types-reference.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * Prepends `/// <reference types="node" />` to the built declaration
+ * rollups.
+ *
+ * The published `.d.ts`/`.d.cts` reference `Buffer`. tsup's declaration
+ * bundler (rollup-plugin-dts) already turns the source's
+ * `import type { Buffer } from 'node:buffer'` into a real import in the
+ * rollup, which resolves for consumers whose tsconfig auto-includes
+ * `@types/node` (the common case).
+ *
+ * Consumers who scope `compilerOptions.types` explicitly (e.g. `types: []`,
+ * common in strict monorepo boilerplates) do not auto-include
+ * `@types/node`'s ambient module declarations — which also back its
+ * `node:buffer` module shim — so even the real import fails to resolve
+ * there. This reference directive forces `@types/node` into the consumer's
+ * program regardless of their `types` scoping. It has to be reinjected here
+ * because rollup-plugin-dts strips triple-slash directives from source
+ * during bundling.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/72
+ */
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REFERENCE_DIRECTIVE = '/// <reference types="node" />\n'
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+const distFiles = ['dist/index.d.ts', 'dist/index.d.cts'].map((relative) =>
+  join(packageRoot, relative),
+)
+
+for (const distFile of distFiles) {
+  const contents = await readFile(distFile, 'utf8')
+  if (contents.startsWith(REFERENCE_DIRECTIVE)) continue
+  await writeFile(distFile, REFERENCE_DIRECTIVE + contents)
+}

--- a/packages/vaultkeeper/src/types.ts
+++ b/packages/vaultkeeper/src/types.ts
@@ -2,6 +2,8 @@
  * Shared types and interfaces for vaultkeeper.
  */
 
+import type { Buffer } from 'node:buffer'
+
 /** Trust tier for executable identity verification. */
 export type TrustTier = 1 | 2 | 3
 

--- a/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
+++ b/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
@@ -93,8 +93,8 @@ describe('published .d.ts typechecks Buffer-typed API in strict consumers (issue
     project.linkDependency('vaultkeeper', { target: vaultkeeperRoot })
 
     // Link the monorepo's own typescript and @types/node so the consumer
-    // project typechecks with the same compiler/lib versions as CI, without
-    // a network install.
+    // project typechecks with the same compiler/lib versions as CI,
+    // without a network install.
     const typescriptRoot = dirname(require.resolve('typescript/package.json'))
     project.linkDependency('typescript', { target: typescriptRoot })
 
@@ -105,11 +105,15 @@ describe('published .d.ts typechecks Buffer-typed API in strict consumers (issue
 
     const tscBin = resolve(typescriptRoot, 'bin', 'tsc')
 
+    // A real tsc invocation (loading the compiler, @types/node's lib
+    // files, and the vaultkeeper rollup) is slow on CI runners relative
+    // to vitest's 5s default test timeout, so both the test and the
+    // child process get a generous budget here.
     await expect(
       execFileAsync('node', [tscBin, '--noEmit'], {
         cwd: project.baseDir,
-        timeout: 30_000,
+        timeout: 90_000,
       }),
     ).resolves.toBeDefined()
-  })
+  }, 120_000)
 })

--- a/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
+++ b/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
@@ -59,8 +59,10 @@ describe('published .d.ts typechecks Buffer-typed API in strict consumers (issue
           skipLibCheck: false,
           noEmit: true,
           // Deliberately scopes ambient globals to none, as many strict
-          // monorepo tsconfigs do. This is the exact reproduction from
-          // issue #72: `@types/node` is installed (linked below) but not
+          // monorepo tsconfigs do. This is the reliably reproducible
+          // trigger verified for issue #72 (the issue's literal "no types
+          // array" setup doesn't reproduce on TS 5.9; explicit types: []
+          // does): `@types/node` is installed (linked below) but not
           // auto-included, so the published `.d.ts` must resolve `Buffer`
           // via a real import rather than relying on the ambient global.
           types: [],

--- a/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
+++ b/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
@@ -1,0 +1,115 @@
+/**
+ * End-to-end test verifying that the published `.d.ts` typechecks in a
+ * standard strict consumer project — without the consumer adding an
+ * explicit `"types": ["node"]` override to their tsconfig.
+ *
+ * `SecretAccessor.read()`, `SignRequest.data`, and `VerifyRequest.data`
+ * reference `Buffer`. Before the fix, the rollup relied on the ambient
+ * global `Buffer` type. Confirmed against a real `npm pack` + `npm install`
+ * consumer (not just this fixture harness): with a strict NodeNext tsconfig
+ * that sets `"types": []` — the common pattern in monorepo boilerplates that
+ * scope ambient globals explicitly rather than auto-including every
+ * `@types/*` package — the pre-fix rollup fails with `TS2591: Cannot find
+ * name 'Buffer'` even though `@types/node` is installed, and adding
+ * `"node"` to `types` (the documented workaround) or applying this fix both
+ * resolve it. This test packs the real published shape (via a linked
+ * build, not source-internal module resolution) and typechecks a consumer
+ * file against it under that same `"types": []` condition.
+ *
+ * Uses `fixturify-project` to create an isolated consumer project outside
+ * the monorepo, matching the pattern in `backend-registration.test.ts`.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/72
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { Project } from 'fixturify-project'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { createRequire } from 'node:module'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const execFileAsync = promisify(execFile)
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const require = createRequire(import.meta.url)
+
+describe('published .d.ts typechecks Buffer-typed API in strict consumers (issue #72)', () => {
+  let project: Project | undefined
+
+  afterEach(() => {
+    project?.dispose()
+    project = undefined
+  })
+
+  it('should typecheck when the consumer scopes ambient globals with "types": []', async () => {
+    project = new Project('vaultkeeper-dts-consumer', '1.0.0')
+    project.mergeFiles({
+      'package.json': JSON.stringify({
+        name: 'vaultkeeper-dts-consumer',
+        version: '1.0.0',
+        type: 'module',
+      }),
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          strict: true,
+          skipLibCheck: false,
+          noEmit: true,
+          // Deliberately scopes ambient globals to none, as many strict
+          // monorepo tsconfigs do. This is the exact reproduction from
+          // issue #72: `@types/node` is installed (linked below) but not
+          // auto-included, so the published `.d.ts` must resolve `Buffer`
+          // via a real import rather than relying on the ambient global.
+          types: [],
+        },
+        include: ['consumer.ts'],
+      }),
+      'consumer.ts': [
+        `import type { SecretAccessor, SignRequest, VerifyRequest } from 'vaultkeeper'`,
+        ``,
+        `function useAccessor(accessor: SecretAccessor): void {`,
+        `  accessor.read((buf) => {`,
+        `    buf.toString('utf8')`,
+        `  })`,
+        `}`,
+        ``,
+        `function useSignRequest(req: SignRequest): string | Buffer {`,
+        `  return req.data`,
+        `}`,
+        ``,
+        `function useVerifyRequest(req: VerifyRequest): string | Buffer {`,
+        `  return req.data`,
+        `}`,
+        ``,
+        `export { useAccessor, useSignRequest, useVerifyRequest }`,
+      ].join('\n'),
+    })
+
+    // Link the local vaultkeeper build (requires `pnpm build` to have run).
+    const vaultkeeperRoot = resolve(__dirname, '..', '..')
+    project.linkDependency('vaultkeeper', { target: vaultkeeperRoot })
+
+    // Link the monorepo's own typescript and @types/node so the consumer
+    // project typechecks with the same compiler/lib versions as CI, without
+    // a network install.
+    const typescriptRoot = dirname(require.resolve('typescript/package.json'))
+    project.linkDependency('typescript', { target: typescriptRoot })
+
+    const typesNodeRoot = dirname(require.resolve('@types/node/package.json'))
+    project.linkDependency('@types/node', { target: typesNodeRoot })
+
+    await project.write()
+
+    const tscBin = resolve(typescriptRoot, 'bin', 'tsc')
+
+    await expect(
+      execFileAsync('node', [tscBin, '--noEmit'], {
+        cwd: project.baseDir,
+        timeout: 30_000,
+      }),
+    ).resolves.toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

Refs #72

`SecretAccessor.read()`, `SignRequest.data`, and `VerifyRequest.data` referenced the ambient global `Buffer`. Strict consumer projects that scope `compilerOptions.types` explicitly (e.g. `types: []`, common in monorepo boilerplates) don't auto-include `@types/node`'s ambient declarations, so they hit `TS2591: Cannot find name 'Buffer'` even with `@types/node` installed.

The published rollup now carries a real `import { Buffer } from 'node:buffer'` (source-level fix, resolves the common case where `@types/node` auto-includes) plus a `/// <reference types="node" />` directive reinjected into `dist/index.d.ts` / `dist/index.d.cts` after `tsup` builds (rollup-plugin-dts strips triple-slash directives from source during bundling, so this has to happen post-build — see `packages/vaultkeeper/scripts/inject-node-types-reference.mjs`). The reference directive is what actually resolves `Buffer` for consumers who exclude ambient globals, since even the explicit `node:buffer` import depends on `@types/node` being part of the program.

`@types/node` is now declared as an optional peer dependency, documented in the README TypeScript install section.

`@vaultkeeper/test-helpers` and `@vaultkeeper/wasm` were audited (criterion 3) and need no changes:
- `test-helpers`' own rollup only `import`s `VaultKeeper` from `vaultkeeper` by reference — it never inlines `vaultkeeper`'s types, so the fix propagates transitively. Verified with a real `npm pack` + install repro (`TestVault.create()` consumer, `types: []`, exit 0).
- `@vaultkeeper/wasm`'s public API uses `Uint8Array`, not `Buffer` — its `dist/index.d.ts` has zero `Buffer` references.

## Acceptance criteria mapping

1. **Buffer resolves without `types: ["node"]`, `@types/node` story documented** — `packages/vaultkeeper/src/types.ts` (explicit import) + `packages/vaultkeeper/scripts/inject-node-types-reference.mjs` (reference directive), wired into `package.json`'s `build` script. `@types/node` peer dependency + README section.
2. **Consumer-typecheck smoke test, fails pre-fix / passes post-fix** — `packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts`. Note: the literal repro in the issue text ("no `types` array at all") did not reproduce TS2591 against a real `npm pack`/`npm install` in this environment — TypeScript's default typeRoots auto-inclusion picks up `@types/node` fine when `types` is simply omitted. The reliably reproducible trigger (verified against real tarball installs, not just the test harness) is a consumer tsconfig that scopes `types: []`, which is the documented pattern the usability-study subjects most plausibly hit. I manually confirmed both directions with real `npm pack` + `npm install` round-trips: pre-fix fails with `TS2591`/`TS2307`, post-fix passes; the automated test encodes the same scenario via `fixturify-project`.
3. **test-helpers / wasm audit** — see above; no changes needed, confirmed via real-tarball repros.
4. **API report regenerated, changeset included** — `packages/vaultkeeper/api-report/vaultkeeper.api.md` updated (shows the new `import` in the rollup); `.changeset/dts-node-buffer-types.md` added (patch).

## Test plan

- [x] `pnpm build` (all 5 TS projects)
- [x] `pnpm check` (typecheck + lint + api-report, 6 projects) — green
- [x] `pnpm --filter vaultkeeper test` — 575 passed, including the new `consumer-typecheck.test.ts`
- [x] `pnpm test` (full workspace) — green
- [x] Manually verified the new smoke test fails against the pre-fix build (`TS2591`/`TS2307`) and passes post-fix, both via the fixture harness and a real `npm pack` + `npm install` round-trip