### PR TITLE
Fix CapabilityToken doc comment referencing unexported validateCapabilityToken

### DIFF
--- a/packages/vaultkeeper/src/identity/session.ts
+++ b/packages/vaultkeeper/src/identity/session.ts
@@ -9,7 +9,23 @@
 import type { VaultClaims } from './types.js'
 import { AuthorizationDeniedError } from '../errors.js'
 
-/** Opaque capability token. Claims are inaccessible without `validateCapabilityToken`. */
+/**
+ * An opaque handle to authorized secret claims.
+ *
+ * A `CapabilityToken` is produced by {@link VaultKeeper.authorize} and
+ * deliberately exposes no readable data. The underlying claims — including the
+ * secret value — are held in a module-private `WeakMap` that this class does
+ * not reference, and its private fields keep any property from leaking them
+ * (`toString()` returns only a debug identifier). There is intentionally no
+ * public API for reading the claims directly.
+ *
+ * To use the secret, pass the token to a {@link VaultKeeper} access method —
+ * {@link VaultKeeper.getSecret}, {@link VaultKeeper.fetch},
+ * {@link VaultKeeper.exec}, or {@link VaultKeeper.sign} — which resolve the
+ * claims internally.
+ *
+ * @public
+ */
 export class CapabilityToken {
   // Private field ensures no public surface leaks claims.
   readonly #brand: symbol

--- a/packages/vaultkeeper/test/unit/identity/session.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/session.test.ts
@@ -52,15 +52,23 @@ describe('CapabilityToken', () => {
 })
 
 // Regression guard for issue #74: the CapabilityToken doc promises there is no
-// public API for reading claims. The claims-unwrapping helpers must therefore
-// stay internal — exporting them would leak the secret and make the doc false.
+// public API for reading claims, so both token helpers must stay internal — for
+// different reasons. Exporting validateCapabilityToken would directly leak the
+// secret, since it reads the claims (including the secret value) back out.
+// Exporting createCapabilityToken would not read claims, but it mints a token
+// around caller-supplied claims, letting callers forge tokens outside the
+// authorize() flow and bypass its validation and usage tracking. Neither is
+// exported.
 describe('CapabilityToken public surface (issue #74)', () => {
   it('exports the CapabilityToken class', () => {
     expect('CapabilityToken' in publicApi).toBe(true)
   })
 
-  it('does not export the internal claims-unwrapping helpers', () => {
-    // Mirrors the issue repro: `'validateCapabilityToken' in import('vaultkeeper')`.
+  it('does not export the internal token helpers', () => {
+    // Asserts the source entrypoint's (src/index.ts) export surface. The issue
+    // repro checks the built package at runtime
+    // (`'validateCapabilityToken' in await import('vaultkeeper')`); both resolve
+    // to the same export set, so this is the fast unit-level equivalent.
     expect('validateCapabilityToken' in publicApi).toBe(false)
     expect('createCapabilityToken' in publicApi).toBe(false)
   })

--- a/packages/vaultkeeper/test/unit/identity/session.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/session.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import * as publicApi from '../../../src/index.js'
 import {
   CapabilityToken,
   createCapabilityToken,
@@ -50,6 +51,21 @@ describe('CapabilityToken', () => {
   })
 })
 
+// Regression guard for issue #74: the CapabilityToken doc promises there is no
+// public API for reading claims. The claims-unwrapping helpers must therefore
+// stay internal — exporting them would leak the secret and make the doc false.
+describe('CapabilityToken public surface (issue #74)', () => {
+  it('exports the CapabilityToken class', () => {
+    expect('CapabilityToken' in publicApi).toBe(true)
+  })
+
+  it('does not export the internal claims-unwrapping helpers', () => {
+    // Mirrors the issue repro: `'validateCapabilityToken' in import('vaultkeeper')`.
+    expect('validateCapabilityToken' in publicApi).toBe(false)
+    expect('createCapabilityToken' in publicApi).toBe(false)
+  })
+})
+
 describe('createCapabilityToken', () => {
   it('creates a distinct token for each call', () => {
     const claims = makeClaims()
@@ -79,7 +95,9 @@ describe('validateCapabilityToken', () => {
   it('throws AuthorizationDeniedError for a token not created by createCapabilityToken', () => {
     const forgery = new CapabilityToken()
     expect(() => validateCapabilityToken(forgery)).toThrow(AuthorizationDeniedError)
-    expect(() => validateCapabilityToken(forgery)).toThrow('Invalid or unrecognized capability token')
+    expect(() => validateCapabilityToken(forgery)).toThrow(
+      'Invalid or unrecognized capability token',
+    )
   })
 
   it('throws AuthorizationDeniedError for a plain object cast-free forgery attempt', () => {


### PR DESCRIPTION
Refs #74

## Path taken: doc-fix (not export)

`validateCapabilityToken` unwraps the token's raw `VaultClaims` — which includes `val`, the secret value. It is `@internal` by design: exporting it would let any consumer extract the secret from an opaque `CapabilityToken`, defeating the whole point of the type. So the correct fix is to **rewrite the doc**, not export the symbol. Consumers already have a real access path: `VaultKeeper.authorize()` returns the token, and they pass it to `getSecret`/`fetch`/`exec`/`sign`, which resolve the claims internally.

## Change

Rewrote the `CapabilityToken` class doc comment to describe the real claims-access story with no dangling symbol reference:

```diff
-/** Opaque capability token. Claims are inaccessible without `validateCapabilityToken`. */
+/**
+ * An opaque handle to authorized secret claims.
+ *
+ * A `CapabilityToken` is produced by {@link VaultKeeper.authorize} and
+ * deliberately exposes no readable data. The underlying claims — including the
+ * secret value — are held in a module-private `WeakMap` that this class does
+ * not reference, and its private fields keep any property from leaking them
+ * (`toString()` returns only a debug identifier). There is intentionally no
+ * public API for reading the claims directly.
+ *
+ * To use the secret, pass the token to a {@link VaultKeeper} access method —
+ * {@link VaultKeeper.getSecret}, {@link VaultKeeper.fetch},
+ * {@link VaultKeeper.exec}, or {@link VaultKeeper.sign} — which resolve the
+ * claims internally.
+ *
+ * @public
+ */
```

All `{@link}` targets are exported public members — API Extractor resolves them with no unresolved-reference warnings.

## Audit (criterion 2)

No doc comment in the published types references an unexported symbol:

- `validateCapabilityToken` / `createCapabilityToken` are **absent** from both `packages/vaultkeeper/api-report/vaultkeeper.api.md` and the built `dist/index.d.ts` (grep returns nothing).
- Every symbol referenced in a published doc comment (`@link` or backticked) resolves to an exported public member (`VaultKeeper`, `CapabilityToken`, `BackendConfig`, `SecretTokenMap`, `VaultResponse`, `ExecutableTrustStatus`, `BackendUnavailableError`), verified against the API report; the remaining backticked tokens are object-property names (`exitCode`, `rotatedJwt`, `vaultResponse`), not symbol references.

## Proof

Issue repro against the built package — `validateCapabilityToken` is not exported (and the doc no longer claims it is):

```
$ node -e "import('vaultkeeper').then(m=>{console.log('validateCapabilityToken in exports:', 'validateCapabilityToken' in m); console.log('CapabilityToken in exports:', 'CapabilityToken' in m)})"
validateCapabilityToken in exports: false
CapabilityToken in exports: true
```

Added a regression guard (`session.test.ts`) asserting the public entrypoint exports `CapabilityToken` but not the internal unwrapping helpers, so the doc's "no public API for reading claims" promise cannot silently break.

## API report / changeset

- **API report:** unchanged. The `.api.md` records tags and signatures, not doc prose, so a doc-only change leaves it byte-identical (`generate:api-report` produces no diff). No regeneration committed because nothing changed.
- **Changeset:** none. The exported surface did not change (criterion 3 conditions a changeset on the surface changing); this is a documentation-only edit to an already-`@public` class.

## Quality gate

`pnpm check` (typecheck + lint + api-report) green; vaultkeeper suite green (604 tests, session.test.ts now 12).
