### PR TITLE
Non-interactive exec: trusted callers skip the prompt; --yes/VAULTKEEPER_YES for CI

### DIFF
--- a/.changeset/noninteractive-exec.md
+++ b/.changeset/noninteractive-exec.md
@@ -1,0 +1,5 @@
+---
+'@vaultkeeper/cli': minor
+---
+
+`vaultkeeper exec` can now run non-interactively. A caller already recorded in the TOFU trust manifest (via `approve` or a prior approval) runs without any prompt on a TTY or not. A new explicit opt-in — the `--yes` flag and the `VAULTKEEPER_YES=1` environment variable — approves an untrusted caller for a single invocation without prompting, recording the approval the same way an interactive `y` would. Without trust and without `--yes`, an untrusted caller on non-TTY stdin still fails, but the error now tells you exactly how to proceed (`vaultkeeper approve --script <caller>` or `--yes`). `exec --help` documents the TTY requirement and both escape hatches, and the README gains a "Running in CI" note. A caller whose contents changed since approval is never auto-approved by `--yes`; it must be re-approved with `vaultkeeper approve`.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ vaultkeeper rotate-key
 vaultkeeper revoke-key
 ```
 
+### Running in CI
+
+`vaultkeeper exec` requires approval the first time a caller requests a secret.
+On an interactive terminal you are prompted `[y/N]`; with non-TTY stdin (CI,
+Docker) there is no prompt, so approve the caller ahead of time — or approve a
+single invocation with `--yes` (or `VAULTKEEPER_YES=1`). The `file` backend needs
+no system credential store, which makes it a good fit for CI.
+
+```sh
+# Recommended: pre-approve the caller once, then exec runs unattended.
+vaultkeeper approve --script "$CI_SCRIPT"
+echo "$MY_SECRET" | vaultkeeper store --name MY_API_KEY
+vaultkeeper exec --secret MY_API_KEY --env API_KEY --caller "$CI_SCRIPT" -- ./deploy.sh
+
+# Or approve a single run non-interactively (records the caller for next time):
+vaultkeeper exec --yes --secret MY_API_KEY --env API_KEY --caller "$CI_SCRIPT" -- ./deploy.sh
+# equivalently: VAULTKEEPER_YES=1 vaultkeeper exec --secret MY_API_KEY ...
+```
+
+A caller whose contents changed since approval is never silently trusted — you
+must re-approve it with `vaultkeeper approve --script <caller>`.
+
 ## TypeScript quick start
 
 ```ts

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -11,7 +11,13 @@
  * Secrets use the file backend under an isolated HOME so no OS credential
  * store is touched.
  *
+ * Issue #58 (non-interactive exec) adds coverage for the CI escape hatches:
+ * `--yes` and `VAULTKEEPER_YES` approve an untrusted caller without a prompt and
+ * record the approval, and an untrusted caller on non-TTY stdin fails with
+ * actionable remediation.
+ *
  * @see https://github.com/mike-north/vaultkeeper/issues/57
+ * @see https://github.com/mike-north/vaultkeeper/issues/58
  */
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
@@ -50,7 +56,7 @@ async function writeCaller(contents: string): Promise<string> {
   return caller
 }
 
-function execArgs(caller: string): string[] {
+function execArgs(caller: string, extraFlags: string[] = []): string[] {
   return [
     'exec',
     '--secret',
@@ -59,6 +65,9 @@ function execArgs(caller: string): string[] {
     'INJECTED',
     '--caller',
     caller,
+    // Extra exec flags must go BEFORE the `--` separator, or they would be
+    // parsed as part of the wrapped command instead of as exec options.
+    ...extraFlags,
     '--',
     'sh',
     '-c',
@@ -67,8 +76,8 @@ function execArgs(caller: string): string[] {
 }
 
 describe('exec trust gate', () => {
-  // Criterion 3: after approve, exec with a matching caller does NOT prompt
-  // and reports a trusted state — proven on non-TTY stdin.
+  // Issue #57 criterion 3 / issue #58 criterion 1: after approve, a trusted
+  // caller runs exec with NO prompt on non-TTY stdin, reporting a trusted state.
   it('does not prompt for an approved caller and injects the secret', async () => {
     if (env === undefined) throw new Error('env not initialized')
     const caller = await writeCaller('#!/bin/sh\necho hi\n')
@@ -121,15 +130,94 @@ describe('exec trust gate', () => {
     expect(result.stdout).not.toContain('ready=yes')
   })
 
-  // Criterion 3/5 contrast: an unapproved caller is also untrusted and reaches
-  // the prompt gate (fails on non-TTY stdin).
-  it('treats a never-approved caller as untrusted', async () => {
+  // Issue #58, criterion 3: a never-approved caller on non-TTY stdin fails, but
+  // the error tells the user exactly how to proceed non-interactively — pre-approve
+  // with `approve --script`, or re-run with --yes / VAULTKEEPER_YES.
+  it('fails an untrusted caller on non-TTY stdin with actionable remediation', async () => {
     if (env === undefined) throw new Error('env not initialized')
     const caller = await writeCaller('#!/bin/sh\necho hi\n')
 
     const result = await env.run(execArgs(caller))
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).not.toContain('Trust: verified')
-    expect(result.stderr).toContain('interactive approval')
+    expect(result.stdout).not.toContain('ready=yes')
+    expect(result.stderr).toContain(`vaultkeeper approve --script ${caller}`)
+    expect(result.stderr).toContain('--yes')
+    expect(result.stderr).toContain('VAULTKEEPER_YES=1')
+  })
+
+  // Issue #58, criterion 2: --yes approves an untrusted caller non-interactively
+  // (non-TTY stdin) AND records the approval, so a later exec without --yes is
+  // trusted and needs no prompt.
+  it('approves an untrusted caller with --yes and records trust for later runs', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+
+    const first = await env.run(execArgs(caller, ['--yes']))
+    expect(first.exitCode).toBe(0)
+    expect(first.stdout).toContain('ready=yes')
+    expect(first.stderr).toContain('approved via --yes')
+    expect(first.stderr).not.toMatch(/Allow\?|\[y\/N\]/)
+
+    // The approval was recorded: a subsequent run WITHOUT --yes is trusted.
+    const second = await env.run(execArgs(caller))
+    expect(second.exitCode).toBe(0)
+    expect(second.stdout).toContain('ready=yes')
+    expect(second.stderr).toContain('Trust: verified')
+  })
+
+  // Issue #58, criterion 2: VAULTKEEPER_YES=1 is equivalent to --yes and records
+  // the approval in the trust manifest.
+  it('approves an untrusted caller via VAULTKEEPER_YES=1 and records it in the manifest', async () => {
+    const yesEnv = await createCliTestEnv({
+      env: { HOME: homeDir, VAULTKEEPER_SKIP_DOCTOR: '1', VAULTKEEPER_YES: '1' },
+    })
+    try {
+      const stored = await yesEnv.runWithStdin(
+        ['store', '--name', SECRET_NAME],
+        `${SECRET_VALUE}\n`,
+      )
+      expect(stored.exitCode).toBe(0)
+
+      const caller = path.join(homeDir, 'yes-env-caller.sh')
+      await fs.writeFile(caller, '#!/bin/sh\necho hi\n', { mode: 0o755 })
+
+      const result = await yesEnv.run(execArgs(caller))
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('ready=yes')
+      expect(result.stderr).toContain('approved via --yes')
+      expect(result.stderr).not.toMatch(/Allow\?|\[y\/N\]/)
+
+      // The approval was recorded in the trust manifest under the caller's path.
+      const manifestRaw = await fs.readFile(
+        path.join(yesEnv.configDir, 'trust-manifest.json'),
+        'utf8',
+      )
+      const manifest: unknown = JSON.parse(manifestRaw)
+      if (
+        typeof manifest !== 'object' ||
+        manifest === null ||
+        !('entries' in manifest) ||
+        typeof manifest.entries !== 'object' ||
+        manifest.entries === null
+      ) {
+        throw new Error('trust manifest missing entries object')
+      }
+      expect(Object.keys(manifest.entries)).toContain(path.resolve(caller))
+    } finally {
+      await yesEnv.cleanup()
+    }
+  })
+
+  // Issue #58, criterion 4: exec --help documents the TTY requirement and both
+  // escape hatches, proven against the real CLI subprocess.
+  it('documents the TTY requirement and escape hatches in exec --help', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const result = await env.run(['exec', '--help'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('--yes')
+    expect(result.stdout).toContain('VAULTKEEPER_YES')
+    expect(result.stdout).toContain('non-TTY')
+    expect(result.stdout).toContain('vaultkeeper approve --script')
   })
 })

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -126,7 +126,8 @@ describe('exec trust gate', () => {
     // Fails on the hash mismatch, not the interactive prompt.
     expect(result.stderr).not.toContain('interactive approval')
     expect(result.stderr).toContain('has changed since it was approved')
-    expect(result.stderr).toContain(`vaultkeeper approve --script ${caller}`)
+    // The path is shell-quoted so the suggested command is copy-paste safe.
+    expect(result.stderr).toContain(`vaultkeeper approve --script '${caller}'`)
     expect(result.stdout).not.toContain('ready=yes')
   })
 
@@ -141,7 +142,8 @@ describe('exec trust gate', () => {
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).not.toContain('Trust: verified')
     expect(result.stdout).not.toContain('ready=yes')
-    expect(result.stderr).toContain(`vaultkeeper approve --script ${caller}`)
+    // The path is shell-quoted so the suggested command is copy-paste safe.
+    expect(result.stderr).toContain(`vaultkeeper approve --script '${caller}'`)
     expect(result.stderr).toContain('--yes')
     expect(result.stderr).toContain('VAULTKEEPER_YES=1')
   })

--- a/packages/cli/src/auto-approve.ts
+++ b/packages/cli/src/auto-approve.ts
@@ -1,0 +1,18 @@
+/**
+ * Determine whether an untrusted caller's approval prompt should be skipped
+ * non-interactively for this invocation.
+ *
+ * Checks the `--yes` flag value and the `VAULTKEEPER_YES` env var. This is an
+ * explicit, opt-in escape hatch for non-interactive/CI use — it is never the
+ * default. It only applies to a caller that is not yet in the trust manifest;
+ * a caller whose recorded hash changed (identity mismatch) is never
+ * auto-approved and must be re-approved with `vaultkeeper approve`.
+ *
+ * @param flagValue - The parsed `--yes` flag value from parseArgs.
+ * @returns `true` if the interactive approval should be skipped and the caller
+ *   approved for this invocation.
+ * @internal
+ */
+export function shouldAutoApprove(flagValue: boolean): boolean {
+  return flagValue || process.env.VAULTKEEPER_YES === '1'
+}

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -4,7 +4,10 @@
  * Flow:
  * 1. Parse flags and the command after `--`
  * 2. Enforce the TOFU trust gate for the caller (runs on every invocation,
- *    including `--cache` hits, so a cached token never bypasses trust)
+ *    including `--cache` hits, so a cached token never bypasses trust). A
+ *    trusted caller passes without a prompt; an untrusted caller is prompted
+ *    interactively, unless `--yes`/`VAULTKEEPER_YES` approves it non-interactively
+ *    or, on non-TTY stdin, the command fails with remediation guidance
  * 3. If `--cache`, check for a cached JWE token; otherwise retrieve and setup
  *    the secret into a fresh JWE
  * 4. Authorize the JWE → obtain a CapabilityToken
@@ -30,6 +33,7 @@ import { promptApproval } from '../approval.js'
 import { readCachedToken, writeCachedToken, invalidateCache } from '../cache.js'
 import { RedactingStream } from '../redact.js'
 import { shouldSkipDoctor } from '../skip-doctor.js'
+import { shouldAutoApprove } from '../auto-approve.js'
 import { formatError } from '../output.js'
 
 /**
@@ -44,20 +48,29 @@ import { formatError } from '../output.js'
  *   since approval): throws {@link IdentityMismatchError} with re-approval
  *   guidance. It does not prompt — `VaultKeeper.setup()` rejects the same hash
  *   conflict regardless of the user's answer, so prompting would waste it.
- * - **Never approved**: shows an interactive approval prompt and returns its
- *   result (`false` if the user declines).
+ *   `autoApprove` never overrides this: a changed binary must be re-approved
+ *   with `vaultkeeper approve`, not silently trusted.
+ * - **Never approved**, with `autoApprove` set (`--yes`/`VAULTKEEPER_YES`):
+ *   returns `true` without prompting. The subsequent `setup()` records the
+ *   caller's hash via TOFU, exactly as an interactive `y` would.
+ * - **Never approved**, non-TTY stdin, no `autoApprove`: throws with
+ *   remediation guidance (pre-approve via `vaultkeeper approve`, or re-run with
+ *   `--yes`) — there is no way to prompt.
+ * - **Never approved**, interactive TTY: shows an approval prompt and returns
+ *   its result (`false` if the user declines).
  *
  * @returns `true` if access is authorized, `false` if the user declined.
  * @throws {IdentityMismatchError} When the caller's hash changed from a
  *   previously approved value.
- * @throws When interactive approval is required but stdin is not a TTY, or when
- *   the caller path cannot be read for hashing.
+ * @throws When approval is required but cannot be obtained (non-TTY stdin
+ *   without `--yes`), or when the caller path cannot be read for hashing.
  */
 async function enforceTrustGate(
   vault: VaultKeeper,
   callerPath: string,
   secret: string,
   reason: string | undefined,
+  autoApprove: boolean,
 ): Promise<boolean> {
   const trust = await vault.checkExecutableTrust(callerPath)
   if (trust.trusted) {
@@ -78,6 +91,27 @@ async function enforceTrustGate(
     )
   }
 
+  // Never-approved caller. --yes / VAULTKEEPER_YES approves this invocation
+  // without prompting; setup() then records the hash via TOFU just as an
+  // interactive "y" would.
+  if (autoApprove) {
+    process.stderr.write('Trust: approved via --yes (recording caller in trust manifest)\n')
+    return true
+  }
+
+  // No non-interactive approval and no TTY to prompt on: fail with actionable
+  // guidance instead of the raw "requires interactive approval" error.
+  // isTTY is `true` only on a real terminal; `undefined`/`false` means non-TTY.
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      `Secret access for ${callerPath} requires approval, but stdin is not a TTY, ` +
+        `so no interactive prompt can be shown.\n` +
+        `To approve non-interactively, either:\n` +
+        `  - pre-approve the caller once:  vaultkeeper approve --script ${callerPath}\n` +
+        `  - or approve just this run:      re-run with --yes (or set VAULTKEEPER_YES=1)`,
+    )
+  }
+
   return promptApproval({
     caller: callerPath,
     trustInfo: 'Pending verification',
@@ -94,11 +128,22 @@ function printExecHelp(): void {
       '  --env <VAR>        Environment variable name to inject the secret into\n' +
       '  --caller <path>    Path to the calling executable (used for TOFU verification)\n' +
       '  --reason <text>    Human-readable reason for access (optional)\n' +
+      '  --yes              Approve an untrusted caller for this invocation without\n' +
+      '                     an interactive prompt, recording it in the trust manifest\n' +
+      '                     (for CI/non-interactive use; never the default)\n' +
       '  --cache            Cache the JWE token for subsequent invocations\n' +
       '  --no-redact        Do not redact the secret from output\n' +
       '  --skip-doctor      Skip doctor preflight checks\n' +
       '  -h, --help         Show this help message\n\n' +
+      'Approval and TTY requirement:\n' +
+      '  A caller that is not yet trusted requires approval. On an interactive\n' +
+      '  terminal you are prompted [y/N]. With non-TTY stdin (CI, pipes) there is\n' +
+      '  no prompt, so you must either pre-approve the caller with\n' +
+      '  `vaultkeeper approve --script <caller>` or pass --yes (or VAULTKEEPER_YES=1)\n' +
+      '  to approve this invocation. Once trusted, exec never prompts again.\n\n' +
       'Environment variables:\n' +
+      '  VAULTKEEPER_YES=1           Approve an untrusted caller non-interactively\n' +
+      '                              (same as --yes)\n' +
       '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n',
   )
 }
@@ -137,6 +182,7 @@ export async function execCommand(args: string[]): Promise<number> {
       env: { type: 'string' },
       caller: { type: 'string' },
       reason: { type: 'string' },
+      yes: { type: 'boolean', default: false },
       cache: { type: 'boolean', default: false },
       'no-redact': { type: 'boolean', default: false },
       'skip-doctor': { type: 'boolean', default: false },
@@ -159,6 +205,7 @@ export async function execCommand(args: string[]): Promise<number> {
   const useCache: boolean = values.cache
   const noRedact: boolean = values['no-redact']
   const skipDoctor = shouldSkipDoctor(values['skip-doctor'])
+  const autoApprove = shouldAutoApprove(values.yes)
 
   try {
     const vault = await VaultKeeper.init({ skipDoctor })
@@ -168,7 +215,7 @@ export async function execCommand(args: string[]): Promise<number> {
     // previously cached JWE can never let a modified or never-approved caller
     // inherit trust it no longer (or never) held. A modified caller surfaces an
     // identity-mismatch error here rather than silently reusing a cached token.
-    const approved = await enforceTrustGate(vault, callerPath, secret, values.reason)
+    const approved = await enforceTrustGate(vault, callerPath, secret, values.reason, autoApprove)
     if (!approved) {
       process.stderr.write('Access denied by user.\n')
       return 1

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -8,8 +8,9 @@
  *    trusted caller passes without a prompt; an untrusted caller is prompted
  *    interactively, unless `--yes`/`VAULTKEEPER_YES` approves it non-interactively
  *    or, on non-TTY stdin, the command fails with remediation guidance
- * 3. If `--cache`, check for a cached JWE token; otherwise retrieve and setup
- *    the secret into a fresh JWE
+ * 3. For an already-trusted caller with `--cache`, reuse a cached JWE token;
+ *    otherwise (including a just-approved caller) retrieve and setup the secret
+ *    into a fresh JWE, which also records a just-approved caller's trust
  * 4. Authorize the JWE → obtain a CapabilityToken
  * 5. Read the secret value via the accessor
  * 6. Spawn the child process with the secret injected as an env var
@@ -34,7 +35,18 @@ import { readCachedToken, writeCachedToken, invalidateCache } from '../cache.js'
 import { RedactingStream } from '../redact.js'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { shouldAutoApprove } from '../auto-approve.js'
+import { shellQuote } from '../shell-quote.js'
 import { formatError } from '../output.js'
+
+/**
+ * Outcome of the TOFU trust gate.
+ *
+ * - `trusted`: the caller's current hash is already approved in the manifest.
+ * - `approved`: the caller was just approved for this invocation (interactive
+ *   `y` or `--yes`/`VAULTKEEPER_YES`) and its hash is not yet recorded.
+ * - `denied`: the user declined the interactive prompt.
+ */
+type TrustGateOutcome = 'trusted' | 'approved' | 'denied'
 
 /**
  * Enforce the TOFU trust gate for `callerPath` before any secret is retrieved
@@ -59,7 +71,9 @@ import { formatError } from '../output.js'
  * - **Never approved**, interactive TTY: shows an approval prompt and returns
  *   its result (`false` if the user declines).
  *
- * @returns `true` if access is authorized, `false` if the user declined.
+ * @returns the {@link TrustGateOutcome}: `trusted` (already approved), `approved`
+ *   (just approved this run — the caller still needs recording via `setup()`),
+ *   or `denied` (user declined).
  * @throws {IdentityMismatchError} When the caller's hash changed from a
  *   previously approved value.
  * @throws When approval is required but cannot be obtained (non-TTY stdin
@@ -71,53 +85,57 @@ async function enforceTrustGate(
   secret: string,
   reason: string | undefined,
   autoApprove: boolean,
-): Promise<boolean> {
+): Promise<TrustGateOutcome> {
   const trust = await vault.checkExecutableTrust(callerPath)
   if (trust.trusted) {
     process.stderr.write('Trust: verified (hash matches trust manifest)\n')
-    return true
+    return 'trusted'
   }
 
   if (trust.hashMismatch) {
     // On a mismatch the manifest holds at least one prior approved hash; report
     // the most recently approved one as previousHash and the on-disk hash as
-    // currentHash so the error payload is accurate for diagnosis.
+    // currentHash so the error payload is accurate for diagnosis. The remediation
+    // command shell-quotes the path so it is safe to copy and paste verbatim.
     const previousHash = trust.approvedHashes.at(-1) ?? trust.hash
     throw new IdentityMismatchError(
       `Executable at ${callerPath} has changed since it was approved. ` +
-        `If this change is expected, re-approve it with: vaultkeeper approve --script ${callerPath}`,
+        `If this change is expected, re-approve it with: vaultkeeper approve --script ${shellQuote(callerPath)}`,
       previousHash,
       trust.hash,
     )
   }
 
   // Never-approved caller. --yes / VAULTKEEPER_YES approves this invocation
-  // without prompting; setup() then records the hash via TOFU just as an
-  // interactive "y" would.
+  // without prompting; the caller reports "approved" so the command records the
+  // hash via setup() (TOFU first-encounter) just as an interactive "y" would.
   if (autoApprove) {
     process.stderr.write('Trust: approved via --yes (recording caller in trust manifest)\n')
-    return true
+    return 'approved'
   }
 
   // No non-interactive approval and no TTY to prompt on: fail with actionable
-  // guidance instead of the raw "requires interactive approval" error.
+  // guidance instead of the raw "requires interactive approval" error. The
+  // caller path is shell-quoted so the suggested command is copy-paste safe.
   // isTTY is `true` only on a real terminal; `undefined`/`false` means non-TTY.
   if (!process.stdin.isTTY) {
     throw new Error(
       `Secret access for ${callerPath} requires approval, but stdin is not a TTY, ` +
         `so no interactive prompt can be shown.\n` +
         `To approve non-interactively, either:\n` +
-        `  - pre-approve the caller once:  vaultkeeper approve --script ${callerPath}\n` +
+        `  - pre-approve the caller once:  vaultkeeper approve --script ${shellQuote(callerPath)}\n` +
         `  - or approve just this run:      re-run with --yes (or set VAULTKEEPER_YES=1)`,
     )
   }
 
-  return promptApproval({
+  return (await promptApproval({
     caller: callerPath,
     trustInfo: 'Pending verification',
     secret,
     reason,
-  })
+  }))
+    ? 'approved'
+    : 'denied'
 }
 
 function printExecHelp(): void {
@@ -139,7 +157,7 @@ function printExecHelp(): void {
       '  A caller that is not yet trusted requires approval. On an interactive\n' +
       '  terminal you are prompted [y/N]. With non-TTY stdin (CI, pipes) there is\n' +
       '  no prompt, so you must either pre-approve the caller with\n' +
-      '  `vaultkeeper approve --script <caller>` or pass --yes (or VAULTKEEPER_YES=1)\n' +
+      '  "vaultkeeper approve --script <caller>" or pass --yes (or VAULTKEEPER_YES=1)\n' +
       '  to approve this invocation. Once trusted, exec never prompts again.\n\n' +
       'Environment variables:\n' +
       '  VAULTKEEPER_YES=1           Approve an untrusted caller non-interactively\n' +
@@ -215,15 +233,20 @@ export async function execCommand(args: string[]): Promise<number> {
     // previously cached JWE can never let a modified or never-approved caller
     // inherit trust it no longer (or never) held. A modified caller surfaces an
     // identity-mismatch error here rather than silently reusing a cached token.
-    const approved = await enforceTrustGate(vault, callerPath, secret, values.reason, autoApprove)
-    if (!approved) {
+    const outcome = await enforceTrustGate(vault, callerPath, secret, values.reason, autoApprove)
+    if (outcome === 'denied') {
       process.stderr.write('Access denied by user.\n')
       return 1
     }
 
-    // Check cache only after the caller has cleared the trust gate.
+    // Only a caller that was ALREADY trusted may reuse a cached token. A caller
+    // that was just approved this run (--yes or interactive "y") must go through
+    // setup(), which records its hash in the trust manifest (TOFU first
+    // encounter) — a cached token (the cache dir is independent of the trust
+    // manifest) must never short-circuit that recording, or the approval would
+    // not persist for later runs.
     let jwe: string | undefined
-    if (useCache) {
+    if (useCache && outcome === 'trusted') {
       jwe = await readCachedToken(callerPath, secret)
     }
 

--- a/packages/cli/src/shell-quote.ts
+++ b/packages/cli/src/shell-quote.ts
@@ -1,0 +1,17 @@
+/**
+ * Quote a string for safe literal use as a single POSIX-shell argument.
+ *
+ * Wraps the value in single quotes and escapes any embedded single quote as
+ * `'\''` (close quote, escaped quote, reopen quote). Use this whenever a
+ * user-controlled value — such as a filesystem path — is embedded in a shell
+ * command shown in help text or remediation guidance, so a path containing
+ * spaces or shell metacharacters can be copied and pasted verbatim without
+ * breaking or injecting.
+ *
+ * @param value - The raw string to quote.
+ * @returns The single-quoted, shell-safe representation.
+ * @internal
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}

--- a/packages/cli/test/unit/auto-approve.test.ts
+++ b/packages/cli/test/unit/auto-approve.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { shouldAutoApprove } from '../../src/auto-approve.js'
+
+describe('shouldAutoApprove', () => {
+  afterEach(() => {
+    delete process.env.VAULTKEEPER_YES
+  })
+
+  it('returns true when the --yes flag is set, regardless of env', () => {
+    delete process.env.VAULTKEEPER_YES
+    expect(shouldAutoApprove(true)).toBe(true)
+  })
+
+  it('returns true when VAULTKEEPER_YES=1 even without the flag', () => {
+    process.env.VAULTKEEPER_YES = '1'
+    expect(shouldAutoApprove(false)).toBe(true)
+  })
+
+  it('returns false when neither the flag nor the env var is set', () => {
+    delete process.env.VAULTKEEPER_YES
+    expect(shouldAutoApprove(false)).toBe(false)
+  })
+
+  // Only the exact value "1" opts in — mirrors VAULTKEEPER_SKIP_DOCTOR semantics
+  // so an incidental "0"/"true"/"false"/"" never silently approves callers.
+  it.each(['0', 'true', 'false', 'yes', '', ' 1 '])(
+    'returns false for VAULTKEEPER_YES=%j without the flag',
+    (value) => {
+      process.env.VAULTKEEPER_YES = value
+      expect(shouldAutoApprove(false)).toBe(false)
+    },
+  )
+})

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -72,6 +72,23 @@ function pendingVaultMock(): {
   }
 }
 
+/**
+ * Force `process.stdin.isTTY` to a fixed value for the duration of a test and
+ * return a restore function. The trust gate only reaches the interactive prompt
+ * on a TTY; on non-TTY stdin an untrusted caller fails with remediation instead.
+ */
+function forceStdinTTY(value: boolean): () => void {
+  const original = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+  Object.defineProperty(process.stdin, 'isTTY', { value, configurable: true })
+  return () => {
+    if (original === undefined) {
+      Reflect.deleteProperty(process.stdin, 'isTTY')
+    } else {
+      Object.defineProperty(process.stdin, 'isTTY', original)
+    }
+  }
+}
+
 describe('execCommand', () => {
   let stderrOutput: string
   let stdoutOutput: string
@@ -94,6 +111,7 @@ describe('execCommand', () => {
     vi.restoreAllMocks()
     vi.clearAllMocks()
     delete process.env.VAULTKEEPER_SKIP_DOCTOR
+    delete process.env.VAULTKEEPER_YES
   })
 
   describe('-- separator validation', () => {
@@ -208,12 +226,24 @@ describe('execCommand', () => {
   })
 
   describe('--skip-doctor flag', () => {
-    // These drive the full command with a never-approved (pending) caller, so
-    // the trust gate reaches promptApproval (mocked to decline) and the command
-    // exits at "Access denied". Asserting the gate was reached keeps these tests
-    // genuinely exercising the trust path — if the default mock stopped providing
-    // checkExecutableTrust, execCommand would throw before promptApproval and
-    // these assertions would fail.
+    // These drive the full command with a never-approved (pending) caller under
+    // a simulated TTY, so the trust gate reaches promptApproval (mocked to
+    // decline) and the command exits at "Access denied". Asserting the gate was
+    // reached keeps these tests genuinely exercising the trust path — if the
+    // default mock stopped providing checkExecutableTrust, execCommand would
+    // throw before promptApproval and these assertions would fail. (On non-TTY
+    // stdin an untrusted caller fails with remediation instead of prompting;
+    // that path is covered by the "trust gate" tests below.)
+    let restoreTTY: () => void = () => {
+      /* replaced in beforeEach */
+    }
+    beforeEach(() => {
+      restoreTTY = forceStdinTTY(true)
+    })
+    afterEach(() => {
+      restoreTTY()
+    })
+
     it('should pass skipDoctor: false to VaultKeeper.init by default', async () => {
       mockInit.mockResolvedValue(pendingVaultMock())
       await execCommand([
@@ -426,6 +456,85 @@ describe('execCommand', () => {
       expect(authorize).toHaveBeenCalledWith('cached.jwe.token')
       expect(stderrOutput).toContain('Trust: verified')
     })
+
+    // Issue #58, criterion 2: --yes approves a never-approved caller without a
+    // prompt and records the approval the same way an interactive "y" would —
+    // via setup(), which TOFU-records the caller hash on first encounter.
+    it('approves an untrusted caller non-interactively with --yes and records trust via setup', async () => {
+      const setup = vi.fn().mockResolvedValue('fresh.jwe')
+      const authorize = vi.fn().mockResolvedValue({ token: {}, vaultResponse: {} })
+      const getSecret = vi.fn().mockReturnValue({
+        read: (cb: (buf: Buffer) => void) => {
+          cb(Buffer.from('s3cr3t'))
+        },
+      })
+      const checkExecutableTrust = vi.fn().mockResolvedValue({
+        trusted: false,
+        hashMismatch: false,
+        hash: 'pending-hash',
+        approvedHashes: [],
+        reason: 'Executable not yet approved',
+      })
+      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+
+      const code = await execCommand(['--yes', ...EXEC_ARGS])
+
+      expect(code).toBe(0)
+      expect(promptApproval).not.toHaveBeenCalled()
+      // Trust recording is delegated to setup() with the caller path, exactly as
+      // the interactive "y" path does.
+      expect(setup).toHaveBeenCalledWith('my-key', { executablePath: '/path/to/script.sh' })
+      expect(stderrOutput).toContain('approved via --yes')
+    })
+
+    // Issue #58, criterion 2: VAULTKEEPER_YES=1 is equivalent to --yes.
+    it('approves an untrusted caller non-interactively via VAULTKEEPER_YES=1', async () => {
+      process.env.VAULTKEEPER_YES = '1'
+      const setup = vi.fn().mockResolvedValue('fresh.jwe')
+      const authorize = vi.fn().mockResolvedValue({ token: {}, vaultResponse: {} })
+      const getSecret = vi.fn().mockReturnValue({
+        read: (cb: (buf: Buffer) => void) => {
+          cb(Buffer.from('s3cr3t'))
+        },
+      })
+      const checkExecutableTrust = vi.fn().mockResolvedValue({
+        trusted: false,
+        hashMismatch: false,
+        hash: 'pending-hash',
+        approvedHashes: [],
+        reason: 'Executable not yet approved',
+      })
+      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+
+      const code = await execCommand(EXEC_ARGS)
+
+      expect(code).toBe(0)
+      expect(promptApproval).not.toHaveBeenCalled()
+      expect(setup).toHaveBeenCalledWith('my-key', { executablePath: '/path/to/script.sh' })
+      expect(stderrOutput).toContain('approved via --yes')
+    })
+
+    // Issue #58, criterion 3: an untrusted caller on non-TTY stdin without --yes
+    // fails, but the error tells the user exactly how to proceed (approve or --yes)
+    // rather than the raw "requires interactive approval" message.
+    it('fails with remediation guidance for an untrusted caller on non-TTY stdin', async () => {
+      const restoreTTY = forceStdinTTY(false)
+      try {
+        const vault = pendingVaultMock()
+        mockInit.mockResolvedValue(vault)
+
+        const code = await execCommand(EXEC_ARGS)
+
+        expect(code).toBe(1)
+        expect(promptApproval).not.toHaveBeenCalled()
+        expect(vault.setup).not.toHaveBeenCalled()
+        expect(stderrOutput).toContain('vaultkeeper approve --script /path/to/script.sh')
+        expect(stderrOutput).toContain('--yes')
+        expect(stderrOutput).toContain('VAULTKEEPER_YES=1')
+      } finally {
+        restoreTTY()
+      }
+    })
   })
 
   describe('--help flag', () => {
@@ -437,6 +546,20 @@ describe('execCommand', () => {
     it('should include VAULTKEEPER_SKIP_DOCTOR env var in help output', async () => {
       await execCommand(['--help'])
       expect(stdoutOutput).toContain('VAULTKEEPER_SKIP_DOCTOR')
+    })
+
+    // Issue #58, criterion 4: help documents the TTY requirement and both escape
+    // hatches (--yes and VAULTKEEPER_YES), plus the approve alternative.
+    it('documents the --yes flag and VAULTKEEPER_YES env var', async () => {
+      await execCommand(['--help'])
+      expect(stdoutOutput).toContain('--yes')
+      expect(stdoutOutput).toContain('VAULTKEEPER_YES')
+    })
+
+    it('documents the TTY requirement and how to approve non-interactively', async () => {
+      await execCommand(['--help'])
+      expect(stdoutOutput).toContain('non-TTY')
+      expect(stdoutOutput).toContain('vaultkeeper approve --script')
     })
   })
 })

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -390,7 +390,8 @@ describe('execCommand', () => {
       expect(setup).not.toHaveBeenCalled()
       expect(authorize).not.toHaveBeenCalled()
       expect(stderrOutput).toContain('has changed since it was approved')
-      expect(stderrOutput).toContain('vaultkeeper approve --script /path/to/script.sh')
+      // Remediation shell-quotes the caller path (safe to copy/paste).
+      expect(stderrOutput).toContain("vaultkeeper approve --script '/path/to/script.sh'")
 
       // Regression for review threads 3582262153 / 3582262187: the constructed
       // error carries the REAL hashes — the manifest-recorded approved hash and
@@ -514,6 +515,41 @@ describe('execCommand', () => {
       expect(stderrOutput).toContain('approved via --yes')
     })
 
+    // Regression for review thread 3582539153: --yes must record trust via
+    // setup() even when a cached token exists. A just-approved (untrusted)
+    // caller must not ride a cached token and skip recording — the cache is
+    // reserved for callers that were ALREADY trusted.
+    it('records trust via setup for a --yes caller even when a cached token exists', async () => {
+      const setup = vi.fn().mockResolvedValue('fresh.jwe')
+      const authorize = vi.fn().mockResolvedValue({ token: {}, vaultResponse: {} })
+      const getSecret = vi.fn().mockReturnValue({
+        read: (cb: (buf: Buffer) => void) => {
+          cb(Buffer.from('s3cr3t'))
+        },
+      })
+      const checkExecutableTrust = vi.fn().mockResolvedValue({
+        trusted: false,
+        hashMismatch: false,
+        hash: 'pending-hash',
+        approvedHashes: [],
+        reason: 'Executable not yet approved',
+      })
+      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      // A stale cached token exists — it must NOT be read or used for a caller
+      // that is only being approved this run.
+      vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')
+
+      const code = await execCommand(['--cache', '--yes', ...EXEC_ARGS])
+
+      expect(code).toBe(0)
+      // The cache was not even consulted for a just-approved caller.
+      expect(readCachedToken).not.toHaveBeenCalled()
+      // setup() ran, recording the approval, and its fresh token was authorized.
+      expect(setup).toHaveBeenCalledWith('my-key', { executablePath: '/path/to/script.sh' })
+      expect(authorize).toHaveBeenCalledWith('fresh.jwe')
+      expect(authorize).not.toHaveBeenCalledWith('cached.jwe.token')
+    })
+
     // Issue #58, criterion 3: an untrusted caller on non-TTY stdin without --yes
     // fails, but the error tells the user exactly how to proceed (approve or --yes)
     // rather than the raw "requires interactive approval" message.
@@ -528,7 +564,8 @@ describe('execCommand', () => {
         expect(code).toBe(1)
         expect(promptApproval).not.toHaveBeenCalled()
         expect(vault.setup).not.toHaveBeenCalled()
-        expect(stderrOutput).toContain('vaultkeeper approve --script /path/to/script.sh')
+        // Remediation shell-quotes the caller path (safe to copy/paste).
+        expect(stderrOutput).toContain("vaultkeeper approve --script '/path/to/script.sh'")
         expect(stderrOutput).toContain('--yes')
         expect(stderrOutput).toContain('VAULTKEEPER_YES=1')
       } finally {

--- a/packages/cli/test/unit/shell-quote.test.ts
+++ b/packages/cli/test/unit/shell-quote.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { shellQuote } from '../../src/shell-quote.js'
+
+describe('shellQuote', () => {
+  it('wraps a plain path in single quotes', () => {
+    expect(shellQuote('/usr/local/bin/tool')).toBe("'/usr/local/bin/tool'")
+  })
+
+  it('preserves spaces inside the quotes', () => {
+    expect(shellQuote('/path/with spaces/tool')).toBe("'/path/with spaces/tool'")
+  })
+
+  it('quotes shell metacharacters literally (no expansion)', () => {
+    // $, ;, &, |, and backticks must be inert when the result is pasted.
+    expect(shellQuote('/tmp/$(rm -rf ~)/x')).toBe("'/tmp/$(rm -rf ~)/x'")
+    expect(shellQuote('/tmp/a;b&c|d')).toBe("'/tmp/a;b&c|d'")
+    expect(shellQuote('/tmp/`whoami`')).toBe("'/tmp/`whoami`'")
+  })
+
+  it('escapes embedded single quotes as \\047 close/escape/reopen', () => {
+    // a'b -> 'a'\''b'
+    expect(shellQuote("a'b")).toBe("'a'\\''b'")
+  })
+
+  it('handles multiple single quotes', () => {
+    expect(shellQuote("'x'")).toBe("''\\''x'\\'''")
+  })
+
+  it('quotes an empty string as a pair of single quotes', () => {
+    expect(shellQuote('')).toBe("''")
+  })
+})


### PR DESCRIPTION
Refs #58

## What

Makes `vaultkeeper exec` usable non-interactively (CI/Docker), building on the TOFU trust gate from #79.

- **Trusted callers skip the prompt** on a TTY or not (already held post-#79; now locked with a subprocess test).
- **`--yes` flag and `VAULTKEEPER_YES=1`** approve an untrusted caller for a single invocation without prompting, recording the approval via `setup()`'s TOFU first-encounter — exactly as an interactive `y` would. An explicit, documented opt-in; never the default.
- **Non-TTY, untrusted, no `--yes`** still fails, but the error now names the exact remediation (`vaultkeeper approve --script <caller>` or `--yes`).
- **A changed binary (identity mismatch) is never auto-approved by `--yes`** — it must be re-approved with `vaultkeeper approve`.
- `exec --help` documents the TTY requirement and both escape hatches; README gains a "Running in CI" note.

## Acceptance criteria → tests

| Criterion | Test |
|---|---|
| 1. Trusted caller, no prompt (TTY/non-TTY) | e2e `does not prompt for an approved caller and injects the secret` |
| 2. `--yes` approves + records trust | e2e `approves an untrusted caller with --yes and records trust for later runs`; unit `approves an untrusted caller non-interactively with --yes and records trust via setup` |
| 2. `VAULTKEEPER_YES=1` equivalent | e2e `approves an untrusted caller via VAULTKEEPER_YES=1 and records it in the manifest`; unit `approves an untrusted caller non-interactively via VAULTKEEPER_YES=1` |
| 3. Non-TTY untrusted fails with remediation | e2e `fails an untrusted caller on non-TTY stdin with actionable remediation`; unit `fails with remediation guidance for an untrusted caller on non-TTY stdin` |
| 4. `exec --help` documents TTY + escape hatches | e2e `documents the TTY requirement and escape hatches in exec --help`; unit help tests |
| 5. Subprocess regression tests | all e2e tests run the real CLI with piped stdin under isolated HOME + file backend |
| 6. README "Running in CI" note | `README.md` |

Also added `shouldAutoApprove` unit tests covering the strict `=1` env semantics (negative/boundary cases).

## `vaultkeeper exec --help`: Options and approval guidance

Documents the new `--yes` flag, the TTY requirement, and `VAULTKEEPER_YES`.

```diff
   --reason <text>    Human-readable reason for access (optional)
+  --yes              Approve an untrusted caller for this invocation without
+                     an interactive prompt, recording it in the trust manifest
+                     (for CI/non-interactive use; never the default)
   --cache            Cache the JWE token for subsequent invocations
   --no-redact        Do not redact the secret from output
   --skip-doctor      Skip doctor preflight checks
   -h, --help         Show this help message

+Approval and TTY requirement:
+  A caller that is not yet trusted requires approval. On an interactive
+  terminal you are prompted [y/N]. With non-TTY stdin (CI, pipes) there is
+  no prompt, so you must either pre-approve the caller with
+  `vaultkeeper approve --script <caller>` or pass --yes (or VAULTKEEPER_YES=1)
+  to approve this invocation. Once trusted, exec never prompts again.
+
 Environment variables:
+  VAULTKEEPER_YES=1           Approve an untrusted caller non-interactively
+                              (same as --yes)
   VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks
```

## `exec` untrusted caller on non-TTY stdin: error message

Before this change the message gave no path forward; now it does.

```diff
-Error: Secret access requires interactive approval. Run this command in a terminal.
+Error: Secret access for <caller> requires approval, but stdin is not a TTY, so no interactive prompt can be shown.
+To approve non-interactively, either:
+  - pre-approve the caller once:  vaultkeeper approve --script <caller>
+  - or approve just this run:      re-run with --yes (or set VAULTKEEPER_YES=1)
```

## Quality gate

`pnpm check` (typecheck + lint + api-report) green; vaultkeeper 603, @vaultkeeper/cli 199, @vaultkeeper/cli-tests 55 passed. Changeset: minor, `@vaultkeeper/cli`.

## Non-goals

Rust CLI parity (tracked separately) and changes to the interactive prompt UX.
