### PR TITLE
Reject {{secret}} placeholders in delegatedExec args

### DIFF
--- a/.changeset/exec-args-secret-guardrail.md
+++ b/.changeset/exec-args-secret-guardrail.md
@@ -1,0 +1,7 @@
+---
+'vaultkeeper': patch
+---
+
+Fix a security gap in `delegatedExec`: `{{secret}}` (or `{{secret:name}}`) in any `args` element was silently substituted with the raw secret value, exposing it on the process command line where it is visible to other processes via `ps` and often collected in logs and telemetry. `exec()` now throws `ExecError` if a placeholder appears in `args`, matching the existing `command`-field guardrail. Inject secrets via `env` instead.
+
+This is a breaking-in-practice fix: any caller that relied on placeholder substitution inside `args` will now get `ExecError` and must move the secret into `env`.

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ const { response } = await vault.fetch(token, {
 
 ### Delegated exec
 
-The secret is substituted for every `{{secret}}` placeholder in `env` values before the process is spawned. Do **not** pass secrets in CLI arguments — process arguments may be visible to other users via `ps` or collected in logs and telemetry.
+The secret is substituted for every `{{secret}}` placeholder in `env` values before the process is spawned. Secret placeholders are **not supported** in `command` or `args` — `exec()` throws `ExecError` if one appears there. Process arguments are visible to other users via `ps` and are often collected in logs and telemetry, so inject secrets via `env` instead.
 
 ```ts
 const { result } = await vault.exec(token, {
@@ -394,27 +394,27 @@ const jwe = await vault.setup('SECRET_NAME', {
 
 All errors extend `VaultError`.
 
-| Class                      | When thrown                                                                                                                              |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `BackendLockedError`       | Keychain or credential store is locked                                                                                                   |
-| `DeviceNotPresentError`    | Required hardware device not connected                                                                                                   |
-| `AuthorizationDeniedError` | User denied an OS permission dialog                                                                                                      |
-| `BackendUnavailableError`  | No configured backend is reachable                                                                                                       |
-| `PluginNotFoundError`      | A required plugin binary is not installed                                                                                                |
-| `SecretNotFoundError`      | Secret does not exist in the backend                                                                                                     |
-| `TokenExpiredError`        | JWE has passed its `exp` claim                                                                                                           |
-| `KeyRotatedError`          | Key exited grace period; JWE is permanently unreadable                                                                                   |
-| `KeyRevokedError`          | Key was explicitly revoked                                                                                                               |
-| `TokenRevokedError`        | Token has been blocked (e.g. single-use token already consumed)                                                                          |
-| `UsageLimitExceededError`  | Token presented more times than its `use` limit allows                                                                                   |
-| `IdentityMismatchError`    | Executable hash changed since TOFU approval                                                                                              |
-| `ExecError`                | `exec()` request was invalid (e.g. `{{secret}}` in the command field) or the command could not be started (not found or failed to spawn) |
-| `InvalidTokenError`        | JWE could not be decrypted or validated (e.g. structurally malformed, tampered, or failed decryption)                                    |
-| `AccessorConsumedError`    | `SecretAccessor.read()` called after already consumed                                                                                    |
-| `InvalidAlgorithmError`    | Signing/verifying with a disallowed algorithm (e.g. `md5`)                                                                               |
-| `SetupError`               | Required system dependency missing or incompatible at init                                                                               |
-| `FilesystemError`          | Config directory not readable or writable                                                                                                |
-| `RotationInProgressError`  | `rotateKey()` called while previous key is still in grace period                                                                         |
+| Class                      | When thrown                                                                                                                                          |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BackendLockedError`       | Keychain or credential store is locked                                                                                                               |
+| `DeviceNotPresentError`    | Required hardware device not connected                                                                                                               |
+| `AuthorizationDeniedError` | User denied an OS permission dialog                                                                                                                  |
+| `BackendUnavailableError`  | No configured backend is reachable                                                                                                                   |
+| `PluginNotFoundError`      | A required plugin binary is not installed                                                                                                            |
+| `SecretNotFoundError`      | Secret does not exist in the backend                                                                                                                 |
+| `TokenExpiredError`        | JWE has passed its `exp` claim                                                                                                                       |
+| `KeyRotatedError`          | Key exited grace period; JWE is permanently unreadable                                                                                               |
+| `KeyRevokedError`          | Key was explicitly revoked                                                                                                                           |
+| `TokenRevokedError`        | Token has been blocked (e.g. single-use token already consumed)                                                                                      |
+| `UsageLimitExceededError`  | Token presented more times than its `use` limit allows                                                                                               |
+| `IdentityMismatchError`    | Executable hash changed since TOFU approval                                                                                                          |
+| `ExecError`                | `exec()` request was invalid (e.g. `{{secret}}` in the `command` or `args` field) or the command could not be started (not found or failed to spawn) |
+| `InvalidTokenError`        | JWE could not be decrypted or validated (e.g. structurally malformed, tampered, or failed decryption)                                                |
+| `AccessorConsumedError`    | `SecretAccessor.read()` called after already consumed                                                                                                |
+| `InvalidAlgorithmError`    | Signing/verifying with a disallowed algorithm (e.g. `md5`)                                                                                           |
+| `SetupError`               | Required system dependency missing or incompatible at init                                                                                           |
+| `FilesystemError`          | Config directory not readable or writable                                                                                                            |
+| `RotationInProgressError`  | `rotateKey()` called while previous key is still in grace period                                                                                     |
 
 ## Architecture
 

--- a/USER_AGENT_INSTRUCTIONS.md
+++ b/USER_AGENT_INSTRUCTIONS.md
@@ -613,7 +613,7 @@ When generating code that uses vaultkeeper, enforce the following rules. Do not 
 
 ### Never pass secrets as CLI arguments
 
-`{{secret}}` is not supported in `args` — process arguments are visible to other processes via `/proc` or `ps` and are often collected in logs and telemetry. `delegatedExec` throws `ExecError` if a placeholder appears in `args` (or `command`). Always inject via `env` instead.
+`{{secret}}` is not supported in `args` — process arguments are visible to other processes via `/proc` or `ps` and are often collected in logs and telemetry. `vault.exec()` throws `ExecError` if a placeholder appears in `args` (or `command`). Always inject via `env` instead.
 
 ```ts
 // Correct: inject via environment variable

--- a/USER_AGENT_INSTRUCTIONS.md
+++ b/USER_AGENT_INSTRUCTIONS.md
@@ -68,10 +68,10 @@ const jwe = await vault.setup('my-api-key')
 
 // With options:
 const jwe = await vault.setup('my-api-key', {
-  ttlMinutes: 30,          // default comes from config
-  useLimit: 1,             // null = unlimited (default)
-  executablePath: '/usr/local/bin/myapp',  // enables TOFU identity binding
-  trustTier: 2,            // 1 | 2 | 3, default comes from config
+  ttlMinutes: 30, // default comes from config
+  useLimit: 1, // null = unlimited (default)
+  executablePath: '/usr/local/bin/myapp', // enables TOFU identity binding
+  trustTier: 2, // 1 | 2 | 3, default comes from config
   backendType: 'keychain', // override the backend used
 })
 ```
@@ -106,25 +106,25 @@ Use the `CapabilityToken` with one of the access methods described in section 5.
 
 ```ts
 interface VaultConfig {
-  version: number          // must be 1
-  backends: BackendConfig[]  // ordered; the first enabled backend wins
+  version: number // must be 1
+  backends: BackendConfig[] // ordered; the first enabled backend wins
   keyRotation: {
-    gracePeriodDays: number  // how long the previous key decrypts after rotation
+    gracePeriodDays: number // how long the previous key decrypts after rotation
   }
   defaults: {
-    ttlMinutes: number       // default JWE TTL
-    trustTier: TrustTier     // 1 | 2 | 3
+    ttlMinutes: number // default JWE TTL
+    trustTier: TrustTier // 1 | 2 | 3
   }
   developmentMode?: {
-    executables: string[]    // paths that bypass TOFU in dev
+    executables: string[] // paths that bypass TOFU in dev
   }
 }
 
 interface BackendConfig {
-  type: string      // e.g. 'keychain', 'file', '1password'
+  type: string // e.g. 'keychain', 'file', '1password'
   enabled: boolean
-  plugin?: boolean  // true for 1password and yubikey
-  path?: string     // for file backend
+  plugin?: boolean // true for 1password and yubikey
+  path?: string // for file backend
 }
 ```
 
@@ -143,10 +143,10 @@ interface BackendConfig {
 
 `VaultKeeper.init()` looks for `config.json` inside the platform-appropriate directory:
 
-| Platform | Path |
-|----------|------|
-| macOS / Linux | `~/.config/vaultkeeper/config.json` |
-| Windows | `%APPDATA%\vaultkeeper\config.json` (falls back to `~/AppData/Roaming/vaultkeeper/config.json`) |
+| Platform      | Path                                                                                            |
+| ------------- | ----------------------------------------------------------------------------------------------- |
+| macOS / Linux | `~/.config/vaultkeeper/config.json`                                                             |
+| Windows       | `%APPDATA%\vaultkeeper\config.json` (falls back to `~/AppData/Roaming/vaultkeeper/config.json`) |
 
 Override the directory with `VaultKeeperOptions.configDir` or by passing a `VaultConfig` object directly via `VaultKeeperOptions.config`.
 
@@ -172,11 +172,13 @@ const { response, vaultResponse } = await vault.fetch(token, {
 ```
 
 The `{{secret}}` placeholder is replaced in:
+
 - `url` — for API-key-in-URL patterns
 - any `headers` value
 - `body` — for POST bodies
 
 The `FetchRequest` interface:
+
 ```ts
 interface FetchRequest {
   url: string
@@ -187,19 +189,23 @@ interface FetchRequest {
 ```
 
 The return type:
+
 ```ts
-{ response: Response; vaultResponse: VaultResponse }
+{
+  response: Response
+  vaultResponse: VaultResponse
+}
 ```
 
 ### 5b. Delegated Exec
 
-Use when the secret must be passed to a subprocess — for example, authenticating a CLI tool. Never put the secret in `args` as a plain string value; use `{{secret}}` so vaultkeeper injects it after you cannot accidentally log it.
+Use when the secret must be passed to a subprocess — for example, authenticating a CLI tool. Always inject via `env`, never via `args`: process arguments are visible to other users via `ps` and are often collected in logs and telemetry.
 
 The secret is injected into:
-- any element of `args` that contains `{{secret}}`
+
 - any value in the `env` map that contains `{{secret}}`
 
-The secret is NEVER injected into `command` itself. Do not use it there.
+`{{secret}}` is NEVER injected into `command` or `args`. `exec()` throws `ExecError` if a placeholder appears in either field — put the placeholder in `env` instead.
 
 ```ts
 const { result, vaultResponse } = await vault.exec(token, {
@@ -216,6 +222,7 @@ console.log(result.exitCode)
 ```
 
 The `ExecRequest` interface:
+
 ```ts
 interface ExecRequest {
   command: string
@@ -226,6 +233,7 @@ interface ExecRequest {
 ```
 
 The `ExecResult` interface:
+
 ```ts
 interface ExecResult {
   stdout: string
@@ -253,6 +261,7 @@ accessor.read((buf) => {
 ```
 
 The `SecretAccessor` interface:
+
 ```ts
 interface SecretAccessor {
   read(callback: (buf: Buffer) => void): void
@@ -260,6 +269,7 @@ interface SecretAccessor {
 ```
 
 Key properties of `SecretAccessor`:
+
 - **Single-use.** The second call to `read()` throws. If you need to read the secret again, call `vault.getSecret(token)` again (which requires another `authorize()` call if the token has a `useLimit` of 1).
 - **Auto-zeroing.** The `Buffer` passed to the callback is filled with zeros in the `finally` block immediately after the callback returns, even if the callback throws.
 - **Revocable proxy.** After the first `read()` completes, the proxy is revoked. Any subsequent property access on the accessor object throws a `TypeError`.
@@ -271,14 +281,14 @@ Key properties of `SecretAccessor`:
 
 Six backends are available. vaultkeeper uses the first enabled backend in the `backends` array.
 
-| Type | Platform | Plugin | Storage |
-|------|----------|--------|---------|
-| `keychain` | macOS only | No | macOS Keychain via `security` CLI |
-| `dpapi` | Windows only | No | Windows DPAPI via PowerShell; blobs stored in `~/.vaultkeeper/dpapi/` |
-| `secret-tool` | Linux only | No | GNOME Keyring / libsecret via `secret-tool` CLI |
-| `file` | All | No | AES-256-GCM encrypted file; default path `~/.config/vaultkeeper/secrets/` |
-| `1password` | All | Yes | 1Password via `op` CLI |
-| `yubikey` | All | Yes | YubiKey PIV via `ykman` CLI |
+| Type          | Platform     | Plugin | Storage                                                                   |
+| ------------- | ------------ | ------ | ------------------------------------------------------------------------- |
+| `keychain`    | macOS only   | No     | macOS Keychain via `security` CLI                                         |
+| `dpapi`       | Windows only | No     | Windows DPAPI via PowerShell; blobs stored in `~/.vaultkeeper/dpapi/`     |
+| `secret-tool` | Linux only   | No     | GNOME Keyring / libsecret via `secret-tool` CLI                           |
+| `file`        | All          | No     | AES-256-GCM encrypted file; default path `~/.config/vaultkeeper/secrets/` |
+| `1password`   | All          | Yes    | 1Password via `op` CLI                                                    |
+| `yubikey`     | All          | Yes    | YubiKey PIV via `ykman` CLI                                               |
 
 Plugin backends (`1password`, `yubikey`) require an external binary and are flagged with `plugin: true` in `BackendConfig`. If the binary is not installed, `store()` and `retrieve()` throw `PluginNotFoundError` with a `.plugin` field (the binary name) and an `.installUrl` field.
 
@@ -307,6 +317,7 @@ await vault.rotateKey()
 ```
 
 After rotation:
+
 - A new current key is generated.
 - The previous key remains valid for decryption during the grace period (`keyRotation.gracePeriodDays` from config).
 - JWEs presented during the grace period decrypt successfully and `authorize()` returns `vaultResponse.keyStatus === 'previous'` along with a `rotatedJwt` field containing the same claims re-encrypted under the new key.
@@ -345,11 +356,11 @@ Failing to persist `rotatedJwt` means the stored JWE will eventually be unreadab
 
 `TrustTier` is `1 | 2 | 3`. Higher numbers mean stricter verification.
 
-| Tier | Meaning |
-|------|---------|
-| 1 | SHA-256 hash of the executable binary — basic TOFU (trust-on-first-use) |
-| 2 | SHA-256 hash + sigstore / code-signing verification (when available) |
-| 3 | Full sigstore verification required; setup fails if sigstore is unavailable |
+| Tier | Meaning                                                                     |
+| ---- | --------------------------------------------------------------------------- |
+| 1    | SHA-256 hash of the executable binary — basic TOFU (trust-on-first-use)     |
+| 2    | SHA-256 hash + sigstore / code-signing verification (when available)        |
+| 3    | Full sigstore verification required; setup fails if sigstore is unavailable |
 
 The tier is embedded in the JWE claims (`tid` field) and enforced when `setup()` computes the executable identity. Specify it in config `defaults.trustTier` or override per-call with `SetupOptions.trustTier`.
 
@@ -404,24 +415,24 @@ VaultError
 
 ### Error class reference
 
-| Class | When thrown | Key typed fields |
-|-------|-------------|-----------------|
-| `VaultError` | Base class — never thrown directly (except one case during init when system not ready) | — |
-| `BackendLockedError` | Keychain / DPAPI requires user interaction before access | `interactive: boolean` — when `true`, prompting the user and retrying may succeed |
-| `DeviceNotPresentError` | YubiKey or smart card is not plugged in | `timeoutMs: number` — how long the operation waited |
-| `AuthorizationDeniedError` | User cancelled an OS permission dialog | — |
-| `BackendUnavailableError` | No enabled backend is configured, or all attempted backends failed | `reason: string` (e.g. `'none-enabled'`, `'all-failed'`, `'unknown-type'`); `attempted: string[]` |
-| `PluginNotFoundError` | `op` or `ykman` binary not installed | `plugin: string` (binary name); `installUrl: string` |
-| `SecretNotFoundError` | The requested secret does not exist in the backend | — |
-| `TokenExpiredError` | JWE `exp` claim has passed | `canRefresh: boolean` — when `true`, the secret still exists and `setup()` can issue a new token |
-| `KeyRotatedError` | JWE was encrypted with a key that has passed its grace period | — |
-| `KeyRevokedError` | JWE was encrypted with a key that was explicitly revoked | — |
-| `TokenRevokedError` | JWE has been blocklisted (e.g. after a single-use token was consumed) | — |
-| `UsageLimitExceededError` | Token presented more times than its `use` limit allows | — |
-| `IdentityMismatchError` | Executable hash changed since it was first approved (TOFU conflict) | `previousHash: string`; `currentHash: string` |
-| `SetupError` | Required system dependency missing or incompatible during init | `dependency: string` (dependency name) |
-| `FilesystemError` | Config directory or secret file not accessible | `path: string`; `permission: string` (e.g. `'read'`, `'write'`) |
-| `RotationInProgressError` | `rotateKey()` called while a grace period is still active | — |
+| Class                      | When thrown                                                                            | Key typed fields                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `VaultError`               | Base class — never thrown directly (except one case during init when system not ready) | —                                                                                                 |
+| `BackendLockedError`       | Keychain / DPAPI requires user interaction before access                               | `interactive: boolean` — when `true`, prompting the user and retrying may succeed                 |
+| `DeviceNotPresentError`    | YubiKey or smart card is not plugged in                                                | `timeoutMs: number` — how long the operation waited                                               |
+| `AuthorizationDeniedError` | User cancelled an OS permission dialog                                                 | —                                                                                                 |
+| `BackendUnavailableError`  | No enabled backend is configured, or all attempted backends failed                     | `reason: string` (e.g. `'none-enabled'`, `'all-failed'`, `'unknown-type'`); `attempted: string[]` |
+| `PluginNotFoundError`      | `op` or `ykman` binary not installed                                                   | `plugin: string` (binary name); `installUrl: string`                                              |
+| `SecretNotFoundError`      | The requested secret does not exist in the backend                                     | —                                                                                                 |
+| `TokenExpiredError`        | JWE `exp` claim has passed                                                             | `canRefresh: boolean` — when `true`, the secret still exists and `setup()` can issue a new token  |
+| `KeyRotatedError`          | JWE was encrypted with a key that has passed its grace period                          | —                                                                                                 |
+| `KeyRevokedError`          | JWE was encrypted with a key that was explicitly revoked                               | —                                                                                                 |
+| `TokenRevokedError`        | JWE has been blocklisted (e.g. after a single-use token was consumed)                  | —                                                                                                 |
+| `UsageLimitExceededError`  | Token presented more times than its `use` limit allows                                 | —                                                                                                 |
+| `IdentityMismatchError`    | Executable hash changed since it was first approved (TOFU conflict)                    | `previousHash: string`; `currentHash: string`                                                     |
+| `SetupError`               | Required system dependency missing or incompatible during init                         | `dependency: string` (dependency name)                                                            |
+| `FilesystemError`          | Config directory or secret file not accessible                                         | `path: string`; `permission: string` (e.g. `'read'`, `'write'`)                                   |
+| `RotationInProgressError`  | `rotateKey()` called while a grace period is still active                              | —                                                                                                 |
 
 ### Recommended error handling pattern
 
@@ -468,7 +479,7 @@ try {
     // Catch-all for any other library error
     console.error(err.message)
   } else {
-    throw err  // Re-throw non-library errors
+    throw err // Re-throw non-library errors
   }
 }
 ```
@@ -498,13 +509,14 @@ const jwe = await vault.keeper.setup('db-password')
 const { token, vaultResponse } = await vault.keeper.authorize(jwe)
 
 // Reset between tests:
-vault.reset()  // clears all stored secrets; same as vault.backend.clear()
+vault.reset() // clears all stored secrets; same as vault.backend.clear()
 ```
 
 With options:
+
 ```ts
 const vault = await TestVault.create({
-  ttlMinutes: 1,   // short TTL for expiry tests
+  ttlMinutes: 1, // short TTL for expiry tests
   trustTier: 2,
 })
 ```
@@ -521,8 +533,8 @@ const backend = new InMemoryBackend()
 BackendRegistry.register('memory', () => backend)
 
 await backend.store('api-key', 'test-value')
-console.log(backend.size)  // 1
-await backend.clear()      // remove all entries
+console.log(backend.size) // 1
+await backend.clear() // remove all entries
 ```
 
 `InMemoryBackend` is always available (`isAvailable()` returns `true`). Its `type` is `'memory'` and `displayName` is `'In-Memory Backend'`.
@@ -553,10 +565,10 @@ describe('my vault consumer', () => {
   })
 
   it('should throw TokenExpiredError on expired token', async () => {
-    const shortVault = await TestVault.create({ ttlMinutes: 0.001 })  // ~60ms
+    const shortVault = await TestVault.create({ ttlMinutes: 0.001 }) // ~60ms
     await shortVault.backend.store('api-key', 'value')
     const jwe = await shortVault.keeper.setup('api-key')
-    await new Promise(resolve => setTimeout(resolve, 100))  // let it expire
+    await new Promise((resolve) => setTimeout(resolve, 100)) // let it expire
     await expect(shortVault.keeper.authorize(jwe)).rejects.toBeInstanceOf(TokenExpiredError)
   })
 })
@@ -579,17 +591,17 @@ const result = await VaultKeeper.doctor()
 
 ```ts
 interface PreflightResult {
-  checks: PreflightCheck[]  // one per dependency inspected
-  ready: boolean            // true when all required checks pass
-  warnings: string[]        // non-fatal, optional dependencies missing
-  nextSteps: string[]       // action items for failed required checks
+  checks: PreflightCheck[] // one per dependency inspected
+  ready: boolean // true when all required checks pass
+  warnings: string[] // non-fatal, optional dependencies missing
+  nextSteps: string[] // action items for failed required checks
 }
 
 interface PreflightCheck {
   name: string
   status: 'ok' | 'missing' | 'version-unsupported'
-  version?: string    // detected version, when found
-  reason?: string     // human-readable explanation when status is not 'ok'
+  version?: string // detected version, when found
+  reason?: string // human-readable explanation when status is not 'ok'
 }
 ```
 
@@ -601,23 +613,23 @@ When generating code that uses vaultkeeper, enforce the following rules. Do not 
 
 ### Never pass secrets as CLI arguments
 
-`delegatedExec` uses `spawn()` with an argument array. While the secret is injected into `args` elements at the last moment before spawning, this means the secret appears in the process argument list visible to other processes via `/proc` or `ps`. When possible, inject the secret via `env` instead of `args`.
+`{{secret}}` is not supported in `args` — process arguments are visible to other processes via `/proc` or `ps` and are often collected in logs and telemetry. `delegatedExec` throws `ExecError` if a placeholder appears in `args` (or `command`). Always inject via `env` instead.
 
 ```ts
-// Prefer: inject via environment variable
+// Correct: inject via environment variable
 vault.exec(token, {
   command: 'my-tool',
   env: { MY_TOOL_SECRET: '{{secret}}' },
 })
 
-// Acceptable but higher risk: inject via arg (still supported by the API)
+// WRONG — throws ExecError: placeholders are not supported in args
 vault.exec(token, {
   command: 'my-tool',
   args: ['--password', '{{secret}}'],
 })
 ```
 
-Never construct a command string with the secret concatenated as a plain value and then split it into args. Always use the `{{secret}}` placeholder.
+Never construct a command string with the secret concatenated as a plain value and then split it into args. Always use the `{{secret}}` placeholder — but only in `env`.
 
 ### Never store a reference to the Buffer outside the SecretAccessor callback
 
@@ -625,7 +637,7 @@ Never construct a command string with the secret concatenated as a plain value a
 // WRONG — storing a reference means the secret outlives the zeroing:
 let leaked: Buffer
 accessor.read((buf) => {
-  leaked = buf  // DO NOT DO THIS
+  leaked = buf // DO NOT DO THIS
 })
 // leaked now contains zeroed bytes and is a security footprint
 
@@ -644,8 +656,10 @@ accessor.read((buf) => {
 // WRONG:
 function getApiKey(accessor: SecretAccessor): string {
   let key = ''
-  accessor.read((buf) => { key = buf.toString('utf8') })
-  return key  // raw secret is now a long-lived string
+  accessor.read((buf) => {
+    key = buf.toString('utf8')
+  })
+  return key // raw secret is now a long-lived string
 }
 
 // CORRECT: compute what you need inside the callback
@@ -654,7 +668,7 @@ function signRequest(accessor: SecretAccessor, payload: string): string {
   accessor.read((buf) => {
     signature = crypto.createHmac('sha256', buf).update(payload).digest('hex')
   })
-  return signature  // derived value only, not the secret
+  return signature // derived value only, not the secret
 }
 ```
 
@@ -707,6 +721,7 @@ Error: SecretAccessor has already been consumed — call getSecret() again to ob
 ```
 
 To read the secret multiple times in a single flow, either:
+
 - Do all work inside a single `read()` callback, or
 - Call `vault.getSecret(token)` again (which works for tokens with `useLimit: null` or a limit greater than the number of accesses consumed so far).
 
@@ -764,7 +779,7 @@ vault.getSecret(token).read((buf) => {
 
 // Key rotation
 await vault.rotateKey()
-await vault.revokeKey()  // emergency only
+await vault.revokeKey() // emergency only
 
 // Doctor
 const preflight = await VaultKeeper.doctor()
@@ -772,5 +787,5 @@ const preflight = await VaultKeeper.doctor()
 // Tests
 const vault = await TestVault.create()
 await vault.backend.store('my-secret', 'value')
-vault.reset()  // clear between tests
+vault.reset() // clear between tests
 ```

--- a/docs/api/vaultkeeper.execrequest.args.md
+++ b/docs/api/vaultkeeper.execrequest.args.md
@@ -4,7 +4,7 @@
 
 ## ExecRequest.args property
 
-Command-line arguments. Secret placeholders (`{{secret}}` or `{{secret:name}}`<!-- -->) are \*\*not\*\* supported here — process arguments are visible to other processes via `ps` and often collected in logs and telemetry. `delegatedExec` throws `ExecError` if a placeholder appears in any argument. Use `env` to inject secrets instead.
+Command-line arguments. Secret placeholders (`{{secret}}` or `{{secret:name}}`<!-- -->) are \*\*not\*\* supported here — process arguments are visible to other processes via `ps` and often collected in logs and telemetry. `VaultKeeper.exec()` throws `ExecError` if a placeholder appears in any argument. Use `env` to inject secrets instead.
 
 **Signature:**
 

--- a/docs/api/vaultkeeper.execrequest.args.md
+++ b/docs/api/vaultkeeper.execrequest.args.md
@@ -4,7 +4,7 @@
 
 ## ExecRequest.args property
 
-Command-line arguments. Any argument may contain `{{secret}}`<!-- -->, which is replaced with the secret value before the command is spawned.
+Command-line arguments. Secret placeholders (`{{secret}}` or `{{secret:name}}`<!-- -->) are \*\*not\*\* supported here — process arguments are visible to other processes via `ps` and often collected in logs and telemetry. `delegatedExec` throws `ExecError` if a placeholder appears in any argument. Use `env` to inject secrets instead.
 
 **Signature:**
 

--- a/docs/api/vaultkeeper.execrequest.env.md
+++ b/docs/api/vaultkeeper.execrequest.env.md
@@ -4,7 +4,7 @@
 
 ## ExecRequest.env property
 
-Additional environment variables to merge into the child process environment. Any value may contain `{{secret}}`<!-- -->, which is replaced with the secret value before the command is spawned.
+Additional environment variables to merge into the child process environment. Any value may contain `{{secret}}` or `{{secret:name}}`<!-- -->, which is replaced with the secret value before the command is spawned.
 
 **Signature:**
 

--- a/docs/api/vaultkeeper.execrequest.md
+++ b/docs/api/vaultkeeper.execrequest.md
@@ -6,7 +6,7 @@
 
 Request for delegated command execution.
 
-String values in `env` may include the placeholder `{{secret}}` (single-token mode) or `{{secret:name}}` (multi-token mode), which are replaced with actual secret values immediately before the command is spawned. Placeholders are \*\*not\*\* supported in `command` or `args` — `delegatedExec` throws `ExecError` if one appears there.
+String values in `env` may include the placeholder `{{secret}}` (single-token mode) or `{{secret:name}}` (multi-token mode), which are replaced with actual secret values immediately before the command is spawned. Placeholders are \*\*not\*\* supported in `command` or `args` — `VaultKeeper.exec()` throws `ExecError` if one appears there.
 
 **Signature:**
 
@@ -52,7 +52,7 @@ string\[\] \| undefined
 
 </td><td>
 
-_(Optional)_ Command-line arguments. Secret placeholders (`{{secret}}` or `{{secret:name}}`<!-- -->) are \*\*not\*\* supported here — process arguments are visible to other processes via `ps` and often collected in logs and telemetry. `delegatedExec` throws `ExecError` if a placeholder appears in any argument. Use `env` to inject secrets instead.
+_(Optional)_ Command-line arguments. Secret placeholders (`{{secret}}` or `{{secret:name}}`<!-- -->) are \*\*not\*\* supported here — process arguments are visible to other processes via `ps` and often collected in logs and telemetry. `VaultKeeper.exec()` throws `ExecError` if a placeholder appears in any argument. Use `env` to inject secrets instead.
 
 
 </td></tr>

--- a/docs/api/vaultkeeper.execrequest.md
+++ b/docs/api/vaultkeeper.execrequest.md
@@ -6,7 +6,7 @@
 
 Request for delegated command execution.
 
-String values in `args` and `env` may include the placeholder `{{secret}}`<!-- -->, which is replaced with the actual secret value immediately before the command is spawned.
+String values in `env` may include the placeholder `{{secret}}` (single-token mode) or `{{secret:name}}` (multi-token mode), which are replaced with actual secret values immediately before the command is spawned. Placeholders are \*\*not\*\* supported in `command` or `args` — `delegatedExec` throws `ExecError` if one appears there.
 
 **Signature:**
 
@@ -52,7 +52,7 @@ string\[\] \| undefined
 
 </td><td>
 
-_(Optional)_ Command-line arguments. Any argument may contain `{{secret}}`<!-- -->, which is replaced with the secret value before the command is spawned.
+_(Optional)_ Command-line arguments. Secret placeholders (`{{secret}}` or `{{secret:name}}`<!-- -->) are \*\*not\*\* supported here — process arguments are visible to other processes via `ps` and often collected in logs and telemetry. `delegatedExec` throws `ExecError` if a placeholder appears in any argument. Use `env` to inject secrets instead.
 
 
 </td></tr>
@@ -109,7 +109,7 @@ Record&lt;string, string&gt; \| undefined
 
 </td><td>
 
-_(Optional)_ Additional environment variables to merge into the child process environment. Any value may contain `{{secret}}`<!-- -->, which is replaced with the secret value before the command is spawned.
+_(Optional)_ Additional environment variables to merge into the child process environment. Any value may contain `{{secret}}` or `{{secret:name}}`<!-- -->, which is replaced with the secret value before the command is spawned.
 
 
 </td></tr>

--- a/packages/vaultkeeper/src/access/delegated-exec.ts
+++ b/packages/vaultkeeper/src/access/delegated-exec.ts
@@ -1,25 +1,26 @@
 /**
  * Delegated command execution access pattern.
  *
- * Replaces `{{secret}}` or `{{secret:name}}` placeholders in command args
- * and environment values, then executes the command.
+ * Replaces `{{secret}}` or `{{secret:name}}` placeholders in environment
+ * values, then executes the command. Placeholders are rejected in the
+ * `command` and `args` fields — process arguments (and the command name)
+ * are visible to other processes via `ps` and often collected in logs and
+ * telemetry, so secrets must be injected via `env` instead.
  */
 
 import { spawn } from 'node:child_process'
 import type { ExecRequest, ExecResult } from '../types.js'
 import { ExecError, VaultError } from '../errors.js'
-import {
-  ANY_PLACEHOLDER_RE,
-  resolvePlaceholders,
-  resolvePlaceholdersInRecord,
-} from './placeholder.js'
+import { ANY_PLACEHOLDER_RE, resolvePlaceholdersInRecord } from './placeholder.js'
 
 /**
- * Execute a delegated command with secrets injected into args and env.
+ * Execute a delegated command with secrets injected into env.
  *
  * @param secrets - A single secret string (replaces `{{secret}}`) or a
  *   name-to-value map (replaces `{{secret:name}}`)
- * @param request - The exec request template with placeholders
+ * @param request - The exec request template with placeholders. Placeholders
+ *   are only resolved in `env`; `command` and `args` reject them with
+ *   `ExecError`.
  * @returns The command result (stdout, stderr, exitCode)
  * @internal
  */
@@ -29,21 +30,24 @@ export async function delegatedExec(
 ): Promise<ExecResult> {
   if (ANY_PLACEHOLDER_RE.test(request.command)) {
     throw new ExecError(
-      `Secret placeholders are not supported in the command field. Use args or env instead.`,
+      `Secret placeholders are not supported in the command field. Use env instead.`,
       request.command,
     )
   }
 
-  let args: string[]
+  const args = request.args ?? []
+  for (const arg of args) {
+    if (ANY_PLACEHOLDER_RE.test(arg)) {
+      throw new ExecError(
+        `Secret placeholders are not supported in the args field — process arguments are visible to other processes via ps. Use env instead.`,
+        request.command,
+      )
+    }
+  }
+
   let env: Record<string, string> | undefined
   try {
-    args = (request.args ?? []).map((arg) =>
-      resolvePlaceholders(arg, secrets),
-    )
-    env =
-      request.env !== undefined
-        ? resolvePlaceholdersInRecord(request.env, secrets)
-        : undefined
+    env = request.env !== undefined ? resolvePlaceholdersInRecord(request.env, secrets) : undefined
   } catch (error) {
     if (error instanceof VaultError) {
       throw new ExecError(error.message, request.command)

--- a/packages/vaultkeeper/src/types.ts
+++ b/packages/vaultkeeper/src/types.ts
@@ -104,9 +104,11 @@ export interface FetchRequest {
 /**
  * Request for delegated command execution.
  *
- * String values in `args` and `env` may include the placeholder `{{secret}}`
+ * String values in `env` may include the placeholder `{{secret}}`
  * (single-token mode) or `{{secret:name}}` (multi-token mode), which are
- * replaced with actual secret values immediately before the command is spawned.
+ * replaced with actual secret values immediately before the command is
+ * spawned. Placeholders are **not** supported in `command` or `args` —
+ * `delegatedExec` throws `ExecError` if one appears there.
  */
 export interface ExecRequest {
   /** The command (binary) to execute. */

--- a/packages/vaultkeeper/src/types.ts
+++ b/packages/vaultkeeper/src/types.ts
@@ -108,7 +108,7 @@ export interface FetchRequest {
  * (single-token mode) or `{{secret:name}}` (multi-token mode), which are
  * replaced with actual secret values immediately before the command is
  * spawned. Placeholders are **not** supported in `command` or `args` —
- * `delegatedExec` throws `ExecError` if one appears there.
+ * `VaultKeeper.exec()` throws `ExecError` if one appears there.
  */
 export interface ExecRequest {
   /** The command (binary) to execute. */
@@ -117,8 +117,8 @@ export interface ExecRequest {
    * Command-line arguments. Secret placeholders (`{{secret}}` or
    * `{{secret:name}}`) are **not** supported here — process arguments are
    * visible to other processes via `ps` and often collected in logs and
-   * telemetry. `delegatedExec` throws `ExecError` if a placeholder appears
-   * in any argument. Use `env` to inject secrets instead.
+   * telemetry. `VaultKeeper.exec()` throws `ExecError` if a placeholder
+   * appears in any argument. Use `env` to inject secrets instead.
    */
   args?: string[] | undefined
   /**

--- a/packages/vaultkeeper/src/types.ts
+++ b/packages/vaultkeeper/src/types.ts
@@ -112,9 +112,11 @@ export interface ExecRequest {
   /** The command (binary) to execute. */
   command: string
   /**
-   * Command-line arguments. Any argument may contain `{{secret}}` or
-   * `{{secret:name}}`, which is replaced with the secret value before the
-   * command is spawned.
+   * Command-line arguments. Secret placeholders (`{{secret}}` or
+   * `{{secret:name}}`) are **not** supported here — process arguments are
+   * visible to other processes via `ps` and often collected in logs and
+   * telemetry. `delegatedExec` throws `ExecError` if a placeholder appears
+   * in any argument. Use `env` to inject secrets instead.
    */
   args?: string[] | undefined
   /**
@@ -237,10 +239,12 @@ export interface VaultConfig {
     trustTier: TrustTier
   }
   /** Development mode configuration. When present, identity checks are relaxed for listed executables. */
-  developmentMode?: {
-    /** Paths of executables that bypass identity verification in development mode. */
-    executables: string[]
-  } | undefined
+  developmentMode?:
+    | {
+        /** Paths of executables that bypass identity verification in development mode. */
+        executables: string[]
+      }
+    | undefined
 }
 
 /** Configuration for a single backend. */

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -376,11 +376,15 @@ export class VaultKeeper {
   /**
    * Execute a delegated command, injecting secrets from the token(s).
    *
-   * **Single token:** every `{{secret}}` placeholder in `request.args` and
-   * `request.env` values is replaced with the secret value.
+   * **Single token:** every `{{secret}}` placeholder in `request.env` values
+   * is replaced with the secret value.
    *
    * **Token map ({@link SecretTokenMap}):** every `{{secret:name}}` placeholder
    * is replaced with the secret from the corresponding named token.
+   *
+   * Secret placeholders are not supported in `request.command` or
+   * `request.args` — process arguments are visible to other processes via
+   * `ps` and often collected in logs and telemetry.
    *
    * The raw secret is never exposed in the return value.
    *
@@ -393,7 +397,7 @@ export class VaultKeeper {
    *   created by this vault instance.
    * @throws {ExecError} If the command cannot be started (e.g. ENOENT),
    *   a placeholder references an unknown secret name, or a secret
-   *   placeholder appears in the `command` field.
+   *   placeholder appears in the `command` or `args` field.
    */
   async exec(
     token: CapabilityToken | SecretTokenMap,

--- a/packages/vaultkeeper/test/unit/access/delegated-exec.test.ts
+++ b/packages/vaultkeeper/test/unit/access/delegated-exec.test.ts
@@ -1,7 +1,23 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { delegatedExec } from '../../../src/access/delegated-exec.js'
 import { ExecError } from '../../../src/errors.js'
 import type { ExecRequest } from '../../../src/access/types.js'
+
+// spawn is wrapped (not replaced) so every other test in this file still
+// spawns real child processes — only the guardrail test below asserts
+// against call count.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return { ...actual, spawn: vi.fn(actual.spawn) }
+})
+
+import { spawn } from 'node:child_process'
+
+const mockSpawn = vi.mocked(spawn)
+
+beforeEach(() => {
+  mockSpawn.mockClear()
+})
 
 describe('delegatedExec', () => {
   describe('args placeholder guardrail', () => {
@@ -20,6 +36,7 @@ describe('delegatedExec', () => {
 
       await expect(promise).rejects.toThrow(ExecError)
       await expect(promise).rejects.toThrow(/placeholders are not supported in the args field/)
+      expect(mockSpawn).not.toHaveBeenCalled()
     })
 
     it('rejects with ExecError when {{secret}} appears alongside static text in an arg', async () => {

--- a/packages/vaultkeeper/test/unit/access/delegated-exec.test.ts
+++ b/packages/vaultkeeper/test/unit/access/delegated-exec.test.ts
@@ -4,39 +4,52 @@ import { ExecError } from '../../../src/errors.js'
 import type { ExecRequest } from '../../../src/access/types.js'
 
 describe('delegatedExec', () => {
-  describe('args placeholder replacement', () => {
-    it('replaces {{secret}} in command args', async () => {
+  describe('args placeholder guardrail', () => {
+    // Regression test for issue #70: {{secret}} in args was silently
+    // substituted, exposing the plaintext secret on the process command
+    // line (visible via `ps`). This must throw ExecError before spawning,
+    // exactly like the command field does.
+    it('rejects with ExecError when {{secret}} is used in args, without spawning', async () => {
       const request: ExecRequest = {
         command: 'echo',
         args: ['{{secret}}'],
+        env: {},
       }
 
-      const result = await delegatedExec('hello', request)
-
-      expect(result.stdout.trim()).toBe('hello')
-      expect(result.exitCode).toBe(0)
+      await expect(delegatedExec('hello', request)).rejects.toThrow(ExecError)
+      await expect(delegatedExec('hello', request)).rejects.toThrow(
+        /placeholders are not supported in the args field/,
+      )
     })
 
-    it('replaces multiple occurrences in a single arg', async () => {
+    it('rejects with ExecError when {{secret}} appears alongside static text in an arg', async () => {
       const request: ExecRequest = {
         command: 'sh',
         args: ['-c', 'echo {{secret}}-{{secret}}'],
       }
 
-      const result = await delegatedExec('x', request)
-
-      expect(result.stdout.trim()).toBe('x-x')
+      await expect(delegatedExec('x', request)).rejects.toThrow(ExecError)
     })
 
-    it('replaces placeholders in multiple args', async () => {
+    it('rejects with ExecError when {{secret}} appears in any element of a multi-arg array', async () => {
       const request: ExecRequest = {
         command: 'sh',
-        args: ['-c', 'echo {{secret}} static {{secret}}'],
+        args: ['-c', 'echo static', '{{secret}}'],
       }
 
-      const result = await delegatedExec('val', request)
+      await expect(delegatedExec('val', request)).rejects.toThrow(ExecError)
+    })
 
-      expect(result.stdout.trim()).toBe('val static val')
+    it('rejects with ExecError when {{secret:name}} is used in args', async () => {
+      const request: ExecRequest = {
+        command: 'sh',
+        args: ['-c', 'echo {{secret:greeting}}'],
+      }
+
+      await expect(delegatedExec({ greeting: 'hello' }, request)).rejects.toThrow(ExecError)
+      await expect(delegatedExec({ greeting: 'hello' }, request)).rejects.toThrow(
+        /placeholders are not supported in the args field/,
+      )
     })
 
     it('handles empty args array', async () => {
@@ -149,29 +162,6 @@ describe('delegatedExec', () => {
   })
 
   describe('named-secret mode (Record)', () => {
-    it('replaces {{secret:name}} in args', async () => {
-      const request: ExecRequest = {
-        command: 'sh',
-        args: ['-c', 'echo {{secret:greeting}}'],
-      }
-
-      const result = await delegatedExec({ greeting: 'hello' }, request)
-
-      expect(result.stdout.trim()).toBe('hello')
-      expect(result.exitCode).toBe(0)
-    })
-
-    it('replaces multiple named secrets in args', async () => {
-      const request: ExecRequest = {
-        command: 'sh',
-        args: ['-c', 'echo {{secret:a}}-{{secret:b}}'],
-      }
-
-      const result = await delegatedExec({ a: 'x', b: 'y' }, request)
-
-      expect(result.stdout.trim()).toBe('x-y')
-    })
-
     it('replaces named secrets in env values', async () => {
       const request: ExecRequest = {
         command: 'sh',
@@ -182,10 +172,7 @@ describe('delegatedExec', () => {
         },
       }
 
-      const result = await delegatedExec(
-        { apiKey: 'key123', dbPass: 'pass456' },
-        request,
-      )
+      const result = await delegatedExec({ apiKey: 'key123', dbPass: 'pass456' }, request)
 
       expect(result.stdout.trim()).toBe('key123 pass456')
     })
@@ -223,7 +210,7 @@ describe('delegatedExec', () => {
     it('rejects with ExecError when a named placeholder references an unknown secret', async () => {
       const request: ExecRequest = {
         command: 'echo',
-        args: ['{{secret:missing}}'],
+        env: { MISSING: '{{secret:missing}}' },
       }
 
       await expect(delegatedExec({ apiKey: 'val' }, request)).rejects.toThrow(ExecError)

--- a/packages/vaultkeeper/test/unit/access/delegated-exec.test.ts
+++ b/packages/vaultkeeper/test/unit/access/delegated-exec.test.ts
@@ -16,10 +16,10 @@ describe('delegatedExec', () => {
         env: {},
       }
 
-      await expect(delegatedExec('hello', request)).rejects.toThrow(ExecError)
-      await expect(delegatedExec('hello', request)).rejects.toThrow(
-        /placeholders are not supported in the args field/,
-      )
+      const promise = delegatedExec('hello', request)
+
+      await expect(promise).rejects.toThrow(ExecError)
+      await expect(promise).rejects.toThrow(/placeholders are not supported in the args field/)
     })
 
     it('rejects with ExecError when {{secret}} appears alongside static text in an arg', async () => {
@@ -46,10 +46,10 @@ describe('delegatedExec', () => {
         args: ['-c', 'echo {{secret:greeting}}'],
       }
 
-      await expect(delegatedExec({ greeting: 'hello' }, request)).rejects.toThrow(ExecError)
-      await expect(delegatedExec({ greeting: 'hello' }, request)).rejects.toThrow(
-        /placeholders are not supported in the args field/,
-      )
+      const promise = delegatedExec({ greeting: 'hello' }, request)
+
+      await expect(promise).rejects.toThrow(ExecError)
+      await expect(promise).rejects.toThrow(/placeholders are not supported in the args field/)
     })
 
     it('handles empty args array', async () => {


### PR DESCRIPTION
## Summary

- Confirmed the claim in #70: `{{secret}}` in `args` was silently substituted by `resolvePlaceholders`, so the plaintext secret ended up in the child process's argv — visible to other processes via `ps` and often captured in logs/telemetry — with no error thrown.
- `delegatedExec` now rejects `{{secret}}`/`{{secret:name}}` placeholders in any `args` element with `ExecError`, matching the existing `command`-field guardrail. The error message points to `env` injection as the supported pattern.
- Updated `ExecRequest.args` JSDoc, `VaultKeeper.exec()` JSDoc, `README.md`, and `USER_AGENT_INSTRUCTIONS.md` (which previously told agents args-injection was "acceptable but higher risk" — now corrected to state it throws).
- Added a changeset (patch) noting this as a breaking-in-practice fix: callers relying on args substitution now get `ExecError` and must move the secret to `env`.

Refs #70

## Test plan

- [x] Added a regression test that reproduces the exact repro from the issue (`{{secret}}` in `args`) and confirmed it **fails** against the pre-fix code (secret leaked into stdout, no error) before applying the fix
- [x] Confirmed the same test **passes** post-fix
- [x] Added negative tests for `{{secret}}` and `{{secret:name}}` in `args` (single occurrence, multiple args, mixed with static text)
- [x] Added negative test for `command` field (pre-existing behavior, still covered)
- [x] Kept/updated positive tests proving `env` substitution still works (single-secret and named-secret modes)
- [x] `pnpm --filter vaultkeeper test` — 577/577 passing
- [x] `pnpm check` — typecheck, lint, and API report all green