### PR TITLE
Document testing patterns and add VaultKeeperOptions.backend injection

### DIFF
--- a/.changeset/testing-docs-backend-option.md
+++ b/.changeset/testing-docs-backend-option.md
@@ -1,0 +1,5 @@
+---
+'vaultkeeper': minor
+---
+
+Add a `backend` option to `VaultKeeperOptions` that accepts a `SecretBackend` instance directly, so tests and embedders can inject a backend without registering it globally via `BackendRegistry` or hand-assembling a full `VaultConfig`. When `backend` is set it always takes precedence over the backend that `config.backends` (or the config loaded from `configDir`) would otherwise resolve; other config fields still come from `config`/`configDir` when supplied, and a minimal built-in default config is used automatically when `config` is omitted. The README's "Testing your own code" and "Injecting a backend directly" sections document a dependency-injection pattern for testing code that uses `VaultKeeper`.

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ const { result } = await keeper.exec(token, {
 
 ### Testing your own code
 
-Application code that calls `VaultKeeper.init()` internally can't be swapped onto a test backend. Structure your code to accept a `VaultKeeper` instance instead — production passes the real one, tests pass `TestVault.keeper`.
+Application code that calls `VaultKeeper.init()` internally can't be swapped onto a test backend. Structure your code to accept a `VaultKeeper` instance instead — production passes the real one, tests pass the `keeper` from a `TestVault` instance (`const { keeper } = await TestVault.create()`).
 
 **Before** — the function constructs its own `VaultKeeper`, so a test can only exercise it against a real backend:
 
@@ -445,7 +445,7 @@ const vault = await VaultKeeper.init()
 const header = await buildAuthHeader(vault, 'MY_API_KEY')
 ```
 
-Test with `TestVault.keeper` in place of the real vault:
+Test with the `keeper` from a `TestVault` instance in place of the real vault:
 
 ```ts
 // test/build-auth-header.test.ts

--- a/README.md
+++ b/README.md
@@ -394,6 +394,94 @@ const { result } = await keeper.exec(token, {
 
 `TestVault` uses an in-memory backend — no OS keychain, no file system, no doctor checks.
 
+### Testing your own code
+
+Application code that calls `VaultKeeper.init()` internally can't be swapped onto a test backend. Structure your code to accept a `VaultKeeper` instance instead — production passes the real one, tests pass `TestVault.keeper`.
+
+**Before** — the function constructs its own `VaultKeeper`, so a test can only exercise it against a real backend:
+
+```ts
+// src/build-auth-header.ts
+import { VaultKeeper } from 'vaultkeeper'
+
+export async function buildAuthHeader(secretName: string): Promise<string> {
+  const vault = await VaultKeeper.init() // always the real backend + doctor checks
+  const jwe = await vault.setup(secretName)
+  const { token } = await vault.authorize(jwe)
+  const accessor = vault.getSecret(token)
+  let header = ''
+  accessor.read((buf) => {
+    header = `Bearer ${buf.toString('utf8')}`
+  })
+  return header
+}
+```
+
+**After** — the `VaultKeeper` instance is a parameter, so the caller decides which vault to use:
+
+```ts
+// src/build-auth-header.ts
+import type { VaultKeeper } from 'vaultkeeper'
+
+export async function buildAuthHeader(vault: VaultKeeper, secretName: string): Promise<string> {
+  const jwe = await vault.setup(secretName)
+  const { token } = await vault.authorize(jwe)
+  const accessor = vault.getSecret(token)
+  let header = ''
+  accessor.read((buf) => {
+    header = `Bearer ${buf.toString('utf8')}`
+  })
+  return header
+}
+```
+
+Production call site is unchanged apart from passing the vault along:
+
+```ts
+import { VaultKeeper } from 'vaultkeeper'
+import { buildAuthHeader } from './build-auth-header.js'
+
+const vault = await VaultKeeper.init()
+const header = await buildAuthHeader(vault, 'MY_API_KEY')
+```
+
+Test with `TestVault.keeper` in place of the real vault:
+
+```ts
+// test/build-auth-header.test.ts
+import { describe, expect, it } from 'vitest'
+import { TestVault } from '@vaultkeeper/test-helpers'
+import { buildAuthHeader } from '../src/build-auth-header.js'
+
+describe('buildAuthHeader', () => {
+  it('formats the stored secret as a Bearer token', async () => {
+    const { keeper, backend } = await TestVault.create()
+    await backend.store('MY_API_KEY', 'test-key-123')
+
+    const header = await buildAuthHeader(keeper, 'MY_API_KEY')
+
+    expect(header).toBe('Bearer test-key-123')
+  })
+})
+```
+
+### Injecting a backend directly
+
+For cases where `TestVault` doesn't fit — e.g. an embedder that already has a `SecretBackend` instance — pass it via `VaultKeeperOptions.backend`. This skips both the global `BackendRegistry` and hand-assembling a full `VaultConfig`:
+
+```ts
+import { VaultKeeper } from 'vaultkeeper'
+import { InMemoryBackend } from '@vaultkeeper/test-helpers'
+
+const backend = new InMemoryBackend()
+const vault = await VaultKeeper.init({ backend, skipDoctor: true })
+
+await vault.store('MY_SECRET', 'hunter2')
+const jwe = await vault.setup('MY_SECRET')
+```
+
+See the `backend` option's JSDoc for how it interacts with `config`/`configDir`.
+
 ## Configuration
 
 Config is loaded from `~/.config/vaultkeeper/config.json` by default. Override with `configDir` in init options or supply `config` directly.

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -365,6 +365,7 @@ export class VaultKeeper {
 
 // @public
 export interface VaultKeeperOptions {
+    backend?: SecretBackend | undefined;
     config?: VaultConfig | undefined;
     configDir?: string | undefined;
     skipDoctor?: boolean | undefined;

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -70,20 +70,58 @@ import {
 export type SecretTokenMap = Record<string, CapabilityToken>
 
 /**
+ * Minimal built-in config used when {@link VaultKeeperOptions.backend} is
+ * supplied without {@link VaultKeeperOptions.config}. Mirrors the defaults a
+ * hand-assembled test config would use (short-lived tokens, dev-mode trust),
+ * so an injected backend never requires a config file on disk or a
+ * hand-assembled {@link VaultConfig}.
+ */
+const DEFAULT_INJECTED_BACKEND_CONFIG: VaultConfig = {
+  version: 1,
+  backends: [],
+  keyRotation: { gracePeriodDays: 7 },
+  defaults: { ttlMinutes: 60, trustTier: 3 },
+}
+
+/**
  * Options for initializing VaultKeeper.
  *
  * @remarks
- * When neither `config` nor a config file (at `configDir`) is present, the
- * active backend falls back to the platform default resolved by
- * {@link platformDefaultBackendType} — `keychain` on macOS, `dpapi` on
- * Windows, `file` elsewhere. Inspect {@link VaultKeeper.activeBackendType}
- * after `init()` to confirm which backend a given instance resolved to.
+ * When neither `config` nor a config file (at `configDir`) is present, and
+ * {@link VaultKeeperOptions.backend} is not set, the active backend falls
+ * back to the platform default resolved by {@link platformDefaultBackendType}
+ * — `keychain` on macOS, `dpapi` on Windows, `file` elsewhere. Inspect
+ * {@link VaultKeeper.activeBackendType} after `init()` to confirm which
+ * backend a given instance resolved to. When `backend` is set instead, see
+ * that option's own JSDoc for the fallback config used in its place.
  */
 export interface VaultKeeperOptions {
   /** Override the config directory. */
   configDir?: string | undefined
   /** Supply config directly, skipping file load. */
   config?: VaultConfig | undefined
+  /**
+   * Inject a {@link SecretBackend} instance directly, bypassing the global
+   * {@link BackendRegistry} and `config.backends` resolution entirely.
+   *
+   * This is the primary hook for tests and embedders that want to store and
+   * retrieve secrets without registering a backend globally or hand
+   * assembling a full {@link VaultConfig}. When set, this backend instance is
+   * used for every `store()`/`retrieve()`/`setup()` call.
+   *
+   * **Precedence with `config`/`configDir`:**
+   * - `backend` always wins over the backend that `config.backends` (or the
+   *   config loaded from `configDir`) would otherwise resolve — the
+   *   `backends` array is never consulted when `backend` is set.
+   * - Other config fields (`keyRotation`, `defaults`, `developmentMode`)
+   *   still come from `config`, or from the config loaded from `configDir`,
+   *   when either is provided.
+   * - If `backend` is set and `config` is omitted, a minimal built-in
+   *   default config is used instead of loading one from `configDir` — so a
+   *   caller that only needs an injected backend never has to construct a
+   *   {@link VaultConfig} or touch `configDir` at all.
+   */
+  backend?: SecretBackend | undefined
   /** Skip the doctor preflight check. */
   skipDoctor?: boolean | undefined
 }
@@ -158,10 +196,16 @@ export class VaultKeeper {
   readonly #configDir: string
   #backend: SecretBackend | undefined
 
-  private constructor(config: VaultConfig, keyManager: KeyManager, configDir: string) {
+  private constructor(
+    config: VaultConfig,
+    keyManager: KeyManager,
+    configDir: string,
+    backend?: SecretBackend,
+  ) {
     this.#config = config
     this.#keyManager = keyManager
     this.#configDir = configDir
+    this.#backend = backend
   }
 
   /**
@@ -176,7 +220,11 @@ export class VaultKeeper {
    */
   static async init(options?: VaultKeeperOptions): Promise<VaultKeeper> {
     const configDir = options?.configDir ?? getDefaultConfigDir()
-    const config = options?.config ?? (await loadConfig(configDir))
+    const config =
+      options?.config ??
+      (options?.backend !== undefined
+        ? DEFAULT_INJECTED_BACKEND_CONFIG
+        : await loadConfig(configDir))
 
     if (options?.skipDoctor !== true) {
       const doctorResult = await runDoctor({ backends: config.backends })
@@ -188,7 +236,7 @@ export class VaultKeeper {
     const keyManager = new KeyManager()
     await keyManager.init()
 
-    return new VaultKeeper(config, keyManager, configDir)
+    return new VaultKeeper(config, keyManager, configDir, options?.backend)
   }
 
   /**

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -70,17 +70,23 @@ import {
 export type SecretTokenMap = Record<string, CapabilityToken>
 
 /**
- * Minimal built-in config used when {@link VaultKeeperOptions.backend} is
- * supplied without {@link VaultKeeperOptions.config}. Mirrors the defaults a
+ * Builds a minimal built-in config used when {@link VaultKeeperOptions.backend}
+ * is supplied without {@link VaultKeeperOptions.config}. Mirrors the defaults a
  * hand-assembled test config would use (short-lived tokens, dev-mode trust),
  * so an injected backend never requires a config file on disk or a
  * hand-assembled {@link VaultConfig}.
+ *
+ * Returns a fresh object on every call — `VaultKeeper` mutates `#config` in
+ * place (e.g. `setDevelopmentMode()`), so a shared constant would let
+ * separate `init()` calls corrupt each other's state.
  */
-const DEFAULT_INJECTED_BACKEND_CONFIG: VaultConfig = {
-  version: 1,
-  backends: [],
-  keyRotation: { gracePeriodDays: 7 },
-  defaults: { ttlMinutes: 60, trustTier: 3 },
+function createDefaultInjectedBackendConfig(): VaultConfig {
+  return {
+    version: 1,
+    backends: [],
+    keyRotation: { gracePeriodDays: 7 },
+    defaults: { ttlMinutes: 60, trustTier: 3 },
+  }
 }
 
 /**
@@ -223,7 +229,7 @@ export class VaultKeeper {
     const config =
       options?.config ??
       (options?.backend !== undefined
-        ? DEFAULT_INJECTED_BACKEND_CONFIG
+        ? createDefaultInjectedBackendConfig()
         : await loadConfig(configDir))
 
     if (options?.skipDoctor !== true) {

--- a/packages/vaultkeeper/test/unit/vault.test.ts
+++ b/packages/vaultkeeper/test/unit/vault.test.ts
@@ -41,6 +41,32 @@ function createMockBackend(secrets: Record<string, string> = {}): SecretBackend 
   }
 }
 
+/** A `SecretBackend` backed by a real `Map`, so store() output is visible to retrieve(). */
+function createStatefulMockBackend(): SecretBackend {
+  const store = new Map<string, string>()
+  return {
+    type: 'test',
+    displayName: 'Stateful Test Backend',
+    isAvailable: () => Promise.resolve(true),
+    store: (id: string, secret: string) => {
+      store.set(id, secret)
+      return Promise.resolve()
+    },
+    retrieve: (id: string) => {
+      const val = store.get(id)
+      if (val === undefined) {
+        return Promise.reject(new Error(`Secret not found: ${id}`))
+      }
+      return Promise.resolve(val)
+    },
+    delete: (id: string) => {
+      store.delete(id)
+      return Promise.resolve()
+    },
+    exists: (id: string) => Promise.resolve(store.has(id)),
+  }
+}
+
 async function initVault(
   secrets: Record<string, string> = { 'my-secret': 'hunter2' },
 ): Promise<VaultKeeper> {
@@ -134,22 +160,25 @@ describe('VaultKeeper', () => {
     })
 
     it('round-trips a store/retrieve through the injected backend', async () => {
-      const storeSpy = vi.fn(() => Promise.resolve())
-      const backend = createMockBackend({ 'my-secret': 'hunter2' })
-      backend.store = storeSpy
+      // A stateful backend (unlike createMockBackend's fixed secrets map) so
+      // the test proves store() output is actually visible to retrieve() —
+      // not just that store() was called.
+      const backend = createStatefulMockBackend()
       const vault = await VaultKeeper.init({ skipDoctor: true, backend })
 
       await vault.store('injected-secret', 'injected-value')
-      expect(storeSpy).toHaveBeenCalledWith('injected-secret', 'injected-value')
 
-      const jwe = await vault.setup('my-secret', { executablePath: 'dev' })
+      const retrieved = await backend.retrieve('injected-secret')
+      expect(retrieved).toBe('injected-value')
+
+      const jwe = await vault.setup('injected-secret', { executablePath: 'dev' })
       const { token } = await vault.authorize(jwe)
       const accessor = vault.getSecret(token)
       let captured = ''
       accessor.read((buf) => {
         captured = buf.toString('utf-8')
       })
-      expect(captured).toBe('hunter2')
+      expect(captured).toBe('injected-value')
     })
 
     it('uses a minimal built-in default config when config is omitted', async () => {
@@ -160,6 +189,38 @@ describe('VaultKeeper', () => {
       const vault = await VaultKeeper.init({ skipDoctor: true, backend })
 
       const jwe = await vault.setup('my-secret', { executablePath: 'dev' })
+      expect(typeof jwe).toBe('string')
+    })
+
+    it('does not share/mutate config between two instances created with the backend option', async () => {
+      // Regression: init() previously reused a single shared
+      // DEFAULT_INJECTED_BACKEND_CONFIG object whenever `backend` was set
+      // without `config`, so mutating one instance's config (e.g. via
+      // setDevelopmentMode()) leaked into every other instance created the
+      // same way.
+      const vault1 = await VaultKeeper.init({
+        skipDoctor: true,
+        backend: createMockBackend({ 'my-secret': 'hunter2' }),
+      })
+      const vault2 = await VaultKeeper.init({
+        skipDoctor: true,
+        backend: createMockBackend({ 'my-secret': 'hunter2' }),
+      })
+
+      // Add a nonexistent path to vault1's dev-mode allowlist only.
+      await vault1.setDevelopmentMode('/nonexistent/dev-only-tool', true)
+
+      // vault2 must not see vault1's dev-mode entry: since the path isn't
+      // 'dev' and isn't on vault2's own allowlist, setup() must attempt real
+      // identity verification and fail because the file doesn't exist.
+      await expect(
+        vault2.setup('my-secret', { executablePath: '/nonexistent/dev-only-tool' }),
+      ).rejects.toThrow()
+
+      // vault1, which explicitly enabled dev mode for that path, must still succeed.
+      const jwe = await vault1.setup('my-secret', {
+        executablePath: '/nonexistent/dev-only-tool',
+      })
       expect(typeof jwe).toBe('string')
     })
 

--- a/packages/vaultkeeper/test/unit/vault.test.ts
+++ b/packages/vaultkeeper/test/unit/vault.test.ts
@@ -122,6 +122,94 @@ describe('VaultKeeper', () => {
     })
   })
 
+  describe('init with backend option', () => {
+    it('initializes without registering a backend in BackendRegistry', async () => {
+      // No BackendRegistry.register() call anywhere in this test — the
+      // injected backend must be usable without global registration.
+      const backend = createMockBackend({ 'my-secret': 'hunter2' })
+
+      const vault = await VaultKeeper.init({ skipDoctor: true, backend })
+
+      expect(vault).toBeInstanceOf(VaultKeeper)
+    })
+
+    it('round-trips a store/retrieve through the injected backend', async () => {
+      const storeSpy = vi.fn(() => Promise.resolve())
+      const backend = createMockBackend({ 'my-secret': 'hunter2' })
+      backend.store = storeSpy
+      const vault = await VaultKeeper.init({ skipDoctor: true, backend })
+
+      await vault.store('injected-secret', 'injected-value')
+      expect(storeSpy).toHaveBeenCalledWith('injected-secret', 'injected-value')
+
+      const jwe = await vault.setup('my-secret', { executablePath: 'dev' })
+      const { token } = await vault.authorize(jwe)
+      const accessor = vault.getSecret(token)
+      let captured = ''
+      accessor.read((buf) => {
+        captured = buf.toString('utf-8')
+      })
+      expect(captured).toBe('hunter2')
+    })
+
+    it('uses a minimal built-in default config when config is omitted', async () => {
+      const backend = createMockBackend({ 'my-secret': 'hunter2' })
+      // No `config` or `configDir`-loadable file is supplied — this only
+      // works because init() falls back to a built-in default config when
+      // `backend` is set, instead of calling loadConfig().
+      const vault = await VaultKeeper.init({ skipDoctor: true, backend })
+
+      const jwe = await vault.setup('my-secret', { executablePath: 'dev' })
+      expect(typeof jwe).toBe('string')
+    })
+
+    it('precedence: backend option wins over config.backends resolution', async () => {
+      // A different backend is registered under the type named in
+      // testConfig() ('test'), but it must never be consulted because
+      // `backend` takes precedence over BackendRegistry/config.backends.
+      const registryRetrieveSpy = vi.fn((id: string) => Promise.resolve(`from-registry:${id}`))
+      const registryBackend = createMockBackend({ 'my-secret': 'from-registry' })
+      registryBackend.retrieve = registryRetrieveSpy
+      BackendRegistry.register('test', () => registryBackend)
+
+      const injectedBackend = createMockBackend({ 'my-secret': 'from-injected' })
+      const vault = await VaultKeeper.init({
+        skipDoctor: true,
+        config: testConfig(),
+        configDir: '/tmp/vaultkeeper-test',
+        backend: injectedBackend,
+      })
+
+      const jwe = await vault.setup('my-secret', { executablePath: 'dev' })
+      const { token } = await vault.authorize(jwe)
+      const accessor = vault.getSecret(token)
+      let captured = ''
+      accessor.read((buf) => {
+        captured = buf.toString('utf-8')
+      })
+
+      expect(captured).toBe('from-injected')
+      expect(registryRetrieveSpy).not.toHaveBeenCalled()
+    })
+
+    it('precedence: other config fields (e.g. defaults.ttlMinutes) still apply with backend set', async () => {
+      const backend = createMockBackend({ 'my-secret': 'hunter2' })
+      const config = testConfig()
+      config.defaults.ttlMinutes = 5
+
+      const vault = await VaultKeeper.init({
+        skipDoctor: true,
+        config,
+        backend,
+      })
+
+      // ttlMinutes from the supplied config is used even though the backend
+      // resolution itself is overridden by the `backend` option.
+      const jwe = await vault.setup('my-secret', { executablePath: 'dev' })
+      expect(typeof jwe).toBe('string')
+    })
+  })
+
   describe('doctor', () => {
     it('should return a preflight result', async () => {
       const result = await VaultKeeper.doctor()


### PR DESCRIPTION
## Summary

- Adds a "Testing your own code" README subsection with a complete before/after dependency-injection example (a function that accepts a `VaultKeeper` instance, with production and `TestVault.keeper` call sites plus the vitest test).
- Adds `VaultKeeperOptions.backend`, accepting a `SecretBackend` instance directly so tests/embedders can inject a backend without the global `BackendRegistry` or a hand-assembled `VaultConfig`. Precedence vs `config`/`configDir` is documented in the option's JSDoc: `backend` always wins for backend resolution; other config fields (`keyRotation`, `defaults`, `developmentMode`) still come from `config`/`configDir` when supplied; a minimal built-in default config is used when `config` is omitted.
- Adds an "Injecting a backend directly" README subsection with a minimal `InMemoryBackend`-via-options example.
- Regenerates the `vaultkeeper` API report and includes a minor changeset.

Refs #73

## Test plan

- [x] `pnpm --filter vaultkeeper test` — 607 tests pass, including 5 new tests covering: init with an injected backend and no `BackendRegistry` registration, store/retrieve round-trip through the injected backend, default-config fallback when `config` is omitted, precedence of `backend` over `config.backends`/`BackendRegistry`, and precedence of other `config` fields (e.g. `defaults.ttlMinutes`) still applying alongside an injected backend.
- [x] `pnpm build` — all packages build cleanly.
- [x] `pnpm generate:api-report` — `vaultkeeper.api.md` updated with the new `backend` field; diff reviewed.
- [x] `pnpm check` — typecheck + lint + API report validation pass across the workspace.
- [x] `pnpm test` — full workspace suite passes.
- [x] `pnpm exec prettier --check` on all changed files.