### PR TITLE
Fix stale package.json#types and add packed-install packaging tests

### DIFF
--- a/.changeset/fix-bin-ownership-and-types-packaging.md
+++ b/.changeset/fix-bin-ownership-and-types-packaging.md
@@ -1,0 +1,9 @@
+---
+"vaultkeeper": patch
+"@vaultkeeper/test-helpers": patch
+"@vaultkeeper/cli-test-helpers": patch
+---
+
+Remove the top-level `package.json#types` field, which pointed at an API Extractor rollup (`dist/<name>-public.d.ts`) that the release pipeline never generates before `changeset publish` and was therefore absent from the published tarball. Types now resolve entirely through the conditional `exports` map, which already pointed at the real per-format `tsup` output. `@vaultkeeper/cli-test-helpers`'s `exports` conditions, which had the same stale rollup reference, now point at the real `dist/index.d.ts` / `dist/index.d.cts` files as well.
+
+Confirms (and now enforces via a packaging test) that only `@vaultkeeper/cli` declares the `vaultkeeper` bin — the `vaultkeeper` library package was already free of a `bin` field in this repo, but the registry had previously observed contradictory bin ownership across published versions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,34 +62,35 @@ All workspace-level scripts use Nx for dependency-graph-aware execution with cac
 
 ### Workspace-level scripts
 
-| Script | Purpose |
-|--------|---------|
-| `pnpm build` | Build all TS packages (Nx resolves dependency order) |
-| `pnpm clean` | Clean all packages |
-| `pnpm test` | Run all tests across all packages |
-| `pnpm test:watch` | Run tests in watch mode (vitest workspace) |
-| `pnpm check` | Run typecheck + lint + API report validation |
-| `pnpm check:typecheck` | `tsc --noEmit` in all packages |
-| `pnpm check:lint-ts` | `eslint .` in all packages |
-| `pnpm check:api-report` | Validate API reports |
-| `pnpm generate:api-report` | Update API reports |
+| Script                     | Purpose                                              |
+| -------------------------- | ---------------------------------------------------- |
+| `pnpm build`               | Build all TS packages (Nx resolves dependency order) |
+| `pnpm clean`               | Clean all packages                                   |
+| `pnpm test`                | Run all tests across all packages                    |
+| `pnpm test:watch`          | Run tests in watch mode (vitest workspace)           |
+| `pnpm check`               | Run typecheck + lint + API report validation         |
+| `pnpm check:typecheck`     | `tsc --noEmit` in all packages                       |
+| `pnpm check:lint-ts`       | `eslint .` in all packages                           |
+| `pnpm check:api-report`    | Validate API reports                                 |
+| `pnpm generate:api-report` | Update API reports                                   |
 
 ### Rust builds
 
 Rust builds are separate from Nx (Cargo manages its own dependency graph):
 
-| Command | Purpose |
-|---------|---------|
-| `cargo build` | Build all Rust crates |
-| `cargo test` | Run all Rust tests (130 tests) |
-| `cargo clippy` | Lint Rust code |
-| `wasm-pack build --target nodejs crates/vaultkeeper-wasm` | Build WASM module |
+| Command                                                   | Purpose                        |
+| --------------------------------------------------------- | ------------------------------ |
+| `cargo build`                                             | Build all Rust crates          |
+| `cargo test`                                              | Run all Rust tests (130 tests) |
+| `cargo clippy`                                            | Lint Rust code                 |
+| `wasm-pack build --target nodejs crates/vaultkeeper-wasm` | Build WASM module              |
 
 The WASM output (`packages/vaultkeeper-wasm/wasm/`) is committed to git so TypeScript builds work without wasm-pack installed.
 
 ### Package-level (run with `--filter`)
 
 Use `pnpm --filter <name>` to target a specific package:
+
 - `pnpm --filter vaultkeeper build`
 - `pnpm --filter @vaultkeeper/wasm test`
 
@@ -159,6 +160,7 @@ Tests use vitest (except `@vaultkeeper/wasm` which uses `node:test`). Coverage c
 ### Conformance testing
 
 Both CLIs (Rust native and TS) are tested against the same data-driven test cases:
+
 1. Cases defined in `crates/vaultkeeper-conformance/src/lib.rs`
 2. Exported as JSON via `cargo run -p export-conformance`
 3. JS runner in `packages/cli-tests/test/conformance/` loads `cases.json` and tests the Rust binary
@@ -206,6 +208,7 @@ Generated files in `**/wasm/**` (wasm-pack output) are excluded from linting.
 API Extractor v7 (`@microsoft/api-extractor`) is configured per-package in `api-extractor.json`. Each package generates its own `.d.ts` rollup and API report.
 
 Workflow:
+
 1. `pnpm build` — produces `dist/*.d.ts` source files
 2. `pnpm generate:api-report` — updates API reports in all packages
 3. Commit `api-report/` when the public API changes
@@ -213,11 +216,14 @@ Workflow:
 
 Every exported symbol in a package's `src/index.ts` must have a `@public` or `@packageDocumentation` JSDoc tag (or be marked `@internal` / `@alpha` / `@beta` if not yet stable).
 
+Publishable dual ESM/CJS packages (`vaultkeeper`, `@vaultkeeper/test-helpers`, `@vaultkeeper/cli-test-helpers`) do not set a top-level `package.json#types` field. The API Extractor `dtsRollup` output (`dist/<name>-public.d.ts`) is only produced by `generate:api-report`/`check:api-report`, which the release pipeline does not run before `changeset publish` — a top-level `types` pointing at it would reference a file missing from the published tarball. Types resolve entirely through the conditional `exports` map (`import.types` / `require.types`, pointing at the real per-format `tsup` output), which is sufficient for `moduleResolution: NodeNext`/`bundler` consumers and is what the packed-install and pack-contents tests in `packages/cli-tests/test/packaging/` verify.
+
 ## Conventions
 
 ### Errors
 
 All errors extend `VaultError` (defined in `packages/vaultkeeper/src/errors.ts`). When adding a new error class:
+
 - Extend the closest existing base (e.g. `VaultError` directly if no better parent exists)
 - Set `this.name` in the constructor to match the class name
 - Add strongly-typed extra fields for machine-readable context

--- a/packages/cli-test-helpers/package.json
+++ b/packages/cli-test-helpers/package.json
@@ -12,15 +12,14 @@
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/cli-test-helpers-public.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/cli-test-helpers-public.d.ts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       },
       "require": {
-        "types": "./dist/cli-test-helpers-public.d.ts",
+        "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
     }

--- a/packages/cli-tests/test/packaging/packaging.test.ts
+++ b/packages/cli-tests/test/packaging/packaging.test.ts
@@ -234,17 +234,31 @@ describe.each(publishablePackageDirs)('packaging: packages/%s', (packageDir) => 
   })
 })
 
+/**
+ * npm's `bin` field has two shapes: an object mapping command name -> script
+ * (`{ "vaultkeeper": "./dist/bin.js" }`), or a string shorthand
+ * (`"./dist/bin.js"`) which declares a single command named after the
+ * package itself — the unscoped portion for scoped packages, e.g.
+ * `@vaultkeeper/cli` -> `cli`. See
+ * https://docs.npmjs.com/cli/v10/configuring-npm/package-json#bin.
+ */
+function declaredBinCommandNames(pkg: PackageJson): string[] {
+  if (pkg.bin === undefined) {
+    return []
+  }
+  if (typeof pkg.bin === 'string') {
+    const slashIndex = pkg.name.lastIndexOf('/')
+    return [slashIndex === -1 ? pkg.name : pkg.name.slice(slashIndex + 1)]
+  }
+  return Object.keys(pkg.bin)
+}
+
 describe('bin ownership', () => {
   it('declares the vaultkeeper bin in exactly one publishable package, @vaultkeeper/cli', async () => {
     const packages = await Promise.all(publishablePackageDirs.map((dir) => readPackageJson(dir)))
 
     const ownersOfVaultkeeperBin = packages
-      .filter((pkg) => {
-        if (typeof pkg.bin === 'string') {
-          return false
-        }
-        return pkg.bin !== undefined && 'vaultkeeper' in pkg.bin
-      })
+      .filter((pkg) => declaredBinCommandNames(pkg).includes('vaultkeeper'))
       .map((pkg) => pkg.name)
 
     expect(ownersOfVaultkeeperBin).toEqual(['@vaultkeeper/cli'])

--- a/packages/cli-tests/test/packaging/packaging.test.ts
+++ b/packages/cli-tests/test/packaging/packaging.test.ts
@@ -1,7 +1,11 @@
 /**
  * Packaging tests for every publishable package: asserts that `npm pack` would
- * include a README.md and that package.json carries repository/homepage/bugs
- * metadata. See https://github.com/mike-north/vaultkeeper/issues/63.
+ * include a README.md, that package.json carries repository/homepage/bugs
+ * metadata, that every file path referenced by package.json (main/types/
+ * module/exports/bin) actually exists in the packed tarball, and that exactly
+ * one package (`@vaultkeeper/cli`) declares the `vaultkeeper` bin.
+ * See https://github.com/mike-north/vaultkeeper/issues/63 and
+ * https://github.com/mike-north/vaultkeeper/issues/64.
  *
  * Uses `npm pack --dry-run --json` specifically because it is the tool that
  * simulates the registry's tarball-inclusion rules (README/LICENSE are always
@@ -34,11 +38,18 @@ interface RepositoryField {
   directory?: string
 }
 
+type ExportsValue = string | { [condition: string]: ExportsValue }
+
 interface PackageJson {
   name: string
   homepage?: string
   bugs?: string
   repository?: RepositoryField | string
+  main?: string
+  module?: string
+  types?: string
+  bin?: string | Record<string, string>
+  exports?: ExportsValue
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -68,6 +79,17 @@ function isRepositoryField(value: unknown): value is RepositoryField {
   )
 }
 
+function isExportsValue(value: unknown): value is ExportsValue {
+  if (typeof value === 'string') {
+    return true
+  }
+  return isPlainObject(value) && Object.values(value).every(isExportsValue)
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isPlainObject(value) && Object.values(value).every((v) => typeof v === 'string')
+}
+
 function isPackageJson(value: unknown): value is PackageJson {
   if (!isPlainObject(value)) {
     return false
@@ -88,7 +110,55 @@ function isPackageJson(value: unknown): value is PackageJson {
   ) {
     return false
   }
+  if (value.main !== undefined && typeof value.main !== 'string') {
+    return false
+  }
+  if (value.module !== undefined && typeof value.module !== 'string') {
+    return false
+  }
+  if (value.types !== undefined && typeof value.types !== 'string') {
+    return false
+  }
+  if (value.bin !== undefined && typeof value.bin !== 'string' && !isStringRecord(value.bin)) {
+    return false
+  }
+  if (value.exports !== undefined && !isExportsValue(value.exports)) {
+    return false
+  }
   return true
+}
+
+/**
+ * Collects every relative file path referenced by main/module/types/bin/exports,
+ * so each one can be checked against the packed tarball's file list.
+ */
+function collectDeclaredPaths(pkg: PackageJson): string[] {
+  const paths: string[] = []
+
+  if (pkg.main !== undefined) paths.push(pkg.main)
+  if (pkg.module !== undefined) paths.push(pkg.module)
+  if (pkg.types !== undefined) paths.push(pkg.types)
+
+  if (typeof pkg.bin === 'string') {
+    paths.push(pkg.bin)
+  } else if (pkg.bin !== undefined) {
+    paths.push(...Object.values(pkg.bin))
+  }
+
+  function collectExportsLeaves(value: ExportsValue): void {
+    if (typeof value === 'string') {
+      paths.push(value)
+      return
+    }
+    for (const nested of Object.values(value)) {
+      collectExportsLeaves(nested)
+    }
+  }
+  if (pkg.exports !== undefined) {
+    collectExportsLeaves(pkg.exports)
+  }
+
+  return paths
 }
 
 const publishablePackageDirs = [
@@ -140,5 +210,48 @@ describe.each(publishablePackageDirs)('packaging: packages/%s', (packageDir) => 
     expect(pkg.repository.type).toBe('git')
     expect(pkg.repository.url).toBe('git+https://github.com/mike-north/vaultkeeper.git')
     expect(pkg.repository.directory).toBe(`packages/${packageDir}`)
+  })
+
+  it('has every main/module/types/bin/exports path present in the packed tarball', async () => {
+    const [pkg, pack] = await Promise.all([
+      readPackageJson(packageDir),
+      runNpmPackDryRun(packageDir),
+    ])
+    const filePaths = new Set(pack.files.map((f) => f.path))
+    const declaredPaths = collectDeclaredPaths(pkg)
+
+    // Regression guard for https://github.com/mike-north/vaultkeeper/issues/64:
+    // package.json#types previously pointed at an API Extractor rollup file
+    // that the release pipeline never generates, so it was absent from the
+    // published tarball. This assertion fails against that pre-fix state.
+    for (const declaredPath of declaredPaths) {
+      const normalized = declaredPath.startsWith('./') ? declaredPath.slice(2) : declaredPath
+      expect(
+        filePaths,
+        `${packageDir}: declared path "${declaredPath}" missing from tarball`,
+      ).toContain(normalized)
+    }
+  })
+})
+
+describe('bin ownership', () => {
+  it('declares the vaultkeeper bin in exactly one publishable package, @vaultkeeper/cli', async () => {
+    const packages = await Promise.all(publishablePackageDirs.map((dir) => readPackageJson(dir)))
+
+    const ownersOfVaultkeeperBin = packages
+      .filter((pkg) => {
+        if (typeof pkg.bin === 'string') {
+          return false
+        }
+        return pkg.bin !== undefined && 'vaultkeeper' in pkg.bin
+      })
+      .map((pkg) => pkg.name)
+
+    expect(ownersOfVaultkeeperBin).toEqual(['@vaultkeeper/cli'])
+  })
+
+  it('declares no bin field on the vaultkeeper library package', async () => {
+    const pkg = await readPackageJson('vaultkeeper')
+    expect(pkg.bin).toBeUndefined()
   })
 })

--- a/packages/cli-tests/test/packaging/packed-install.test.ts
+++ b/packages/cli-tests/test/packaging/packed-install.test.ts
@@ -34,7 +34,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '..', '..', '..', '..')
 
 interface PnpmPackResult {
-  filename: string
+  // pnpm's `pack --json` output has varied across versions: some emit
+  // `filename` (observed as a full path under --pack-destination on the
+  // pnpm version pinned in this repo's packageManager field), others emit
+  // `tarball` (documented as a basename). Accept either and resolve
+  // whichever we get against destDir so this doesn't drift silently.
+  filename?: string
+  tarball?: string
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -48,7 +54,16 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 function isPnpmPackResult(value: unknown): value is PnpmPackResult {
-  return isPlainObject(value) && typeof value.filename === 'string'
+  if (!isPlainObject(value)) {
+    return false
+  }
+  if (value.filename !== undefined && typeof value.filename !== 'string') {
+    return false
+  }
+  if (value.tarball !== undefined && typeof value.tarball !== 'string') {
+    return false
+  }
+  return typeof value.filename === 'string' || typeof value.tarball === 'string'
 }
 
 interface PackageJsonVersion {
@@ -70,8 +85,15 @@ async function pnpmPack(packageDir: string, destDir: string): Promise<string> {
   if (!isPnpmPackResult(parsed)) {
     throw new Error(`Unexpected pnpm pack output for ${packageDir}: ${stdout}`)
   }
-  // pnpm pack --json's `filename` is already the full path under --pack-destination.
-  return parsed.filename
+  const tarballPath = parsed.filename ?? parsed.tarball
+  if (tarballPath === undefined) {
+    throw new Error(
+      `pnpm pack output for ${packageDir} had neither filename nor tarball: ${stdout}`,
+    )
+  }
+  // Resolve against destDir in case this pnpm version returned a basename
+  // (`tarball`) rather than the full path (`filename`).
+  return path.isAbsolute(tarballPath) ? tarballPath : path.join(destDir, tarballPath)
 }
 
 const tempDirs: string[] = []
@@ -122,7 +144,11 @@ describe('packed-install smoke test', () => {
       },
     )
 
-    const versionResult = await execFileAsync('npx', ['vaultkeeper', '--version'], {
+    // --no-install keeps this hermetic: if the local bin link is missing —
+    // the exact regression this test guards against — npx must fail rather
+    // than silently falling back to fetching `vaultkeeper` from the
+    // registry, which would mask the bug (and introduce network flakiness).
+    const versionResult = await execFileAsync('npx', ['--no-install', 'vaultkeeper', '--version'], {
       cwd: projectDir,
     })
     expect(versionResult.stdout.trim()).toBe(expectedCliVersion)

--- a/packages/cli-tests/test/packaging/packed-install.test.ts
+++ b/packages/cli-tests/test/packaging/packed-install.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Packed-install smoke test: builds real tarballs for `vaultkeeper` and
+ * `@vaultkeeper/cli`, installs them into an isolated temp project the same
+ * way an end user would (`npm install <tarball>`), then drives the packages
+ * through their public entry points — `npx vaultkeeper --version` and
+ * `import('vaultkeeper')`. Unlike packaging.test.ts (which only inspects
+ * `npm pack --dry-run` file listings), this test actually installs and runs
+ * the packed output, so it catches defects that only manifest once npm's
+ * bin-linking and module resolution run for real — the two failure modes
+ * from https://github.com/mike-north/vaultkeeper/issues/64:
+ *   - contradictory/missing bin ownership ("could not determine executable
+ *     to run")
+ *   - a `types`/`main`/`exports` path that doesn't exist in the tarball,
+ *     which breaks module resolution even though `npm pack --dry-run` may
+ *     still succeed
+ *
+ * Uses `pnpm pack` (not `npm pack`) to produce the installable tarballs
+ * because pnpm rewrites `workspace:*` dependency ranges to the real resolved
+ * semver version at pack time; `npm pack` would leave the literal string
+ * "workspace:*" in the tarball's package.json, which is not installable
+ * outside a pnpm workspace.
+ */
+import { describe, it, expect, afterAll } from 'vitest'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const execFileAsync = promisify(execFile)
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..')
+
+interface PnpmPackResult {
+  filename: string
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype &&
+    Object.getOwnPropertySymbols(value).length === 0
+  )
+}
+
+function isPnpmPackResult(value: unknown): value is PnpmPackResult {
+  return isPlainObject(value) && typeof value.filename === 'string'
+}
+
+interface PackageJsonVersion {
+  version: string
+}
+
+function isPackageJsonVersion(value: unknown): value is PackageJsonVersion {
+  return isPlainObject(value) && typeof value.version === 'string'
+}
+
+async function pnpmPack(packageDir: string, destDir: string): Promise<string> {
+  const cwd = path.join(repoRoot, 'packages', packageDir)
+  const { stdout } = await execFileAsync(
+    'pnpm',
+    ['pack', '--pack-destination', destDir, '--json'],
+    { cwd },
+  )
+  const parsed: unknown = JSON.parse(stdout)
+  if (!isPnpmPackResult(parsed)) {
+    throw new Error(`Unexpected pnpm pack output for ${packageDir}: ${stdout}`)
+  }
+  // pnpm pack --json's `filename` is already the full path under --pack-destination.
+  return parsed.filename
+}
+
+const tempDirs: string[] = []
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+afterAll(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('packed-install smoke test', () => {
+  it('installs the packed tarballs and resolves the vaultkeeper bin and library entry point', async () => {
+    const packDestination = await makeTempDir('vaultkeeper-pack-')
+    const [vaultkeeperTarball, cliTarball] = await Promise.all([
+      pnpmPack('vaultkeeper', packDestination),
+      pnpmPack('cli', packDestination),
+    ])
+
+    const cliPackageJsonRaw = await readFile(
+      path.join(repoRoot, 'packages', 'cli', 'package.json'),
+      'utf8',
+    )
+    const cliPackageJson: unknown = JSON.parse(cliPackageJsonRaw)
+    if (!isPackageJsonVersion(cliPackageJson)) {
+      throw new Error('Could not read @vaultkeeper/cli package.json#version')
+    }
+    const expectedCliVersion = cliPackageJson.version
+
+    const projectDir = await makeTempDir('vaultkeeper-install-')
+    await writeFile(
+      path.join(projectDir, 'package.json'),
+      JSON.stringify(
+        { name: 'vaultkeeper-packed-install-smoke-test', version: '0.0.0', private: true },
+        null,
+        2,
+      ),
+    )
+
+    await execFileAsync(
+      'npm',
+      ['install', '--no-save', '--no-audit', '--no-fund', vaultkeeperTarball, cliTarball],
+      {
+        cwd: projectDir,
+      },
+    )
+
+    const versionResult = await execFileAsync('npx', ['vaultkeeper', '--version'], {
+      cwd: projectDir,
+    })
+    expect(versionResult.stdout.trim()).toBe(expectedCliVersion)
+
+    const importResult = await execFileAsync(
+      'node',
+      ['-e', "import('vaultkeeper').then(m => console.log(typeof m.VaultKeeper))"],
+      { cwd: projectDir },
+    )
+    expect(importResult.stdout.trim()).toBe('function')
+  }, 120_000)
+})

--- a/packages/cli-tests/test/packaging/packed-install.test.ts
+++ b/packages/cli-tests/test/packaging/packed-install.test.ts
@@ -153,11 +153,18 @@ describe('packed-install smoke test', () => {
     })
     expect(versionResult.stdout.trim()).toBe(expectedCliVersion)
 
+    // Asserts only that module resolution succeeds — not on any specific
+    // export name — so this doesn't couple a packaging test to the library's
+    // runtime API surface. execFileAsync rejects (and fails the test) on a
+    // non-zero exit, which `.catch` triggers on import rejection.
     const importResult = await execFileAsync(
       'node',
-      ['-e', "import('vaultkeeper').then(m => console.log(typeof m.VaultKeeper))"],
+      [
+        '-e',
+        "import('vaultkeeper').then(() => console.log('import-ok')).catch((err) => { console.error(err); process.exit(1) })",
+      ],
       { cwd: projectDir },
     )
-    expect(importResult.stdout.trim()).toBe('function')
+    expect(importResult.stdout.trim()).toBe('import-ok')
   }, 120_000)
 })

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -12,7 +12,6 @@
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/test-helpers-public.d.ts",
   "exports": {
     ".": {
       "import": {

--- a/packages/vaultkeeper/package.json
+++ b/packages/vaultkeeper/package.json
@@ -12,7 +12,6 @@
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "./dist/vaultkeeper-public.d.ts",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
## Summary

Refs #64

Bin ownership was already correct in this repo (only `@vaultkeeper/cli` declares the `vaultkeeper` bin; the `vaultkeeper` library package declares none) — the registry's contradictory bin ownership across published versions had no in-repo counterpart to fix, so this PR focuses on the two defects that were reproducible locally, plus the tests that would have caught all three:

- **`package.json#types` pointed at a file the release pipeline never produces.** `vaultkeeper`, `@vaultkeeper/test-helpers`, and `@vaultkeeper/cli-test-helpers` all had a top-level `types` field pointing at an API Extractor `dtsRollup` output (`dist/<name>-public.d.ts`). That file is only generated by `generate:api-report`/`check:api-report`, and `.github/workflows/release.yml` runs `pnpm build` (tsup only) before `changeset publish` — it never runs API Extractor. The rollup was therefore never in the published tarball. Removed the top-level `types` field from all three packages in favor of the already-correct conditional `exports` map (`import.types`/`require.types`, pointing at the real per-format `tsup` output); `@vaultkeeper/cli-test-helpers`'s `exports` conditions had the same stale rollup reference and now point at the real files too. Rationale documented in `CLAUDE.md`'s API Extractor section.
- **Packed-install and pack-contents packaging tests** (extends `packages/cli-tests/test/packaging/packaging.test.ts`, adds `packed-install.test.ts`):
  - Every `main`/`module`/`types`/`bin`/`exports` path declared in each publishable package's `package.json` is checked against the actual `npm pack --dry-run` file listing.
  - Exactly one publishable package (`@vaultkeeper/cli`) declares the `vaultkeeper` bin.
  - A full install smoke test: `pnpm pack` (not `npm pack` — pnpm rewrites `workspace:*` to a real semver range) both `vaultkeeper` and `@vaultkeeper/cli`, install both tarballs into an isolated temp project with `npm install`, then assert `npx vaultkeeper --version` prints the CLI's own `package.json` version (read at runtime, never hardcoded) and `node -e "import('vaultkeeper')"` resolves.

Each new test was verified to fail against the pre-fix state (temporarily reintroducing the broken `types` field, and temporarily deleting `@vaultkeeper/cli`'s `bin` field, reproduced `npm error could not determine executable to run` — the exact failure from the issue).

Changesets added for the three packages whose `package.json` changed (`vaultkeeper`, `@vaultkeeper/test-helpers`, `@vaultkeeper/cli-test-helpers`); `@vaultkeeper/cli` was unchanged so no changeset was needed for it.

## Acceptance criteria mapping

1. Exactly one package declares the `vaultkeeper` bin — `packaging.test.ts > bin ownership` (2 tests)
2. `vaultkeeper#types` points at a real packed file or is removed — `packages/vaultkeeper/package.json` (removed, exports-only; rationale in `CLAUDE.md`)
3. Packed-install smoke test in CI — `packed-install.test.ts` (runs via the existing `pnpm test` CI step, no workflow change needed)
4. Pack-time assertion that every package.json path entry exists in the tarball — `packaging.test.ts > has every main/module/types/bin/exports path present in the packed tarball` (one test per publishable package)
5. Changesets for changed publishable packages — `.changeset/fix-bin-ownership-and-types-packaging.md`

## Test plan

- [x] `pnpm check` (typecheck + lint + API report) green
- [x] `pnpm test` green, including new `packages/cli-tests/test/packaging/packed-install.test.ts` and extended `packaging.test.ts`
- [x] Confirmed both new tests fail against the pre-fix state (stale `types`, missing `bin`) and pass against the fix
- [x] `pnpm exec prettier --check` clean on all changed files