### PR TITLE
Backend selection UX: config init --backend, reject unknown flags, surface the active backend

### DIFF
--- a/.changeset/backend-selection-ux.md
+++ b/.changeset/backend-selection-ux.md
@@ -1,0 +1,12 @@
+---
+'vaultkeeper': minor
+'@vaultkeeper/cli': minor
+---
+
+Make backend selection visible and overridable from the CLI and introspectable from the library.
+
+- `vaultkeeper config init --backend <type>` now writes a config whose first enabled backend is `<type>`. Valid values are the registered backend types; an unknown value exits 2 and lists the valid types.
+- Any unknown flag on a `config` subcommand (`config init`, `config show`) now exits 2 with an "unknown option" error instead of being silently ignored — a typo can no longer send secrets to an unintended credential store.
+- `config init` output now states which backend was configured and how to change it (e.g. `Backend: keychain (macOS default). Use --backend file for a portable, CI-friendly store.`). `config show` reports the resolved active backend (first enabled).
+- New public `platformDefaultBackendType()` documents exactly how the default backend resolves when no config exists: `keychain` on macOS, `dpapi` on Windows, `file` elsewhere. A bare `VaultKeeper.init()` with no config file now follows this same resolution, so on macOS/Windows it targets the real OS credential store (previously it always fell back to the `file` backend).
+- New public `VaultKeeper.activeBackendType` getter exposes the type of the active (first enabled) backend at runtime.

--- a/README.md
+++ b/README.md
@@ -116,11 +116,28 @@ must re-approve it with `vaultkeeper approve --script <caller>`.
 
 ## TypeScript quick start
 
+> [!WARNING]
+> With no config file present, a bare `VaultKeeper.init()` — and `vaultkeeper config init` with no `--backend` — targets your **real OS credential store**: the macOS Keychain on macOS, Windows DPAPI on Windows. On those platforms, secrets you store land in the live system store. To use a portable, CI-friendly encrypted file instead, choose the `file` backend explicitly (shown below). Inspect `vault.activeBackendType` to confirm which backend an instance resolved to.
+
 ```ts
 import { VaultKeeper } from 'vaultkeeper'
 
 // 1. Initialize (runs doctor preflight checks)
+//    With no config file, the backend defaults to the platform's OS credential
+//    store (keychain on macOS, dpapi on Windows, file elsewhere).
 const vault = await VaultKeeper.init()
+console.log(vault.activeBackendType) // e.g. "keychain" on macOS
+
+// Prefer a portable, CI-friendly encrypted file? Pass an explicit config:
+// const vault = await VaultKeeper.init({
+//   config: {
+//     version: 1,
+//     backends: [{ type: 'file', enabled: true }],
+//     keyRotation: { gracePeriodDays: 7 },
+//     defaults: { ttlMinutes: 60, trustTier: 3 },
+//   },
+// })
+// From the CLI, the equivalent is: vaultkeeper config init --backend file
 
 // 2. Store a secret in the configured backend
 await vault.store('MY_API_KEY', 'my-secret-value')

--- a/packages/cli-tests/test/e2e/config.test.ts
+++ b/packages/cli-tests/test/e2e/config.test.ts
@@ -2,13 +2,20 @@
  * UATs for the config init/show lifecycle.
  *
  * These tests verify the config command works with an isolated config dir
- * via VAULTKEEPER_CONFIG_DIR.
+ * via VAULTKEEPER_CONFIG_DIR. Each maps to an acceptance criterion of the
+ * backend-selection UX work: choosing a backend, rejecting typos in flags
+ * and backend values, keeping the platform default, and surfacing the
+ * resolved active backend.
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
 import type { CliTestEnv } from '@vaultkeeper/cli-test-helpers'
+
+/** The backend type config init writes by default on the current platform. */
+const platformDefaultBackend =
+  process.platform === 'darwin' ? 'keychain' : process.platform === 'win32' ? 'dpapi' : 'file'
 
 describe('config command', () => {
   let env: CliTestEnv | undefined
@@ -19,6 +26,18 @@ describe('config command', () => {
       env = undefined
     }
   })
+
+  /** Create an env and remove the config.json that createCliTestEnv seeds. */
+  async function freshEnv(): Promise<CliTestEnv> {
+    const created = await createCliTestEnv()
+    await fs.rm(path.join(created.configDir, 'config.json'))
+    return created
+  }
+
+  async function readConfig(dir: string): Promise<unknown> {
+    const content = await fs.readFile(path.join(dir, 'config.json'), 'utf8')
+    return JSON.parse(content)
+  }
 
   it('should show config and exit 0 when config.json exists', async () => {
     env = await createCliTestEnv()
@@ -38,44 +57,102 @@ describe('config command', () => {
   })
 
   it('should create config with config init when no config exists', async () => {
-    env = await createCliTestEnv()
-    // Remove the config.json that createCliTestEnv wrote
-    await fs.rm(path.join(env.configDir, 'config.json'))
+    env = await freshEnv()
     const result = await env.run(['config', 'init'])
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain('Config created at')
-    // Verify the file was actually created
-    const content = await fs.readFile(path.join(env.configDir, 'config.json'), 'utf8')
-    const parsed: unknown = JSON.parse(content)
+    const parsed = await readConfig(env.configDir)
     expect(parsed).toHaveProperty('version', 1)
   })
 
+  // Criterion 3: without --backend, keep the platform default.
   it('should generate platform-appropriate defaults for config init', async () => {
-    env = await createCliTestEnv()
-    // Remove the config.json that createCliTestEnv wrote
-    await fs.rm(path.join(env.configDir, 'config.json'))
+    env = await freshEnv()
     const result = await env.run(['config', 'init'])
     expect(result.exitCode).toBe(0)
-    const content = await fs.readFile(path.join(env.configDir, 'config.json'), 'utf8')
-    const parsed: unknown = JSON.parse(content)
-    const expectedBackendType =
-      process.platform === 'darwin'
-        ? 'keychain'
-        : process.platform === 'win32'
-          ? 'dpapi'
-          : 'file'
-    expect(parsed).toHaveProperty('backends[0].type', expectedBackendType)
-    // The file backend does not use a 'path' field — the backend manages
-    // its own storage location and ignores any path in config.
-    if (expectedBackendType === 'file') {
-      expect(parsed).not.toHaveProperty('backends[0].path')
-    }
+    const parsed = await readConfig(env.configDir)
+    expect(parsed).toHaveProperty('backends[0].type', platformDefaultBackend)
+  })
+
+  // Criterion 3: init states which backend was configured and how to change it.
+  it('should report the configured backend and how to change it on default init', async () => {
+    env = await freshEnv()
+    const result = await env.run(['config', 'init'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain(`Backend: ${platformDefaultBackend}`)
+    // Every default-init message points the user at the override flag.
+    expect(result.stdout).toContain('--backend')
+  })
+
+  // Criterion 1: --backend <type> writes a config whose first enabled backend
+  // is <type>.
+  it('should write the file backend when config init --backend file is used', async () => {
+    env = await freshEnv()
+    const result = await env.run(['config', 'init', '--backend', 'file'])
+    expect(result.exitCode).toBe(0)
+    const parsed = await readConfig(env.configDir)
+    expect(parsed).toHaveProperty('backends[0].type', 'file')
+    expect(parsed).toHaveProperty('backends[0].enabled', true)
+    expect(result.stdout).toContain('Backend: file')
+  })
+
+  // Criterion 1: an unknown backend value exits 2 listing valid types.
+  it('should exit 2 for config init with an unknown backend value', async () => {
+    env = await freshEnv()
+    const result = await env.run(['config', 'init', '--backend', 'nope'])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain("unknown backend type 'nope'")
+    // The error lists valid backend types so the user can correct the typo.
+    expect(result.stderr).toContain('file')
+    // Nothing should have been written.
+    await expect(fs.access(path.join(env.configDir, 'config.json'))).rejects.toThrow()
+  })
+
+  // Criterion 2: a typo in a flag on config init must never be silently ignored
+  // (it could route secrets to the wrong credential store).
+  it('should exit 2 for config init with an unknown flag', async () => {
+    env = await freshEnv()
+    const result = await env.run(['config', 'init', '--bakcend', 'file'])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr.toLowerCase()).toContain('unknown option')
+    // The typo must not have silently written a (default keychain) config.
+    await expect(fs.access(path.join(env.configDir, 'config.json'))).rejects.toThrow()
+  })
+
+  // Criterion 2: unknown flags on config show also exit 2.
+  it('should exit 2 for config show with an unknown flag', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['config', 'show', '--nope'])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr.toLowerCase()).toContain('unknown option')
+  })
+
+  // Criterion 4: config show reports the resolved active backend.
+  it('should report the resolved active backend on config show', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['config', 'show'])
+    expect(result.exitCode).toBe(0)
+    // stdout stays valid JSON; the active backend is annotated on stderr.
+    const parsed: unknown = JSON.parse(result.stdout)
+    expect(parsed).toHaveProperty('backends[0].type', 'file')
+    expect(result.stderr).toContain('Active backend: file')
+  })
+
+  // Criterion 7 / Proof: init --backend file then show, end-to-end.
+  it('should demonstrate the file backend end-to-end (init --backend file then show)', async () => {
+    env = await freshEnv()
+    const initResult = await env.run(['config', 'init', '--backend', 'file'])
+    expect(initResult.exitCode).toBe(0)
+
+    const showResult = await env.run(['config', 'show'])
+    expect(showResult.exitCode).toBe(0)
+    const parsed: unknown = JSON.parse(showResult.stdout)
+    expect(parsed).toHaveProperty('backends[0].type', 'file')
+    expect(showResult.stderr).toContain('Active backend: file')
   })
 
   it('should exit 1 for config show when no config exists', async () => {
-    env = await createCliTestEnv()
-    // Remove the config.json
-    await fs.rm(path.join(env.configDir, 'config.json'))
+    env = await freshEnv()
     const result = await env.run(['config', 'show'])
     expect(result.exitCode).toBe(1)
     expect(result.stderr).toContain('No config file found')
@@ -87,27 +164,5 @@ describe('config command', () => {
     const result = await env.run(['config'])
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('Usage: vaultkeeper config')
-  })
-
-  it('should generate platform-appropriate defaults for config init', async () => {
-    env = await createCliTestEnv()
-    // Remove the config.json that createCliTestEnv wrote
-    await fs.rm(path.join(env.configDir, 'config.json'))
-    const result = await env.run(['config', 'init'])
-    expect(result.exitCode).toBe(0)
-    const content = await fs.readFile(path.join(env.configDir, 'config.json'), 'utf8')
-    const parsed: unknown = JSON.parse(content)
-    const expectedBackendType =
-      process.platform === 'darwin'
-        ? 'keychain'
-        : process.platform === 'win32'
-          ? 'dpapi'
-          : 'file'
-    expect(parsed).toHaveProperty('backends[0].type', expectedBackendType)
-    // The file backend does not use a 'path' field — the backend manages
-    // its own storage location and ignores any path in config.
-    if (expectedBackendType === 'file') {
-      expect(parsed).not.toHaveProperty('backends[0].path')
-    }
   })
 })

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -2,6 +2,7 @@ import { parseArgs } from 'node:util'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as os from 'node:os'
+import { BackendRegistry, platformDefaultBackendType } from 'vaultkeeper'
 import { formatError } from '../output.js'
 
 function getDefaultConfigDir(): string {
@@ -19,27 +20,81 @@ function getDefaultConfigDir(): string {
   return path.join(os.homedir(), '.config', 'vaultkeeper')
 }
 
-function getDefaultConfig(): string {
-  let backendType: string
+/** Human-readable name for the current platform, for user-facing messages. */
+function platformLabel(): string {
   if (process.platform === 'darwin') {
-    backendType = 'keychain'
-  } else if (process.platform === 'win32') {
-    backendType = 'dpapi'
-  } else {
-    // Linux and other Unix-like systems.
-    // Use 'file' rather than 'secret-tool' because secret-tool requires
-    // installing libsecret-tools which many Linux systems don't have.
-    backendType = 'file'
+    return 'macOS'
   }
+  if (process.platform === 'win32') {
+    return 'Windows'
+  }
+  return 'Linux'
+}
 
+/** Serialize a default config whose first enabled backend is `backendType`. */
+function buildConfig(backendType: string): string {
   const config: Record<string, unknown> = {
     version: 1,
     backends: [{ type: backendType, enabled: true }],
     keyRotation: { gracePeriodDays: 7 },
     defaults: { ttlMinutes: 60, trustTier: 3 },
   }
-
   return JSON.stringify(config, null, 2)
+}
+
+/** Narrow an unknown value to an enabled backend entry with a string type. */
+function isEnabledBackendEntry(entry: unknown): entry is { type: string; enabled: true } {
+  return (
+    typeof entry === 'object' &&
+    entry !== null &&
+    'enabled' in entry &&
+    entry.enabled === true &&
+    'type' in entry &&
+    typeof entry.type === 'string'
+  )
+}
+
+/**
+ * Return the type of the first enabled backend described by a config file's
+ * JSON contents, or `undefined` if none can be resolved.
+ */
+function firstEnabledBackendType(content: string): string | undefined {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(content)
+  } catch {
+    return undefined
+  }
+  if (typeof parsed !== 'object' || parsed === null || !('backends' in parsed)) {
+    return undefined
+  }
+  const backends: unknown = parsed.backends
+  if (!Array.isArray(backends)) {
+    return undefined
+  }
+  const entries: readonly unknown[] = backends
+  for (const entry of entries) {
+    if (isEnabledBackendEntry(entry)) {
+      return entry.type
+    }
+  }
+  return undefined
+}
+
+/**
+ * Reject any flag in `rest` that is not in `allowed`. Returns the raw form of
+ * the first unknown flag encountered, or `undefined` if all flags are allowed.
+ * A typo in a flag name must never be silently ignored — it could route
+ * secrets to an unintended credential store.
+ */
+function findUnknownFlag(rest: string[], allowed: ReadonlySet<string>): string | undefined {
+  const { tokens } = parseArgs({ args: rest, strict: false, allowPositionals: true, tokens: true })
+  for (const token of tokens) {
+    if (token.kind === 'option' && !allowed.has(token.name)) {
+      return token.rawName
+    }
+  }
+  return undefined
 }
 
 function printConfigHelp(): void {
@@ -48,6 +103,9 @@ function printConfigHelp(): void {
       'Subcommands:\n' +
       '  init   Create a default config file\n' +
       '  show   Print the current config file\n\n' +
+      'Options for init:\n' +
+      '  --backend <type>   Backend to configure as the active store\n' +
+      `                     (valid: ${BackendRegistry.getTypes().join(', ')})\n\n` +
       'Options:\n' +
       '  -h, --help   Show this help message\n',
   )
@@ -58,6 +116,119 @@ function isEnoent(err: unknown): boolean {
   return err instanceof Error && 'code' in err && err.code === 'ENOENT'
 }
 
+async function configInit(rest: string[]): Promise<number> {
+  const unknownFlag = findUnknownFlag(rest, new Set(['backend']))
+  if (unknownFlag !== undefined) {
+    process.stderr.write(`Error: unknown option '${unknownFlag}' for 'config init'\n`)
+    return 2
+  }
+
+  const { values } = parseArgs({
+    args: rest,
+    options: { backend: { type: 'string' } },
+    allowPositionals: true,
+    strict: false,
+  })
+
+  let requestedBackend: string | undefined
+  if (values.backend !== undefined) {
+    if (typeof values.backend !== 'string' || values.backend.trim() === '') {
+      process.stderr.write('Error: --backend requires a backend type value\n')
+      return 2
+    }
+    const validTypes = BackendRegistry.getTypes()
+    if (!validTypes.includes(values.backend)) {
+      process.stderr.write(
+        `Error: unknown backend type '${values.backend}'. Valid types: ${validTypes.join(', ')}\n`,
+      )
+      return 2
+    }
+    requestedBackend = values.backend
+  }
+
+  const backendType = requestedBackend ?? platformDefaultBackendType()
+
+  try {
+    const configDir = getDefaultConfigDir()
+    const configPath = path.join(configDir, 'config.json')
+    // Create config directory with restrictive permissions.
+    await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
+
+    try {
+      await fs.access(configPath)
+      process.stderr.write(`Config already exists at ${configPath}\n`)
+      return 1
+    } catch {
+      // File doesn't exist — create it.
+    }
+
+    await fs.writeFile(configPath, buildConfig(backendType) + '\n', {
+      encoding: 'utf8',
+      mode: 0o600,
+    })
+    process.stdout.write(`Config created at ${configPath}\n`)
+
+    if (requestedBackend === undefined) {
+      if (backendType === 'file') {
+        process.stdout.write(
+          `Backend: file (${platformLabel()} default). ` +
+            'Use --backend <type> to target an OS credential store.\n',
+        )
+      } else {
+        process.stdout.write(
+          `Backend: ${backendType} (${platformLabel()} default). ` +
+            'Use --backend file for a portable, CI-friendly store.\n',
+        )
+      }
+    } else {
+      process.stdout.write(
+        `Backend: ${backendType} (from --backend). ` +
+          "Re-run 'vaultkeeper config init --backend <type>' to change.\n",
+      )
+    }
+    return 0
+  } catch (err) {
+    process.stderr.write(`${formatError(err)}\n`)
+    return 1
+  }
+}
+
+async function configShow(rest: string[]): Promise<number> {
+  const unknownFlag = findUnknownFlag(rest, new Set())
+  if (unknownFlag !== undefined) {
+    process.stderr.write(`Error: unknown option '${unknownFlag}' for 'config show'\n`)
+    return 2
+  }
+
+  try {
+    const configDir = getDefaultConfigDir()
+    const configPath = path.join(configDir, 'config.json')
+    const content = await fs.readFile(configPath, 'utf8')
+    process.stdout.write(content)
+    if (!content.endsWith('\n')) {
+      process.stdout.write('\n')
+    }
+    // Report the resolved active backend on stderr so stdout stays valid JSON.
+    const active = firstEnabledBackendType(content)
+    if (active !== undefined) {
+      process.stderr.write(`Active backend: ${active} (first enabled)\n`)
+    } else {
+      process.stderr.write('Active backend: none (no enabled backend found)\n')
+    }
+    return 0
+  } catch (err) {
+    // Show a user-friendly message when the config file is missing.
+    if (isEnoent(err)) {
+      process.stderr.write(
+        "Error: No config file found. Run 'vaultkeeper config init' to create one.\n",
+      )
+      return 1
+    }
+    process.stderr.write(`${formatError(err)}\n`)
+    return 1
+  }
+}
+
 export async function configCommand(args: string[]): Promise<number> {
   // Handle --help / -h before subcommand dispatch.
   if (args.includes('--help') || args.includes('-h')) {
@@ -65,61 +236,15 @@ export async function configCommand(args: string[]): Promise<number> {
     return 0
   }
 
-  const { positionals } = parseArgs({
-    args,
-    allowPositionals: true,
-    strict: false,
-  })
-
-  const subcommand = positionals[0]
+  const subcommand = args[0]
+  const rest = args.slice(1)
 
   switch (subcommand) {
-    case 'init': {
-      try {
-        const configDir = getDefaultConfigDir()
-        const configPath = path.join(configDir, 'config.json')
-        // [W4 fix] Create config directory with restrictive permissions
-        await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
+    case 'init':
+      return configInit(rest)
 
-        try {
-          await fs.access(configPath)
-          process.stderr.write(`Config already exists at ${configPath}\n`)
-          return 1
-        } catch {
-          // File doesn't exist — create it
-        }
-
-        await fs.writeFile(configPath, getDefaultConfig() + '\n', { encoding: 'utf8', mode: 0o600 })
-        process.stdout.write(`Config created at ${configPath}\n`)
-        return 0
-      } catch (err) {
-        process.stderr.write(`${formatError(err)}\n`)
-        return 1
-      }
-    }
-
-    case 'show': {
-      try {
-        const configDir = getDefaultConfigDir()
-        const configPath = path.join(configDir, 'config.json')
-        const content = await fs.readFile(configPath, 'utf8')
-        process.stdout.write(content)
-        if (!content.endsWith('\n')) {
-          process.stdout.write('\n')
-        }
-        return 0
-      } catch (err) {
-        // Show a user-friendly message when the config file is missing.
-        if (isEnoent(err)) {
-          process.stderr.write(
-            "Error: No config file found. Run 'vaultkeeper config init' to create one.\n",
-          )
-          return 1
-        }
-        process.stderr.write(`${formatError(err)}\n`)
-        return 1
-      }
-    }
+    case 'show':
+      return configShow(rest)
 
     default:
       process.stderr.write('Error: missing or unknown config subcommand\n')

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -179,6 +179,9 @@ export interface ListableBackend extends SecretBackend {
 export type Platform = 'darwin' | 'win32' | 'linux';
 
 // @public
+export function platformDefaultBackendType(): string;
+
+// @public
 export class PluginNotFoundError extends VaultError {
     constructor(message: string, plugin: string, installUrl: string);
     readonly installUrl: string;
@@ -329,6 +332,7 @@ export class VaultError extends Error {
 
 // @public
 export class VaultKeeper {
+    get activeBackendType(): string;
     approveExecutable(executablePath: string): Promise<ExecutableTrustStatus>;
     authorize(jwe: string): Promise<{
         token: CapabilityToken;

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -27,11 +27,47 @@ export function getDefaultConfigDir(): string {
   return path.join(os.homedir(), '.config', 'vaultkeeper')
 }
 
-/** Default configuration when no config file exists. */
+/**
+ * Resolve the backend type that vaultkeeper uses by default on the current
+ * platform when no backend is explicitly configured.
+ *
+ * @remarks
+ * The default deliberately targets the platform-native OS credential store so
+ * that secrets are protected by the operating system out of the box:
+ *
+ * - **macOS** → `keychain` (macOS Keychain)
+ * - **Windows** → `dpapi` (Windows DPAPI)
+ * - **all other platforms** (Linux, etc.) → `file` (AES-256-GCM encrypted file)
+ *
+ * On macOS and Windows this means a bare {@link VaultKeeper.(init:1)} — or a
+ * `vaultkeeper config init` with no `--backend` flag — writes to the real OS
+ * credential store. Choose `file` explicitly for a portable, CI-friendly store
+ * that requires no system credential service.
+ *
+ * @returns The default backend type identifier for the current platform.
+ * @public
+ */
+export function platformDefaultBackendType(): string {
+  if (process.platform === 'darwin') {
+    return 'keychain'
+  }
+  if (process.platform === 'win32') {
+    return 'dpapi'
+  }
+  // Linux and other Unix-like systems. Use 'file' rather than 'secret-tool'
+  // because secret-tool requires libsecret-tools, which many systems lack.
+  return 'file'
+}
+
+/**
+ * Default configuration when no config file exists.
+ *
+ * The active backend is resolved by {@link platformDefaultBackendType}.
+ */
 function defaultConfig(): VaultConfig {
   return {
     version: 1,
-    backends: [{ type: 'file', enabled: true }],
+    backends: [{ type: platformDefaultBackendType(), enabled: true }],
     keyRotation: { gracePeriodDays: 7 },
     defaults: { ttlMinutes: 60, trustTier: 3 },
   }

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -39,7 +39,7 @@ export function getDefaultConfigDir(): string {
  * - **Windows** → `dpapi` (Windows DPAPI)
  * - **all other platforms** (Linux, etc.) → `file` (AES-256-GCM encrypted file)
  *
- * On macOS and Windows this means a bare {@link VaultKeeper.(init:1)} — or a
+ * On macOS and Windows this means a bare {@link VaultKeeper.init} — or a
  * `vaultkeeper config init` with no `--backend` flag — writes to the real OS
  * credential store. Choose `file` explicitly for a portable, CI-friendly store
  * that requires no system credential service.

--- a/packages/vaultkeeper/src/index.ts
+++ b/packages/vaultkeeper/src/index.ts
@@ -70,6 +70,8 @@ export type {
   ExecutableTrustStatus,
 } from './vault.js'
 
+export { platformDefaultBackendType } from './config.js'
+
 export { runDoctor } from './doctor/runner.js'
 export type { RunDoctorOptions } from './doctor/runner.js'
 export type { Platform } from './util/platform.js'

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -69,7 +69,16 @@ import {
  */
 export type SecretTokenMap = Record<string, CapabilityToken>
 
-/** Options for initializing VaultKeeper. */
+/**
+ * Options for initializing VaultKeeper.
+ *
+ * @remarks
+ * When neither `config` nor a config file (at `configDir`) is present, the
+ * active backend falls back to the platform default resolved by
+ * {@link platformDefaultBackendType} — `keychain` on macOS, `dpapi` on
+ * Windows, `file` elsewhere. Inspect {@link VaultKeeper.activeBackendType}
+ * after `init()` to confirm which backend a given instance resolved to.
+ */
 export interface VaultKeeperOptions {
   /** Override the config directory. */
   configDir?: string | undefined
@@ -193,6 +202,23 @@ export class VaultKeeper {
    */
   static async doctor(options?: RunDoctorOptions): Promise<PreflightResult> {
     return runDoctor(options)
+  }
+
+  /**
+   * The type identifier of the active backend — the first enabled backend in
+   * the resolved configuration (the one `store()`, `delete()`, and `setup()`
+   * operate on).
+   *
+   * @remarks
+   * Use this to confirm which backend an instance resolved to, especially when
+   * no config file exists and the platform default applies (see
+   * {@link platformDefaultBackendType}). On macOS this reads `keychain` by
+   * default, meaning operations target the real OS Keychain.
+   *
+   * @public
+   */
+  get activeBackendType(): string {
+    return this.#requireBackend().type
   }
 
   /**

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -210,15 +210,32 @@ export class VaultKeeper {
    * operate on).
    *
    * @remarks
-   * Use this to confirm which backend an instance resolved to, especially when
+   * This is a pure, side-effect-free view of the resolved configuration: it
+   * reads the type of the first enabled backend without instantiating the
+   * backend or requiring it to be registered or healthy. Reading it therefore
+   * never throws for an unavailable or unregistered backend — unlike a secret
+   * operation — so it is safe to call purely to introspect an instance.
+   *
+   * Use it to confirm which backend an instance resolved to, especially when
    * no config file exists and the platform default applies (see
    * {@link platformDefaultBackendType}). On macOS this reads `keychain` by
-   * default, meaning operations target the real OS Keychain.
+   * default, meaning secret operations target the real OS Keychain.
+   *
+   * @throws A {@link BackendUnavailableError} only when the configuration has
+   * no enabled backend at all (a configuration error, not a backend fault).
    *
    * @public
    */
   get activeBackendType(): string {
-    return this.#requireBackend().type
+    const firstEnabled = this.#config.backends.find((b) => b.enabled)
+    if (firstEnabled === undefined) {
+      throw new BackendUnavailableError(
+        'No enabled backends configured',
+        'none-enabled',
+        this.#config.backends.map((b) => b.type),
+      )
+    }
+    return firstEnabled.type
   }
 
   /**

--- a/packages/vaultkeeper/test/unit/config.test.ts
+++ b/packages/vaultkeeper/test/unit/config.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { validateConfig, loadConfig, getDefaultConfigDir } from '../../src/config.js'
+import {
+  validateConfig,
+  loadConfig,
+  getDefaultConfigDir,
+  platformDefaultBackendType,
+} from '../../src/config.js'
 import { ConfigValidationError } from '../../src/errors.js'
 
 vi.mock('node:fs/promises', () => ({
@@ -319,5 +324,26 @@ describe('loadConfig', () => {
   it('should throw on invalid config structure', async () => {
     vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: 99 }))
     await expect(loadConfig('/fake')).rejects.toThrow('version must be 1')
+  })
+
+  it('should resolve the platform-default backend when no config file exists', async () => {
+    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'))
+    const config = await loadConfig('/nonexistent')
+    const firstBackend = config.backends[0]
+    expect(firstBackend?.type).toBe(platformDefaultBackendType())
+  })
+})
+
+// ---------------------------------------------------------------------------
+// platformDefaultBackendType
+// ---------------------------------------------------------------------------
+
+describe('platformDefaultBackendType', () => {
+  it('should map the current platform to its native credential store', () => {
+    // Resolution contract (see platformDefaultBackendType docs):
+    // macOS -> keychain, Windows -> dpapi, everything else -> file.
+    const expected =
+      process.platform === 'darwin' ? 'keychain' : process.platform === 'win32' ? 'dpapi' : 'file'
+    expect(platformDefaultBackendType()).toBe(expected)
   })
 })

--- a/packages/vaultkeeper/test/unit/vault.test.ts
+++ b/packages/vaultkeeper/test/unit/vault.test.ts
@@ -100,6 +100,26 @@ describe('VaultKeeper', () => {
       })
       expect(vault.activeBackendType).toBe('test')
     })
+
+    // Introspection must not instantiate the backend: reading the type of an
+    // unregistered/unavailable backend returns its configured type instead of
+    // throwing (thread 3582762757 — a getter that called #requireBackend()
+    // would have thrown here).
+    it('should return the configured type without instantiating an unregistered backend', async () => {
+      // No BackendRegistry.register('unregistered-backend', ...) — the type is
+      // not registered, so instantiating it would throw.
+      const vault = await VaultKeeper.init({
+        skipDoctor: true,
+        configDir: '/tmp/vaultkeeper-test',
+        config: {
+          version: 1,
+          backends: [{ type: 'unregistered-backend', enabled: true }],
+          keyRotation: { gracePeriodDays: 7 },
+          defaults: { ttlMinutes: 60, trustTier: 3 },
+        },
+      })
+      expect(vault.activeBackendType).toBe('unregistered-backend')
+    })
   })
 
   describe('doctor', () => {

--- a/packages/vaultkeeper/test/unit/vault.test.ts
+++ b/packages/vaultkeeper/test/unit/vault.test.ts
@@ -76,6 +76,32 @@ describe('VaultKeeper', () => {
     })
   })
 
+  describe('activeBackendType', () => {
+    it('should expose the type of the first enabled backend', async () => {
+      const vault = await initVault()
+      expect(vault.activeBackendType).toBe('test')
+    })
+
+    it('should reflect the first enabled backend when several are configured', async () => {
+      const backend = createMockBackend()
+      BackendRegistry.register('test', () => backend)
+      const vault = await VaultKeeper.init({
+        skipDoctor: true,
+        configDir: '/tmp/vaultkeeper-test',
+        config: {
+          version: 1,
+          backends: [
+            { type: 'disabled-first', enabled: false },
+            { type: 'test', enabled: true },
+          ],
+          keyRotation: { gracePeriodDays: 7 },
+          defaults: { ttlMinutes: 60, trustTier: 3 },
+        },
+      })
+      expect(vault.activeBackendType).toBe('test')
+    })
+  })
+
   describe('doctor', () => {
     it('should return a preflight result', async () => {
       const result = await VaultKeeper.doctor()
@@ -234,9 +260,7 @@ describe('VaultKeeper', () => {
       const { token } = await vault.authorize(jwe)
 
       const mockResult = { stdout: 'hunter2\n', stderr: '', exitCode: 0 }
-      const execSpy = vi
-        .spyOn(delegatedExecModule, 'delegatedExec')
-        .mockResolvedValue(mockResult)
+      const execSpy = vi.spyOn(delegatedExecModule, 'delegatedExec').mockResolvedValue(mockResult)
 
       const { result, vaultResponse } = await vault.exec(token, {
         command: 'echo',
@@ -257,9 +281,7 @@ describe('VaultKeeper', () => {
       const { token } = await vault.authorize(jwe)
 
       const mockResult = { signature: 'c2lnbmF0dXJl', algorithm: 'ed25519' }
-      const signSpy = vi
-        .spyOn(delegatedSignModule, 'delegatedSign')
-        .mockReturnValue(mockResult)
+      const signSpy = vi.spyOn(delegatedSignModule, 'delegatedSign').mockReturnValue(mockResult)
 
       const { result, vaultResponse } = await vault.sign(token, { data: 'test-data' })
 
@@ -273,9 +295,7 @@ describe('VaultKeeper', () => {
 
   describe('verify', () => {
     it('delegates to delegatedVerify', () => {
-      const verifySpy = vi
-        .spyOn(delegatedVerifyModule, 'delegatedVerify')
-        .mockReturnValue(true)
+      const verifySpy = vi.spyOn(delegatedVerifyModule, 'delegatedVerify').mockReturnValue(true)
 
       const result = VaultKeeper.verify({
         data: 'test',
@@ -330,9 +350,9 @@ describe('VaultKeeper', () => {
 
     it('should reject setup for nonexistent secret', async () => {
       const vault = await initVault()
-      await expect(
-        vault.setup('nonexistent', { executablePath: 'dev' }),
-      ).rejects.toThrow('Secret not found')
+      await expect(vault.setup('nonexistent', { executablePath: 'dev' })).rejects.toThrow(
+        'Secret not found',
+      )
     })
 
     it('should reject store with empty secret name', async () => {
@@ -352,9 +372,9 @@ describe('VaultKeeper', () => {
 
     it('should reject setup with empty secret name', async () => {
       const vault = await initVault()
-      await expect(
-        vault.setup('', { executablePath: 'dev' }),
-      ).rejects.toThrow('Secret name must not be empty')
+      await expect(vault.setup('', { executablePath: 'dev' })).rejects.toThrow(
+        'Secret name must not be empty',
+      )
     })
   })
 })


### PR DESCRIPTION
Refs #61

## Summary

Makes backend selection visible and overridable from the CLI, and introspectable from the library. Previously `config init` hardcoded the platform default with no way to choose otherwise, and `config init --backend file` exited 0 while silently ignoring the unknown flag and writing keychain — a typo could route secrets to an unintended credential store.

The platform default is unchanged (keychain on macOS, dpapi on Windows, file elsewhere) — it is now just visible and overridable.

## Changes

**CLI (`@vaultkeeper/cli`)**
- `config init --backend <type>` writes a config whose first enabled backend is `<type>`; an unknown value exits 2 and lists the valid registered types.
- Any unknown flag on `config init` / `config show` exits 2 with an "unknown option" error instead of being silently ignored (scoped to config subcommands; global exit-code taxonomy is tracked separately in #69).
- `config init` output states which backend was configured and how to change it; without `--backend` the platform default is kept.
- `config show` reports the resolved active backend (first enabled) on stderr, keeping stdout valid JSON.

**Library (`vaultkeeper`)**
- New public `platformDefaultBackendType()` documents exactly how the default resolves when no config exists. A bare `VaultKeeper.init()` with no config file now follows this same resolution (previously it always fell back to `file`).
- New public `VaultKeeper.activeBackendType` getter exposes the active backend type at runtime.
- `VaultKeeperOptions` documents the fallback.

**Docs**
- README quick start warns that a bare `VaultKeeper.init()` / `config init` targets the real OS keychain on macOS/Windows, with the file-backend override shown alongside.

## CLI output

### \`vaultkeeper config init\` (default)

\`\`\`diff
  Config created at <dir>/config.json
+ Backend: keychain (macOS default). Use --backend file for a portable, CI-friendly store.
\`\`\`

### \`vaultkeeper config init --backend <bad>\`

\`\`\`diff
+ Error: unknown backend type 'bad'. Valid types: file, keychain, ...
\`\`\`
(exit 2)

## Testing

- `pnpm check` (typecheck + lint + API report) green; API report regenerated.
- Subprocess CLI tests per acceptance criterion in an isolated config dir: `--backend file` writes the file backend, unknown flag exits 2, unknown backend value exits 2, default init keeps the platform default and reports it, `config show` reports the active backend, and an `init --backend file` → `show` end-to-end.
- Library unit tests for `platformDefaultBackendType()` and `activeBackendType`.
- Changeset included (minor bump for `vaultkeeper` and `@vaultkeeper/cli`).