### PR TITLE
Add --config-dir flag / VAULTKEEPER_CONFIG_DIR env var to the CLI

### DIFF
--- a/.changeset/cli-config-dir-override.md
+++ b/.changeset/cli-config-dir-override.md
@@ -1,0 +1,7 @@
+---
+'vaultkeeper': minor
+'@vaultkeeper/cli': minor
+'@vaultkeeper/cli-test-helpers': minor
+---
+
+Add a global `--config-dir <path>` flag / `VAULTKEEPER_CONFIG_DIR` environment variable to the CLI so every command (`store`, `delete`, `exec`, `approve`, `dev-mode`, `doctor`, `config`, `rotate-key`, `revoke-key`) can be pointed at an isolated config directory — the flag wins over the env var, which wins over the platform default. `config init` creates the override directory as needed, and `config show` reports the path it loaded from. The library's `getDefaultConfigDir()` and `loadConfig()` are now public so embedders and the CLI share the same resolution logic. `@vaultkeeper/cli-test-helpers`'s `createCliTestEnv()` gains a `configDirMode` option (`'env'` | `'flag'`) and no longer manipulates the subprocess's `HOME` directory to achieve isolation.

--- a/packages/cli-test-helpers/api-report/cli-test-helpers.api.md
+++ b/packages/cli-test-helpers/api-report/cli-test-helpers.api.md
@@ -22,6 +22,7 @@ export interface CliTestEnv {
 // @public
 export interface CliTestEnvOptions {
     config?: Record<string, unknown>;
+    configDirMode?: 'env' | 'flag';
     env?: Record<string, string>;
     timeout?: number;
 }

--- a/packages/cli-test-helpers/src/create-cli-test-env.ts
+++ b/packages/cli-test-helpers/src/create-cli-test-env.ts
@@ -51,12 +51,7 @@ function runProcess(
       [binPath, ...args],
       { timeout, env },
       (error, stdout, stderr) => {
-        const exitCode =
-          error !== null
-            ? typeof error.code === 'number'
-              ? error.code
-              : 1
-            : 0
+        const exitCode = error !== null ? (typeof error.code === 'number' ? error.code : 1) : 0
         resolve({ stdout, stderr, exitCode })
       },
     )
@@ -78,12 +73,8 @@ function runProcess(
  * @returns A disposable test environment with `run()`, `runWithStdin()`, and `cleanup()`.
  * @public
  */
-export async function createCliTestEnv(
-  options?: CliTestEnvOptions,
-): Promise<CliTestEnv> {
-  const configDir = await fs.mkdtemp(
-    path.join(os.tmpdir(), 'vaultkeeper-cli-test-'),
-  )
+export async function createCliTestEnv(options?: CliTestEnvOptions): Promise<CliTestEnv> {
+  const configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vaultkeeper-cli-test-'))
 
   const secretsDir = path.join(configDir, 'secrets')
   await fs.mkdir(secretsDir, { recursive: true })

--- a/packages/cli-test-helpers/src/create-cli-test-env.ts
+++ b/packages/cli-test-helpers/src/create-cli-test-env.ts
@@ -98,9 +98,11 @@ export async function createCliTestEnv(options?: CliTestEnvOptions): Promise<Cli
   }
   if (configDirMode === 'env') {
     baseEnv.VAULTKEEPER_CONFIG_DIR = configDir
-  } else {
-    // 'flag' mode: never let an inherited VAULTKEEPER_CONFIG_DIR leak in —
-    // tests exercising --config-dir must pass it explicitly via run() args.
+  } else if (!('VAULTKEEPER_CONFIG_DIR' in extraEnv)) {
+    // 'flag' mode: strip only an *inherited* VAULTKEEPER_CONFIG_DIR (from
+    // process.env) so it doesn't leak in unexpectedly. A caller-supplied
+    // extraEnv.VAULTKEEPER_CONFIG_DIR is left intact so flag-vs-env
+    // precedence tests can set a competing env var alongside --config-dir.
     delete baseEnv.VAULTKEEPER_CONFIG_DIR
   }
 

--- a/packages/cli-test-helpers/src/create-cli-test-env.ts
+++ b/packages/cli-test-helpers/src/create-cli-test-env.ts
@@ -99,11 +99,18 @@ export async function createCliTestEnv(
   const binPath = resolveCliBinPath()
   const timeout = options?.timeout ?? 15_000
   const extraEnv = options?.env ?? {}
+  const configDirMode = options?.configDirMode ?? 'env'
 
   const baseEnv: Record<string, string | undefined> = {
     ...process.env,
     ...extraEnv,
-    VAULTKEEPER_CONFIG_DIR: configDir,
+  }
+  if (configDirMode === 'env') {
+    baseEnv.VAULTKEEPER_CONFIG_DIR = configDir
+  } else {
+    // 'flag' mode: never let an inherited VAULTKEEPER_CONFIG_DIR leak in —
+    // tests exercising --config-dir must pass it explicitly via run() args.
+    delete baseEnv.VAULTKEEPER_CONFIG_DIR
   }
 
   return {

--- a/packages/cli-test-helpers/src/types.ts
+++ b/packages/cli-test-helpers/src/types.ts
@@ -22,6 +22,16 @@ export interface CliTestEnvOptions {
   env?: Record<string, string>
   /** Subprocess timeout in ms (default: 15000). */
   timeout?: number
+  /**
+   * How the isolated config directory is communicated to the CLI subprocess.
+   *
+   * - `'env'` (default): sets `VAULTKEEPER_CONFIG_DIR` in the subprocess env.
+   * - `'flag'`: does not set `VAULTKEEPER_CONFIG_DIR` — tests must pass
+   *   `--config-dir <env.configDir>` explicitly via `run()`/`runWithStdin()`
+   *   args. Use this to exercise `--config-dir` flag behavior in isolation,
+   *   including precedence over a separately-set env var.
+   */
+  configDirMode?: 'env' | 'flag'
 }
 
 /**

--- a/packages/cli-test-helpers/test/unit/create-cli-test-env.test.ts
+++ b/packages/cli-test-helpers/test/unit/create-cli-test-env.test.ts
@@ -36,7 +36,7 @@ describe('createCliTestEnv', () => {
     env = await createCliTestEnv()
     const result = await env.run(['--help'])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should set VAULTKEEPER_CONFIG_DIR in the subprocess', async () => {

--- a/packages/cli-tests/test/e2e/config-dir.test.ts
+++ b/packages/cli-tests/test/e2e/config-dir.test.ts
@@ -1,0 +1,188 @@
+/**
+ * UATs for the CLI config directory override — VAULTKEEPER_CONFIG_DIR and
+ * the global --config-dir flag.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/65
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
+import type { CliTestEnv } from '@vaultkeeper/cli-test-helpers'
+
+/** Build a minimal valid config with a distinguishing ttlMinutes marker. */
+function configWithMarker(ttlMinutes: number): Record<string, unknown> {
+  return {
+    version: 1,
+    backends: [{ type: 'file', enabled: true }],
+    keyRotation: { gracePeriodDays: 7 },
+    defaults: { ttlMinutes, trustTier: 3 },
+  }
+}
+
+describe('CLI config-dir override', () => {
+  let env: CliTestEnv | undefined
+  let extraDirs: string[] = []
+
+  afterEach(async () => {
+    if (env !== undefined) {
+      await env.cleanup()
+      env = undefined
+    }
+    for (const dir of extraDirs) {
+      await fs.rm(dir, { recursive: true, force: true })
+    }
+    extraDirs = []
+  })
+
+  // Acceptance criterion 1: VAULTKEEPER_CONFIG_DIR redirects config read/write.
+  it('honors VAULTKEEPER_CONFIG_DIR for config show (env var isolation)', async () => {
+    env = await createCliTestEnv({ config: configWithMarker(111) })
+    const result = await env.run(['config', 'show'])
+    expect(result.exitCode).toBe(0)
+    const parsed: unknown = JSON.parse(result.stdout)
+    expect(parsed).toHaveProperty('defaults.ttlMinutes', 111)
+  })
+
+  // Acceptance criterion 1: --config-dir redirects config read/write.
+  it('honors --config-dir for config show (flag isolation)', async () => {
+    env = await createCliTestEnv({ config: configWithMarker(222), configDirMode: 'flag' })
+    const result = await env.run(['--config-dir', env.configDir, 'config', 'show'])
+    expect(result.exitCode).toBe(0)
+    const parsed: unknown = JSON.parse(result.stdout)
+    expect(parsed).toHaveProperty('defaults.ttlMinutes', 222)
+  })
+
+  // Acceptance criterion 1: flag wins over env var when both are set.
+  it('prefers --config-dir over VAULTKEEPER_CONFIG_DIR when both are set', async () => {
+    env = await createCliTestEnv({ config: configWithMarker(333) }) // env var -> env.configDir
+
+    const flagDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vaultkeeper-config-dir-flag-'))
+    extraDirs.push(flagDir)
+    await fs.writeFile(
+      path.join(flagDir, 'config.json'),
+      JSON.stringify(configWithMarker(444), null, 2) + '\n',
+      { encoding: 'utf8', mode: 0o600 },
+    )
+
+    // env.run() sets VAULTKEEPER_CONFIG_DIR=env.configDir (ttlMinutes 333);
+    // --config-dir points at flagDir (ttlMinutes 444). The flag must win.
+    const result = await env.run(['--config-dir', flagDir, 'config', 'show'])
+    expect(result.exitCode).toBe(0)
+    const parsed: unknown = JSON.parse(result.stdout)
+    expect(parsed).toHaveProperty('defaults.ttlMinutes', 444)
+  })
+
+  // Acceptance criterion 2: config show reports the path it loaded from.
+  it('reports the loaded config path on config show', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['config', 'show'])
+    expect(result.exitCode).toBe(0)
+    const expectedPath = path.join(env.configDir, 'config.json')
+    expect(result.stderr).toContain(`Loaded from: ${expectedPath}`)
+  })
+
+  // Acceptance criterion 2: config init creates the override directory as needed.
+  it('creates the override directory on config init when it does not yet exist', async () => {
+    const parentDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vaultkeeper-config-dir-init-'))
+    extraDirs.push(parentDir)
+    const nestedConfigDir = path.join(parentDir, 'nested', 'vaultkeeper')
+
+    env = await createCliTestEnv({ configDirMode: 'flag' })
+    const result = await env.run(['--config-dir', nestedConfigDir, 'config', 'init'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain(`Config created at ${path.join(nestedConfigDir, 'config.json')}`)
+
+    const content = await fs.readFile(path.join(nestedConfigDir, 'config.json'), 'utf8')
+    const parsed: unknown = JSON.parse(content)
+    expect(parsed).toHaveProperty('version', 1)
+  })
+
+  // Acceptance criterion 3: doctor also respects the override (reads the
+  // config to scope its checks) rather than ignoring it.
+  it('scopes doctor checks to the backends configured under --config-dir', async () => {
+    env = await createCliTestEnv({ config: configWithMarker(60), configDirMode: 'flag' })
+    const result = await env.run(['--config-dir', env.configDir, 'doctor'])
+    expect(result.exitCode === 0 || result.exitCode === 1).toBe(true)
+    const hasChecks = result.stdout.includes('✓') || result.stdout.includes('✗')
+    expect(hasChecks).toBe(true)
+  })
+
+  // Acceptance criterion 6 / Proof: two simultaneous isolated config dirs on
+  // one machine, neither touching the default (~/.config/vaultkeeper) location.
+  it('supports two simultaneous isolated config dirs without cross-contamination', async () => {
+    const envA = await createCliTestEnv({ config: configWithMarker(11) })
+    const envB = await createCliTestEnv({ config: configWithMarker(22) })
+
+    try {
+      expect(envA.configDir).not.toBe(envB.configDir)
+
+      const [resultA, resultB] = await Promise.all([
+        envA.run(['config', 'show']),
+        envB.run(['config', 'show']),
+      ])
+
+      expect(resultA.exitCode).toBe(0)
+      expect(resultB.exitCode).toBe(0)
+
+      const parsedA: unknown = JSON.parse(resultA.stdout)
+      const parsedB: unknown = JSON.parse(resultB.stdout)
+      expect(parsedA).toHaveProperty('defaults.ttlMinutes', 11)
+      expect(parsedB).toHaveProperty('defaults.ttlMinutes', 22)
+
+      // Neither isolated dir is (or is under) the real default location.
+      const defaultDir = path.join(os.homedir(), '.config', 'vaultkeeper')
+      expect(envA.configDir).not.toBe(defaultDir)
+      expect(envB.configDir).not.toBe(defaultDir)
+    } finally {
+      await envA.cleanup()
+      await envB.cleanup()
+    }
+  })
+
+  // Negative: --config-dir without a value is a usage error, not a crash.
+  it('exits 2 when --config-dir is given without a value', async () => {
+    env = await createCliTestEnv({ configDirMode: 'flag' })
+    const result = await env.run(['--config-dir'])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('--config-dir requires a value')
+  })
+
+  // Negative: --config-dir after exec's `--` separator belongs to the
+  // wrapped command, not to vaultkeeper itself, and must pass through untouched.
+  it('does not consume --config-dir after the exec -- separator', async () => {
+    env = await createCliTestEnv({ configDirMode: 'flag' })
+    const result = await env.run([
+      '--config-dir',
+      env.configDir,
+      'exec',
+      '--secret',
+      'does-not-exist',
+      '--env',
+      'FOO',
+      '--caller',
+      'dev',
+      '--skip-doctor',
+      '--',
+      'echo',
+      '--config-dir',
+      'not-a-vaultkeeper-flag',
+    ])
+    // The secret lookup will fail (it doesn't exist), but the point of this
+    // test is that argument parsing doesn't choke on --config-dir inside the
+    // wrapped command — it should reach the "secret not found" failure path,
+    // not a usage error about --config-dir.
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).not.toContain('--config-dir requires a value')
+  })
+
+  // --help documents the flag and env var (acceptance criterion 4).
+  it('documents --config-dir and VAULTKEEPER_CONFIG_DIR in top-level --help', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['--help'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('--config-dir')
+    expect(result.stdout).toContain('VAULTKEEPER_CONFIG_DIR')
+  })
+})

--- a/packages/cli-tests/test/e2e/config-dir.test.ts
+++ b/packages/cli-tests/test/e2e/config-dir.test.ts
@@ -92,7 +92,9 @@ describe('CLI config-dir override', () => {
     env = await createCliTestEnv({ configDirMode: 'flag' })
     const result = await env.run(['--config-dir', nestedConfigDir, 'config', 'init'])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain(`Config created at ${path.join(nestedConfigDir, 'config.json')}`)
+    expect(result.stdout).toContain(
+      `Config created at ${path.join(nestedConfigDir, 'config.json')}`,
+    )
 
     const content = await fs.readFile(path.join(nestedConfigDir, 'config.json'), 'utf8')
     const parsed: unknown = JSON.parse(content)

--- a/packages/cli-tests/test/e2e/config-dir.test.ts
+++ b/packages/cli-tests/test/e2e/config-dir.test.ts
@@ -74,6 +74,34 @@ describe('CLI config-dir override', () => {
     expect(parsed).toHaveProperty('defaults.ttlMinutes', 444)
   })
 
+  // Acceptance criterion 1: flag wins over env var even when the test harness
+  // itself is asked to set a *competing* VAULTKEEPER_CONFIG_DIR via
+  // configDirMode: 'flag' + options.env — regression for a bug where
+  // createCliTestEnv() unconditionally stripped VAULTKEEPER_CONFIG_DIR in
+  // 'flag' mode, making it impossible to exercise this precedence case.
+  it('prefers --config-dir over a caller-supplied VAULTKEEPER_CONFIG_DIR in flag mode', async () => {
+    const envConfigDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'vaultkeeper-config-dir-competing-env-'),
+    )
+    extraDirs.push(envConfigDir)
+    await fs.writeFile(
+      path.join(envConfigDir, 'config.json'),
+      JSON.stringify(configWithMarker(555), null, 2) + '\n',
+      { encoding: 'utf8', mode: 0o600 },
+    )
+
+    env = await createCliTestEnv({
+      config: configWithMarker(666),
+      configDirMode: 'flag',
+      env: { VAULTKEEPER_CONFIG_DIR: envConfigDir },
+    })
+
+    const result = await env.run(['--config-dir', env.configDir, 'config', 'show'])
+    expect(result.exitCode).toBe(0)
+    const parsed: unknown = JSON.parse(result.stdout)
+    expect(parsed).toHaveProperty('defaults.ttlMinutes', 666)
+  })
+
   // Acceptance criterion 2: config show reports the path it loaded from.
   it('reports the loaded config path on config show', async () => {
     env = await createCliTestEnv()

--- a/packages/cli-tests/test/e2e/config-dir.test.ts
+++ b/packages/cli-tests/test/e2e/config-dir.test.ts
@@ -179,6 +179,24 @@ describe('CLI config-dir override', () => {
     expect(result.stderr).toContain('--config-dir requires a value')
   })
 
+  // Negative: an empty --config-dir value must not be silently treated as
+  // "no override" — that would mask a malformed invocation by falling back
+  // to env/default resolution instead of failing loudly.
+  it('exits 2 when --config-dir is given an empty value via a separate arg', async () => {
+    env = await createCliTestEnv({ configDirMode: 'flag' })
+    const result = await env.run(['--config-dir', '', 'config', 'show'])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('--config-dir requires a value')
+  })
+
+  // Negative: same as above, but for the --config-dir=<value> form.
+  it('exits 2 when --config-dir= is given an empty value', async () => {
+    env = await createCliTestEnv({ configDirMode: 'flag' })
+    const result = await env.run(['--config-dir=', 'config', 'show'])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('--config-dir requires a value')
+  })
+
   // Negative: --config-dir after exec's `--` separator belongs to the
   // wrapped command, not to vaultkeeper itself, and must pass through untouched.
   it('does not consume --config-dir after the exec -- separator', async () => {

--- a/packages/cli-tests/test/e2e/help.test.ts
+++ b/packages/cli-tests/test/e2e/help.test.ts
@@ -19,21 +19,21 @@ describe('help and usage', () => {
     env = await createCliTestEnv()
     const result = await env.run([])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should print help and exit 0 for --help', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['--help'])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should print help and exit 0 for -h', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['-h'])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should exit 2 and show error for unknown command', async () => {
@@ -41,7 +41,7 @@ describe('help and usage', () => {
     const result = await env.run(['not-a-real-command'])
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('Unknown command: not-a-real-command')
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should print version and exit 0 for --version', async () => {

--- a/packages/cli-tests/test/e2e/help.test.ts
+++ b/packages/cli-tests/test/e2e/help.test.ts
@@ -61,7 +61,17 @@ describe('help and usage', () => {
   it('should list all expected commands in help output', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['--help'])
-    const commands = ['exec', 'doctor', 'approve', 'dev-mode', 'store', 'delete', 'config', 'rotate-key', 'revoke-key']
+    const commands = [
+      'exec',
+      'doctor',
+      'approve',
+      'dev-mode',
+      'store',
+      'delete',
+      'config',
+      'rotate-key',
+      'revoke-key',
+    ]
     for (const cmd of commands) {
       expect(result.stdout).toContain(cmd)
     }

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -21,6 +21,12 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parseArgs } from 'node:util'
+import {
+  extractConfigDirFlag,
+  resolveConfigDir,
+  CONFIG_DIR_HELP_OPTION,
+  CONFIG_DIR_HELP_ENV,
+} from './config-dir.js'
 
 // Read the package version at startup so --version doesn't need an async import.
 // We read and parse the package.json synchronously to avoid a dynamic import()
@@ -40,23 +46,39 @@ function readPackageVersion(): string {
 
 const packageVersion = readPackageVersion()
 
-// argv[2] is the first user-supplied token. Check it directly before
-// parseArgs so that --version / -V (parsed as option values, not positionals)
-// and --help / -h are handled without going through the switch.
-const firstArg = process.argv[2]
+// The global --config-dir flag may appear anywhere before the subcommand's
+// own `--` separator (if any), so it is extracted from the full argv up
+// front — before subcommand/positional detection — and stripped from the
+// args forwarded to the subcommand.
+let configDirFlag: string | undefined
+let filteredArgv: string[]
+let configDirFlagError: string | undefined
+try {
+  const extracted = extractConfigDirFlag(process.argv.slice(2))
+  configDirFlag = extracted.configDir
+  filteredArgv = extracted.rest
+} catch (err) {
+  configDirFlagError = err instanceof Error ? err.message : String(err)
+  filteredArgv = []
+}
+
+// The first user-supplied token (after --config-dir extraction). Check it
+// directly before parseArgs so that --version / -V (parsed as option values,
+// not positionals) and --help / -h are handled without going through the switch.
+const firstArg = filteredArgv[0]
 
 const { positionals } = parseArgs({
+  args: filteredArgv,
   allowPositionals: true,
   strict: false,
 })
 
 const subcommand = positionals[0]
-// argv[0]=node, argv[1]=script, argv[2]=subcommand, argv[3..]=commandArgs
-const commandArgs = process.argv.slice(3)
+const commandArgs = filteredArgv.slice(1)
 
 function printHelp(): void {
   process.stdout.write(
-    'Usage: vaultkeeper <command> [options]\n\n' +
+    'Usage: vaultkeeper [--config-dir <path>] <command> [options]\n\n' +
       'Commands:\n' +
       '  exec         Run a command with a secret injected as an env var\n' +
       '  doctor       Run preflight checks\n' +
@@ -66,14 +88,25 @@ function printHelp(): void {
       '  delete       Delete a secret\n' +
       '  config       Manage configuration\n' +
       '  rotate-key   Rotate the encryption key\n' +
-      '  revoke-key   Emergency key revocation\n',
+      '  revoke-key   Emergency key revocation\n\n' +
+      'Global options:\n' +
+      CONFIG_DIR_HELP_OPTION +
+      '\n' +
+      'Environment variables:\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
 async function main(): Promise<number> {
+  if (configDirFlagError !== undefined) {
+    process.stderr.write(`Error: ${configDirFlagError}\n`)
+    // Exit code 2: usage error (--config-dir given without a value)
+    return 2
+  }
+
   // Handle --version / -V before subcommand dispatch.
   // parseArgs treats these as option values (not positionals) with strict:false,
-  // so we inspect argv[2] directly to detect them.
+  // so we inspect the first filtered token directly to detect them.
   if (firstArg === '--version' || firstArg === '-V') {
     process.stdout.write(`${packageVersion}\n`)
     return 0
@@ -85,42 +118,44 @@ async function main(): Promise<number> {
     return 0
   }
 
+  const configDir = resolveConfigDir(configDirFlag)
+
   switch (subcommand) {
     case 'exec': {
       const { execCommand } = await import('./commands/exec.js')
-      return execCommand(commandArgs)
+      return execCommand(commandArgs, configDir)
     }
     case 'doctor': {
       const { doctorCommand } = await import('./commands/doctor.js')
-      return doctorCommand(commandArgs)
+      return doctorCommand(commandArgs, configDir)
     }
     case 'approve': {
       const { approveCommand } = await import('./commands/approve.js')
-      return approveCommand(commandArgs)
+      return approveCommand(commandArgs, configDir)
     }
     case 'dev-mode': {
       const { devModeCommand } = await import('./commands/dev-mode.js')
-      return devModeCommand(commandArgs)
+      return devModeCommand(commandArgs, configDir)
     }
     case 'store': {
       const { storeCommand } = await import('./commands/store.js')
-      return storeCommand(commandArgs)
+      return storeCommand(commandArgs, configDir)
     }
     case 'delete': {
       const { deleteCommand } = await import('./commands/delete.js')
-      return deleteCommand(commandArgs)
+      return deleteCommand(commandArgs, configDir)
     }
     case 'config': {
       const { configCommand } = await import('./commands/config.js')
-      return configCommand(commandArgs)
+      return configCommand(commandArgs, configDir)
     }
     case 'rotate-key': {
       const { rotateKeyCommand } = await import('./commands/rotate-key.js')
-      return rotateKeyCommand(commandArgs)
+      return rotateKeyCommand(commandArgs, configDir)
     }
     case 'revoke-key': {
       const { revokeKeyCommand } = await import('./commands/revoke-key.js')
-      return revokeKeyCommand(commandArgs)
+      return revokeKeyCommand(commandArgs, configDir)
     }
     default:
       process.stderr.write(`Unknown command: ${subcommand}\n`)

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -35,7 +35,12 @@ function readPackageVersion(): string {
   try {
     const pkgPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../package.json')
     const raw: unknown = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
-    if (raw !== null && typeof raw === 'object' && 'version' in raw && typeof raw.version === 'string') {
+    if (
+      raw !== null &&
+      typeof raw === 'object' &&
+      'version' in raw &&
+      typeof raw.version === 'string'
+    ) {
       return raw.version
     }
   } catch {

--- a/packages/cli/src/commands/approve.ts
+++ b/packages/cli/src/commands/approve.ts
@@ -2,6 +2,7 @@ import { parseArgs } from 'node:util'
 import * as path from 'node:path'
 import { VaultKeeper } from 'vaultkeeper'
 import { formatError } from '../output.js'
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 function printApproveHelp(): void {
   process.stdout.write(
@@ -11,11 +12,14 @@ function printApproveHelp(): void {
       'approved, unchanged script is idempotent.\n\n' +
       'Options:\n' +
       '  --script <path>   Path to the script to approve\n' +
-      '  -h, --help        Show this help message\n',
+      CONFIG_DIR_HELP_OPTION +
+      '  -h, --help        Show this help message\n\n' +
+      'Environment variables:\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
-export async function approveCommand(args: string[]): Promise<number> {
+export async function approveCommand(args: string[], configDir: string): Promise<number> {
   // Handle --help / -h before strict parseArgs.
   if (args.includes('--help') || args.includes('-h')) {
     printApproveHelp()
@@ -44,7 +48,7 @@ export async function approveCommand(args: string[]): Promise<number> {
     // trust manifest, never the secret backend. Skip the doctor preflight, and
     // VaultKeeper.init() itself resolves the backend lazily, so approve works
     // even when the configured backend or plugin is unavailable.
-    const vault = await VaultKeeper.init({ skipDoctor: true })
+    const vault = await VaultKeeper.init({ configDir, skipDoctor: true })
     const status = await vault.approveExecutable(scriptPath)
     process.stdout.write(`Approved ${scriptPath} (hash: ${status.hash})\n`)
     return 0

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,24 +1,9 @@
 import { parseArgs } from 'node:util'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import * as os from 'node:os'
 import { BackendRegistry, platformDefaultBackendType } from 'vaultkeeper'
 import { formatError } from '../output.js'
-
-function getDefaultConfigDir(): string {
-  const envOverride = process.env.VAULTKEEPER_CONFIG_DIR
-  if (envOverride !== undefined && envOverride !== '') {
-    return envOverride
-  }
-  if (process.platform === 'win32') {
-    const appData = process.env.APPDATA
-    if (appData !== undefined) {
-      return path.join(appData, 'vaultkeeper')
-    }
-    return path.join(os.homedir(), 'AppData', 'Roaming', 'vaultkeeper')
-  }
-  return path.join(os.homedir(), '.config', 'vaultkeeper')
-}
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 /** Human-readable name for the current platform, for user-facing messages. */
 function platformLabel(): string {
@@ -107,7 +92,10 @@ function printConfigHelp(): void {
       '  --backend <type>   Backend to configure as the active store\n' +
       `                     (valid: ${BackendRegistry.getTypes().join(', ')})\n\n` +
       'Options:\n' +
-      '  -h, --help   Show this help message\n',
+      CONFIG_DIR_HELP_OPTION +
+      '  -h, --help   Show this help message\n\n' +
+      'Environment variables:\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
@@ -116,7 +104,7 @@ function isEnoent(err: unknown): boolean {
   return err instanceof Error && 'code' in err && err.code === 'ENOENT'
 }
 
-async function configInit(rest: string[]): Promise<number> {
+async function configInit(rest: string[], configDir: string): Promise<number> {
   const unknownFlag = findUnknownFlag(rest, new Set(['backend']))
   if (unknownFlag !== undefined) {
     process.stderr.write(`Error: unknown option '${unknownFlag}' for 'config init'\n`)
@@ -149,7 +137,6 @@ async function configInit(rest: string[]): Promise<number> {
   const backendType = requestedBackend ?? platformDefaultBackendType()
 
   try {
-    const configDir = getDefaultConfigDir()
     const configPath = path.join(configDir, 'config.json')
     // Create config directory with restrictive permissions.
     await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
@@ -193,7 +180,7 @@ async function configInit(rest: string[]): Promise<number> {
   }
 }
 
-async function configShow(rest: string[]): Promise<number> {
+async function configShow(rest: string[], configDir: string): Promise<number> {
   const unknownFlag = findUnknownFlag(rest, new Set())
   if (unknownFlag !== undefined) {
     process.stderr.write(`Error: unknown option '${unknownFlag}' for 'config show'\n`)
@@ -201,9 +188,11 @@ async function configShow(rest: string[]): Promise<number> {
   }
 
   try {
-    const configDir = getDefaultConfigDir()
     const configPath = path.join(configDir, 'config.json')
     const content = await fs.readFile(configPath, 'utf8')
+    // The loaded path is a diagnostic, so it goes to stderr — stdout
+    // stays pure JSON for consumers that pipe/parse `config show`.
+    process.stderr.write(`Loaded from: ${configPath}\n`)
     process.stdout.write(content)
     if (!content.endsWith('\n')) {
       process.stdout.write('\n')
@@ -229,7 +218,7 @@ async function configShow(rest: string[]): Promise<number> {
   }
 }
 
-export async function configCommand(args: string[]): Promise<number> {
+export async function configCommand(args: string[], configDir: string): Promise<number> {
   // Handle --help / -h before subcommand dispatch.
   if (args.includes('--help') || args.includes('-h')) {
     printConfigHelp()
@@ -241,10 +230,10 @@ export async function configCommand(args: string[]): Promise<number> {
 
   switch (subcommand) {
     case 'init':
-      return configInit(rest)
+      return configInit(rest, configDir)
 
     case 'show':
-      return configShow(rest)
+      return configShow(rest, configDir)
 
     default:
       process.stderr.write('Error: missing or unknown config subcommand\n')

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -2,6 +2,7 @@ import { parseArgs } from 'node:util'
 import { VaultKeeper } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 function printDeleteHelp(): void {
   process.stdout.write(
@@ -9,13 +10,15 @@ function printDeleteHelp(): void {
       'Options:\n' +
       '  --name <name>      Name of the secret to delete\n' +
       '  --skip-doctor      Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_OPTION +
       '  -h, --help         Show this help message\n\n' +
       'Environment variables:\n' +
-      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n',
+      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
-export async function deleteCommand(args: string[]): Promise<number> {
+export async function deleteCommand(args: string[], configDir: string): Promise<number> {
   // Handle --help / -h before strict parseArgs.
   if (args.includes('--help') || args.includes('-h')) {
     printDeleteHelp()
@@ -43,7 +46,7 @@ export async function deleteCommand(args: string[]): Promise<number> {
   try {
     // Delete via VaultKeeper, which resolves the first enabled backend from the
     // loaded config and forwards that backend's config (including `path`).
-    const vault = await VaultKeeper.init({ skipDoctor })
+    const vault = await VaultKeeper.init({ configDir, skipDoctor })
     await vault.delete(values.name)
     process.stdout.write(`Secret "${values.name}" deleted.\n`)
     return 0

--- a/packages/cli/src/commands/dev-mode.ts
+++ b/packages/cli/src/commands/dev-mode.ts
@@ -56,9 +56,7 @@ export async function devModeCommand(args: string[], configDir: string): Promise
   try {
     const vault = await VaultKeeper.init({ configDir, skipDoctor })
     await vault.setDevelopmentMode(scriptPath, enabled)
-    process.stdout.write(
-      `Development mode ${enabled ? 'enabled' : 'disabled'} for ${scriptPath}\n`,
-    )
+    process.stdout.write(`Development mode ${enabled ? 'enabled' : 'disabled'} for ${scriptPath}\n`)
     return 0
   } catch (err) {
     process.stderr.write(`${formatError(err)}\n`)

--- a/packages/cli/src/commands/dev-mode.ts
+++ b/packages/cli/src/commands/dev-mode.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path'
 import { VaultKeeper } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 function printDevModeHelp(): void {
   process.stdout.write(
@@ -14,13 +15,15 @@ function printDevModeHelp(): void {
       'Options:\n' +
       '  --script <path>    Path to the script\n' +
       '  --skip-doctor      Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_OPTION +
       '  -h, --help         Show this help message\n\n' +
       'Environment variables:\n' +
-      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n',
+      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
-export async function devModeCommand(args: string[]): Promise<number> {
+export async function devModeCommand(args: string[], configDir: string): Promise<number> {
   // Handle --help / -h before parseArgs.
   if (args.includes('--help') || args.includes('-h')) {
     printDevModeHelp()
@@ -51,7 +54,7 @@ export async function devModeCommand(args: string[]): Promise<number> {
   const skipDoctor = shouldSkipDoctor(values['skip-doctor'])
 
   try {
-    const vault = await VaultKeeper.init({ skipDoctor })
+    const vault = await VaultKeeper.init({ configDir, skipDoctor })
     await vault.setDevelopmentMode(scriptPath, enabled)
     process.stdout.write(
       `Development mode ${enabled ? 'enabled' : 'disabled'} for ${scriptPath}\n`,

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,5 +1,6 @@
-import { VaultKeeper } from 'vaultkeeper'
+import { VaultKeeper, loadConfig } from 'vaultkeeper'
 import { formatError } from '../output.js'
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 function printDoctorHelp(): void {
   process.stdout.write(
@@ -7,18 +8,24 @@ function printDoctorHelp(): void {
       'Run preflight checks to verify the vault is correctly configured\n' +
       'and all required dependencies are available.\n\n' +
       'Options:\n' +
-      '  -h, --help   Show this help message\n',
+      CONFIG_DIR_HELP_OPTION +
+      '  -h, --help   Show this help message\n\n' +
+      'Environment variables:\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
-export async function doctorCommand(args: string[]): Promise<number> {
+export async function doctorCommand(args: string[], configDir: string): Promise<number> {
   if (args.includes('--help') || args.includes('-h')) {
     printDoctorHelp()
     return 0
   }
 
   try {
-    const result = await VaultKeeper.doctor()
+    // Scope checks to the backends configured under configDir, so doctor
+    // reflects the same config the other commands will read/write.
+    const config = await loadConfig(configDir)
+    const result = await VaultKeeper.doctor({ backends: config.backends })
 
     for (const check of result.checks) {
       const icon = check.status === 'ok' ? '✓' : '✗'

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -37,6 +37,7 @@ import { shouldSkipDoctor } from '../skip-doctor.js'
 import { shouldAutoApprove } from '../auto-approve.js'
 import { shellQuote } from '../shell-quote.js'
 import { formatError } from '../output.js'
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 /**
  * Outcome of the TOFU trust gate.
@@ -152,6 +153,7 @@ function printExecHelp(): void {
       '  --cache            Cache the JWE token for subsequent invocations\n' +
       '  --no-redact        Do not redact the secret from output\n' +
       '  --skip-doctor      Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_OPTION +
       '  -h, --help         Show this help message\n\n' +
       'Approval and TTY requirement:\n' +
       '  A caller that is not yet trusted requires approval. On an interactive\n' +
@@ -162,11 +164,12 @@ function printExecHelp(): void {
       'Environment variables:\n' +
       '  VAULTKEEPER_YES=1           Approve an untrusted caller non-interactively\n' +
       '                              (same as --yes)\n' +
-      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n',
+      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
-export async function execCommand(args: string[]): Promise<number> {
+export async function execCommand(args: string[], configDir: string): Promise<number> {
   // Handle --help / -h before any other processing.
   if (args.includes('--help') || args.includes('-h')) {
     printExecHelp()
@@ -226,7 +229,7 @@ export async function execCommand(args: string[]): Promise<number> {
   const autoApprove = shouldAutoApprove(values.yes)
 
   try {
-    const vault = await VaultKeeper.init({ skipDoctor })
+    const vault = await VaultKeeper.init({ configDir, skipDoctor })
 
     // Enforce the trust gate BEFORE touching the cache or retrieving the
     // secret. This runs on every invocation — including a `--cache` hit — so a

--- a/packages/cli/src/commands/revoke-key.ts
+++ b/packages/cli/src/commands/revoke-key.ts
@@ -2,6 +2,7 @@ import { parseArgs } from 'node:util'
 import { VaultKeeper } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 function printRevokeKeyHelp(): void {
   process.stdout.write(
@@ -10,13 +11,15 @@ function printRevokeKeyHelp(): void {
       'with the revoked key become immediately invalid.\n\n' +
       'Options:\n' +
       '  --skip-doctor          Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_OPTION +
       '  -h, --help             Show this help message\n\n' +
       'Environment variables:\n' +
-      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n',
+      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
-export async function revokeKeyCommand(args: string[]): Promise<number> {
+export async function revokeKeyCommand(args: string[], configDir: string): Promise<number> {
   if (args.includes('--help') || args.includes('-h')) {
     printRevokeKeyHelp()
     return 0
@@ -41,7 +44,7 @@ export async function revokeKeyCommand(args: string[]): Promise<number> {
   const skipDoctor = shouldSkipDoctor(skipDoctorFlag)
 
   try {
-    const vault = await VaultKeeper.init({ skipDoctor })
+    const vault = await VaultKeeper.init({ configDir, skipDoctor })
     await vault.revokeKey()
     process.stdout.write('Key revoked successfully.\n')
     return 0

--- a/packages/cli/src/commands/rotate-key.ts
+++ b/packages/cli/src/commands/rotate-key.ts
@@ -2,6 +2,7 @@ import { parseArgs } from 'node:util'
 import { VaultKeeper } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 function printRotateKeyHelp(): void {
   process.stdout.write(
@@ -10,13 +11,15 @@ function printRotateKeyHelp(): void {
       'key remain readable during the configured grace period.\n\n' +
       'Options:\n' +
       '  --skip-doctor          Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_OPTION +
       '  -h, --help             Show this help message\n\n' +
       'Environment variables:\n' +
-      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n',
+      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
-export async function rotateKeyCommand(args: string[]): Promise<number> {
+export async function rotateKeyCommand(args: string[], configDir: string): Promise<number> {
   if (args.includes('--help') || args.includes('-h')) {
     printRotateKeyHelp()
     return 0
@@ -41,7 +44,7 @@ export async function rotateKeyCommand(args: string[]): Promise<number> {
   const skipDoctor = shouldSkipDoctor(skipDoctorFlag)
 
   try {
-    const vault = await VaultKeeper.init({ skipDoctor })
+    const vault = await VaultKeeper.init({ configDir, skipDoctor })
     await vault.rotateKey()
     process.stdout.write('Key rotated successfully.\n')
     return 0

--- a/packages/cli/src/commands/store.ts
+++ b/packages/cli/src/commands/store.ts
@@ -2,6 +2,7 @@ import { parseArgs } from 'node:util'
 import { VaultKeeper } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
+import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 
 function printStoreHelp(): void {
   process.stdout.write(
@@ -9,13 +10,15 @@ function printStoreHelp(): void {
       'Options:\n' +
       '  --name <name>      Name to store the secret under\n' +
       '  --skip-doctor      Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_OPTION +
       '  -h, --help         Show this help message\n\n' +
       'Environment variables:\n' +
-      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n',
+      '  VAULTKEEPER_SKIP_DOCTOR=1   Skip doctor preflight checks\n' +
+      CONFIG_DIR_HELP_ENV,
   )
 }
 
-export async function storeCommand(args: string[]): Promise<number> {
+export async function storeCommand(args: string[], configDir: string): Promise<number> {
   // Handle --help / -h before parseArgs to avoid strict-mode rejection of -h.
   if (args.includes('--help') || args.includes('-h')) {
     printStoreHelp()
@@ -61,7 +64,7 @@ export async function storeCommand(args: string[]): Promise<number> {
 
     // Store via VaultKeeper, which resolves the first enabled backend from the
     // loaded config and forwards that backend's config (including `path`).
-    const vault = await VaultKeeper.init({ skipDoctor })
+    const vault = await VaultKeeper.init({ configDir, skipDoctor })
     await vault.store(values.name, secret)
     process.stdout.write(`Secret "${values.name}" stored successfully.\n`)
     return 0

--- a/packages/cli/src/config-dir.ts
+++ b/packages/cli/src/config-dir.ts
@@ -1,0 +1,84 @@
+/**
+ * Global `--config-dir` flag extraction and resolution.
+ *
+ * Precedence: `--config-dir <path>` flag, then `VAULTKEEPER_CONFIG_DIR`
+ * (resolved by the library's `getDefaultConfigDir`), then the
+ * platform-appropriate default.
+ *
+ * @internal
+ */
+
+import { getDefaultConfigDir } from 'vaultkeeper'
+
+/** Thrown when `--config-dir` is given without a following value. */
+export class ConfigDirFlagError extends Error {}
+
+/** Result of extracting the global `--config-dir` flag from an argv array. */
+export interface ExtractedConfigDir {
+  /** The flag's value, or `undefined` if `--config-dir` was not present. */
+  configDir: string | undefined
+  /** `argv` with the `--config-dir` flag (and its value) removed. */
+  rest: string[]
+}
+
+/**
+ * Extract a `--config-dir <path>` / `--config-dir=<path>` flag from `argv`.
+ *
+ * Scanning stops at the first bare `--` token so that a wrapped command's
+ * own `--config-dir` (e.g. after `vaultkeeper exec ... -- --config-dir X`)
+ * is left untouched and passed through to the child process.
+ */
+export function extractConfigDirFlag(argv: string[]): ExtractedConfigDir {
+  const rest: string[] = []
+  let configDir: string | undefined
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === undefined) {
+      continue
+    }
+
+    // Stop scanning at the first bare `--`: everything after it belongs to
+    // the wrapped command (e.g. `exec ... -- --config-dir X`), not us.
+    if (arg === '--') {
+      rest.push(...argv.slice(i))
+      break
+    }
+
+    if (arg === '--config-dir') {
+      const value = argv[i + 1]
+      if (value === undefined) {
+        throw new ConfigDirFlagError('--config-dir requires a value')
+      }
+      configDir = value
+      i++
+      continue
+    }
+
+    if (arg.startsWith('--config-dir=')) {
+      configDir = arg.slice('--config-dir='.length)
+      continue
+    }
+
+    rest.push(arg)
+  }
+
+  return { configDir, rest }
+}
+
+/**
+ * Resolve the effective config directory: the flag value if given,
+ * otherwise the library's env-var-or-platform-default resolution.
+ */
+export function resolveConfigDir(flagValue: string | undefined): string {
+  if (flagValue !== undefined && flagValue !== '') {
+    return flagValue
+  }
+  return getDefaultConfigDir()
+}
+
+/** Help text fragment shared by every command that supports `--config-dir`. */
+export const CONFIG_DIR_HELP_OPTION = '  --config-dir <path>  Override the config directory\n'
+
+/** Help text fragment for the `VAULTKEEPER_CONFIG_DIR` env var. */
+export const CONFIG_DIR_HELP_ENV = '  VAULTKEEPER_CONFIG_DIR=<path>   Override the config directory\n'

--- a/packages/cli/src/config-dir.ts
+++ b/packages/cli/src/config-dir.ts
@@ -81,4 +81,5 @@ export function resolveConfigDir(flagValue: string | undefined): string {
 export const CONFIG_DIR_HELP_OPTION = '  --config-dir <path>  Override the config directory\n'
 
 /** Help text fragment for the `VAULTKEEPER_CONFIG_DIR` env var. */
-export const CONFIG_DIR_HELP_ENV = '  VAULTKEEPER_CONFIG_DIR=<path>   Override the config directory\n'
+export const CONFIG_DIR_HELP_ENV =
+  '  VAULTKEEPER_CONFIG_DIR=<path>   Override the config directory\n'

--- a/packages/cli/src/config-dir.ts
+++ b/packages/cli/src/config-dir.ts
@@ -47,7 +47,7 @@ export function extractConfigDirFlag(argv: string[]): ExtractedConfigDir {
 
     if (arg === '--config-dir') {
       const value = argv[i + 1]
-      if (value === undefined) {
+      if (value === undefined || value.trim() === '') {
         throw new ConfigDirFlagError('--config-dir requires a value')
       }
       configDir = value
@@ -56,7 +56,11 @@ export function extractConfigDirFlag(argv: string[]): ExtractedConfigDir {
     }
 
     if (arg.startsWith('--config-dir=')) {
-      configDir = arg.slice('--config-dir='.length)
+      const value = arg.slice('--config-dir='.length)
+      if (value.trim() === '') {
+        throw new ConfigDirFlagError('--config-dir requires a value')
+      }
+      configDir = value
       continue
     }
 
@@ -69,9 +73,13 @@ export function extractConfigDirFlag(argv: string[]): ExtractedConfigDir {
 /**
  * Resolve the effective config directory: the flag value if given,
  * otherwise the library's env-var-or-platform-default resolution.
+ *
+ * `flagValue` is assumed non-empty — `extractConfigDirFlag` rejects an
+ * empty/whitespace-only `--config-dir` value as a usage error before this
+ * function is ever called.
  */
 export function resolveConfigDir(flagValue: string | undefined): string {
-  if (flagValue !== undefined && flagValue !== '') {
+  if (flagValue !== undefined) {
     return flagValue
   }
   return getDefaultConfigDir()

--- a/packages/cli/test/unit/bin.test.ts
+++ b/packages/cli/test/unit/bin.test.ts
@@ -23,20 +23,10 @@ interface CliResult {
 
 function runCli(args: string[]): Promise<CliResult> {
   return new Promise((resolve) => {
-    execFile(
-      TSX_BIN,
-      [BIN_PATH, ...args],
-      { timeout: 15000 },
-      (error, stdout, stderr) => {
-        const exitCode =
-          error !== null
-            ? typeof error.code === 'number'
-              ? error.code
-              : 1
-            : 0
-        resolve({ stdout, stderr, exitCode })
-      },
-    )
+    execFile(TSX_BIN, [BIN_PATH, ...args], { timeout: 15000 }, (error, stdout, stderr) => {
+      const exitCode = error !== null ? (typeof error.code === 'number' ? error.code : 1) : 0
+      resolve({ stdout, stderr, exitCode })
+    })
   })
 }
 

--- a/packages/cli/test/unit/bin.test.ts
+++ b/packages/cli/test/unit/bin.test.ts
@@ -44,7 +44,7 @@ describe('bin.ts entry point', () => {
   it('should print help and exit 0 when no arguments are given', async () => {
     const result = await runCli([])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
     expect(result.stdout).toContain('exec')
     expect(result.stdout).toContain('doctor')
   })
@@ -52,13 +52,13 @@ describe('bin.ts entry point', () => {
   it('should print help and exit 0 for --help', async () => {
     const result = await runCli(['--help'])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should print help and exit 0 for -h', async () => {
     const result = await runCli(['-h'])
     expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should write an error to stderr and exit 2 for an unknown command', async () => {
@@ -70,7 +70,7 @@ describe('bin.ts entry point', () => {
   it('should include help text after an unknown command error', async () => {
     const result = await runCli(['totally-bogus'])
     expect(result.exitCode).toBe(2)
-    expect(result.stdout).toContain('Usage: vaultkeeper <command>')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should list all known commands in the help output', async () => {

--- a/packages/cli/test/unit/commands/approve.test.ts
+++ b/packages/cli/test/unit/commands/approve.test.ts
@@ -14,7 +14,6 @@ describe('approveCommand', () => {
   let stderrOutput: string
   let stdoutOutput: string
   let configDir: string
-  const originalConfigDir = process.env.VAULTKEEPER_CONFIG_DIR
 
   beforeEach(async () => {
     stderrOutput = ''
@@ -28,36 +27,31 @@ describe('approveCommand', () => {
       return true
     })
     // Isolate the trust manifest to a temp dir; never touch the real config dir.
+    // Passed explicitly as approveCommand's configDir param — no env var needed.
     configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-approve-unit-'))
-    process.env.VAULTKEEPER_CONFIG_DIR = configDir
   })
 
   afterEach(async () => {
     vi.restoreAllMocks()
-    if (originalConfigDir === undefined) {
-      delete process.env.VAULTKEEPER_CONFIG_DIR
-    } else {
-      process.env.VAULTKEEPER_CONFIG_DIR = originalConfigDir
-    }
     await fs.rm(configDir, { recursive: true, force: true })
   })
 
   describe('--help / -h', () => {
     it('should print usage and return 0 for --help', async () => {
-      const code = await approveCommand(['--help'])
+      const code = await approveCommand(['--help'], configDir)
       expect(code).toBe(0)
       expect(stdoutOutput).toContain('Usage: vaultkeeper approve')
     })
 
     it('should print usage and return 0 for -h', async () => {
-      const code = await approveCommand(['-h'])
+      const code = await approveCommand(['-h'], configDir)
       expect(code).toBe(0)
       expect(stdoutOutput).toContain('Usage: vaultkeeper approve')
     })
 
     // Criterion 6: help describes the real (idempotent, manifest-writing) behavior.
     it('describes the TOFU manifest behavior accurately', async () => {
-      await approveCommand(['--help'])
+      await approveCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('TOFU trust manifest')
       expect(stdoutOutput).toContain('idempotent')
     })
@@ -65,17 +59,17 @@ describe('approveCommand', () => {
 
   describe('--script flag validation', () => {
     it('should return 2 when --script is missing', async () => {
-      const code = await approveCommand([])
+      const code = await approveCommand([], configDir)
       expect(code).toBe(2)
     })
 
     it('should write error to stderr when --script is missing', async () => {
-      await approveCommand([])
+      await approveCommand([], configDir)
       expect(stderrOutput).toContain('--script is required')
     })
 
     it('should include usage hint when --script is missing', async () => {
-      await approveCommand([])
+      await approveCommand([], configDir)
       expect(stderrOutput).toContain('Usage: vaultkeeper approve')
     })
   })
@@ -87,7 +81,7 @@ describe('approveCommand', () => {
       const script = path.join(configDir, 'my-script.sh')
       await fs.writeFile(script, contents, { mode: 0o755 })
 
-      const code = await approveCommand(['--script', script])
+      const code = await approveCommand(['--script', script], configDir)
       expect(code).toBe(0)
       expect(stdoutOutput).toContain('Approved')
       expect(stdoutOutput).toContain(sha256Hex(contents))
@@ -98,7 +92,7 @@ describe('approveCommand', () => {
       const script = path.join(configDir, 'script.sh')
       await fs.writeFile(script, contents, { mode: 0o755 })
 
-      const code = await approveCommand(['--script', script])
+      const code = await approveCommand(['--script', script], configDir)
       expect(code).toBe(0)
       const match = /Approved (.+) \(hash:/.exec(stdoutOutput)
       const printedPath = match?.[1]
@@ -111,7 +105,7 @@ describe('approveCommand', () => {
     // Criterion 2: a nonexistent path exits non-zero, naming the missing path.
     it('exits 1 and names the missing path', async () => {
       const missing = path.join(configDir, 'does-not-exist.sh')
-      const code = await approveCommand(['--script', missing])
+      const code = await approveCommand(['--script', missing], configDir)
       expect(code).toBe(1)
       expect(stderrOutput).toContain(path.resolve(missing))
     })

--- a/packages/cli/test/unit/commands/config.test.ts
+++ b/packages/cli/test/unit/commands/config.test.ts
@@ -1,22 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import * as os from 'node:os'
 import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
 import * as path from 'node:path'
-
-// Mock node:os so we can control homedir() per-test.
-// vi.spyOn cannot patch ESM namespace exports at runtime.
-vi.mock('node:os', async (importOriginal) => {
-  const actual = await importOriginal<typeof os>()
-  return {
-    ...actual,
-    homedir: vi.fn(() => actual.homedir()),
-  }
-})
 
 describe('configCommand', () => {
   let stderrOutput: string
   let stdoutOutput: string
   let tempDir: string
+  let configDir: string
 
   beforeEach(async () => {
     stderrOutput = ''
@@ -29,9 +20,11 @@ describe('configCommand', () => {
       stdoutOutput += String(chunk)
       return true
     })
-    // Create a fresh temp directory and redirect homedir to it
+    // Create a fresh temp directory to isolate this test's config dir.
+    // configCommand no longer derives a default path from os.homedir() —
+    // it operates directly on whatever configDir is passed in.
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vaultkeeper-config-test-'))
-    vi.mocked(os.homedir).mockReturnValue(tempDir)
+    configDir = path.join(tempDir, '.config', 'vaultkeeper')
   })
 
   afterEach(async () => {
@@ -43,21 +36,21 @@ describe('configCommand', () => {
   describe('init subcommand', () => {
     it('should create config.json and return 0', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      const code = await configCommand(['init'])
+      const code = await configCommand(['init'], configDir)
       expect(code).toBe(0)
     })
 
     it('should write success message to stdout', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand(['init'])
+      await configCommand(['init'], configDir)
       expect(stdoutOutput).toContain('Config created at')
       expect(stdoutOutput).toContain('config.json')
     })
 
     it('should create config.json with valid JSON content', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand(['init'])
-      const configPath = path.join(tempDir, '.config', 'vaultkeeper', 'config.json')
+      await configCommand(['init'], configDir)
+      const configPath = path.join(configDir, 'config.json')
       const content = await fs.readFile(configPath, 'utf8')
       const parsed: unknown = JSON.parse(content)
       expect(parsed).toMatchObject({ version: 1 })
@@ -65,16 +58,16 @@ describe('configCommand', () => {
 
     it('should return 1 when config already exists', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand(['init'])
-      const code = await configCommand(['init'])
+      await configCommand(['init'], configDir)
+      const code = await configCommand(['init'], configDir)
       expect(code).toBe(1)
     })
 
     it('should write error to stderr when config already exists', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand(['init'])
+      await configCommand(['init'], configDir)
       stderrOutput = ''
-      await configCommand(['init'])
+      await configCommand(['init'], configDir)
       expect(stderrOutput).toContain('Config already exists at')
     })
   })
@@ -82,36 +75,36 @@ describe('configCommand', () => {
   describe('show subcommand', () => {
     it('should output config content and return 0 when config exists', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand(['init'])
+      await configCommand(['init'], configDir)
       stdoutOutput = ''
-      const code = await configCommand(['show'])
+      const code = await configCommand(['show'], configDir)
       expect(code).toBe(0)
     })
 
     it('should write config content to stdout', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand(['init'])
+      await configCommand(['init'], configDir)
       stdoutOutput = ''
-      await configCommand(['show'])
+      await configCommand(['show'], configDir)
       const parsed: unknown = JSON.parse(stdoutOutput)
       expect(parsed).toMatchObject({ version: 1 })
     })
 
     it('should return 1 when config does not exist', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      const code = await configCommand(['show'])
+      const code = await configCommand(['show'], configDir)
       expect(code).toBe(1)
     })
 
     it('should write error to stderr when config does not exist', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand(['show'])
+      await configCommand(['show'], configDir)
       expect(stderrOutput.length).toBeGreaterThan(0)
     })
 
     it('should show a user-friendly message when no config file exists', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand(['show'])
+      await configCommand(['show'], configDir)
       expect(stderrOutput).toContain('No config file found')
       expect(stderrOutput).toContain('vaultkeeper config init')
     })
@@ -120,14 +113,14 @@ describe('configCommand', () => {
   describe('--help / -h', () => {
     it('should print usage and return 0 for --help', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      const code = await configCommand(['--help'])
+      const code = await configCommand(['--help'], configDir)
       expect(code).toBe(0)
       expect(stdoutOutput).toContain('Usage: vaultkeeper config')
     })
 
     it('should print usage and return 0 for -h', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      const code = await configCommand(['-h'])
+      const code = await configCommand(['-h'], configDir)
       expect(code).toBe(0)
       expect(stdoutOutput).toContain('Usage: vaultkeeper config')
     })
@@ -136,19 +129,19 @@ describe('configCommand', () => {
   describe('missing/unknown subcommand', () => {
     it('should return 2 when no subcommand given', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      const code = await configCommand([])
+      const code = await configCommand([], configDir)
       expect(code).toBe(2)
     })
 
     it('should return 2 for unknown subcommand', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      const code = await configCommand(['unknown'])
+      const code = await configCommand(['unknown'], configDir)
       expect(code).toBe(2)
     })
 
     it('should write usage to stderr for missing subcommand', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
-      await configCommand([])
+      await configCommand([], configDir)
       expect(stderrOutput).toContain('Usage: vaultkeeper config')
     })
   })

--- a/packages/cli/test/unit/commands/delete.test.ts
+++ b/packages/cli/test/unit/commands/delete.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+const configDir = '/tmp/vaultkeeper-test-config-dir'
+
 // vi.hoisted ensures the mock factory can reference mockInit before imports are resolved.
 const mockInit = vi.hoisted(() => vi.fn())
 const mockDeleteFn = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
@@ -45,19 +47,19 @@ describe('deleteCommand', () => {
   describe('--name flag validation', () => {
     it('should return 2 when --name is missing', async () => {
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      const code = await deleteCommand([])
+      const code = await deleteCommand([], configDir)
       expect(code).toBe(2)
     })
 
     it('should write error to stderr when --name is missing', async () => {
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand([])
+      await deleteCommand([], configDir)
       expect(stderrOutput).toContain('--name is required')
     })
 
     it('should include usage hint when --name is missing', async () => {
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand([])
+      await deleteCommand([], configDir)
       expect(stderrOutput).toContain('Usage:')
     })
   })
@@ -66,14 +68,14 @@ describe('deleteCommand', () => {
     it('should return 1', async () => {
       mockInit.mockRejectedValue(new Error('backend unavailable'))
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      const code = await deleteCommand(['--name', 'my-secret'])
+      const code = await deleteCommand(['--name', 'my-secret'], configDir)
       expect(code).toBe(1)
     })
 
     it('should write formatted error to stderr', async () => {
       mockInit.mockRejectedValue(new Error('backend unavailable'))
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--name', 'my-secret'])
+      await deleteCommand(['--name', 'my-secret'], configDir)
       expect(stderrOutput).toContain('backend unavailable')
     })
   })
@@ -82,14 +84,14 @@ describe('deleteCommand', () => {
     it('should return 0', async () => {
       mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      const code = await deleteCommand(['--name', 'my-secret'])
+      const code = await deleteCommand(['--name', 'my-secret'], configDir)
       expect(code).toBe(0)
     })
 
     it('should write success message to stdout', async () => {
       mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--name', 'my-secret'])
+      await deleteCommand(['--name', 'my-secret'], configDir)
       expect(stdoutOutput).toContain('deleted')
     })
   })
@@ -98,60 +100,60 @@ describe('deleteCommand', () => {
     it('should pass skipDoctor: false to VaultKeeper.init by default', async () => {
       mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await deleteCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
       mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--name', 'my-secret', '--skip-doctor'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await deleteCommand(['--name', 'my-secret', '--skip-doctor'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '1'
       mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await deleteCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '0'
       mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await deleteCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=true (non-numeric)', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = 'true'
       mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await deleteCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR is empty string', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = ''
       mockInit.mockResolvedValue({ delete: mockDeleteFn })
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await deleteCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
   })
 
   describe('--help flag', () => {
     it('should include --skip-doctor in help output', async () => {
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--help'])
+      await deleteCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('--skip-doctor')
     })
 
     it('should include VAULTKEEPER_SKIP_DOCTOR env var in help output', async () => {
       const { deleteCommand } = await import('../../../src/commands/delete.js')
-      await deleteCommand(['--help'])
+      await deleteCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('VAULTKEEPER_SKIP_DOCTOR')
     })
   })

--- a/packages/cli/test/unit/commands/dev-mode.test.ts
+++ b/packages/cli/test/unit/commands/dev-mode.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+const configDir = '/tmp/vaultkeeper-test-config-dir'
+
 // vi.hoisted ensures the mock factory can reference mockInit before imports are resolved.
 const mockInit = vi.hoisted(() => vi.fn())
 
@@ -35,25 +37,25 @@ describe('devModeCommand', () => {
   describe('action validation', () => {
     it('should return 2 when no action is provided', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      const code = await devModeCommand(['--script', '/path/to/script.sh'])
+      const code = await devModeCommand(['--script', '/path/to/script.sh'], configDir)
       expect(code).toBe(2)
     })
 
     it('should return 2 for invalid action', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      const code = await devModeCommand(['invalid', '--script', '/path/to/script.sh'])
+      const code = await devModeCommand(['invalid', '--script', '/path/to/script.sh'], configDir)
       expect(code).toBe(2)
     })
 
     it('should return 2 for action that is neither enable nor disable', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      const code = await devModeCommand(['toggle', '--script', '/path/to/script.sh'])
+      const code = await devModeCommand(['toggle', '--script', '/path/to/script.sh'], configDir)
       expect(code).toBe(2)
     })
 
     it('should write usage to stderr for invalid action', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand(['invalid', '--script', '/path/to/script.sh'])
+      await devModeCommand(['invalid', '--script', '/path/to/script.sh'], configDir)
       expect(stderrOutput).toContain('Usage: vaultkeeper dev-mode')
       expect(stderrOutput).toContain('<enable|disable>')
     })
@@ -62,19 +64,19 @@ describe('devModeCommand', () => {
   describe('--script flag validation', () => {
     it('should return 2 when --script is missing with valid action', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      const code = await devModeCommand(['enable'])
+      const code = await devModeCommand(['enable'], configDir)
       expect(code).toBe(2)
     })
 
     it('should return 2 when --script is missing with disable action', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      const code = await devModeCommand(['disable'])
+      const code = await devModeCommand(['disable'], configDir)
       expect(code).toBe(2)
     })
 
     it('should write usage to stderr when --script is missing', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand(['enable'])
+      await devModeCommand(['enable'], configDir)
       expect(stderrOutput).toContain('--script')
     })
   })
@@ -82,13 +84,13 @@ describe('devModeCommand', () => {
   describe('when both action and --script are missing', () => {
     it('should return 2 with no args', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      const code = await devModeCommand([])
+      const code = await devModeCommand([], configDir)
       expect(code).toBe(2)
     })
 
     it('should write usage to stderr with no args', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand([])
+      await devModeCommand([], configDir)
       expect(stderrOutput).toContain('Usage:')
     })
   })
@@ -98,16 +100,16 @@ describe('devModeCommand', () => {
       const mockVault = { setDevelopmentMode: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand(['enable', '--script', '/path/to/script.sh'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await devModeCommand(['enable', '--script', '/path/to/script.sh'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
       const mockVault = { setDevelopmentMode: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand(['enable', '--script', '/path/to/script.sh', '--skip-doctor'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await devModeCommand(['enable', '--script', '/path/to/script.sh', '--skip-doctor'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
@@ -115,8 +117,8 @@ describe('devModeCommand', () => {
       const mockVault = { setDevelopmentMode: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand(['enable', '--script', '/path/to/script.sh'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await devModeCommand(['enable', '--script', '/path/to/script.sh'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
@@ -124,21 +126,21 @@ describe('devModeCommand', () => {
       const mockVault = { setDevelopmentMode: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand(['enable', '--script', '/path/to/script.sh'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await devModeCommand(['enable', '--script', '/path/to/script.sh'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
   })
 
   describe('--help flag', () => {
     it('should include --skip-doctor in help output', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand(['--help'])
+      await devModeCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('--skip-doctor')
     })
 
     it('should include VAULTKEEPER_SKIP_DOCTOR env var in help output', async () => {
       const { devModeCommand } = await import('../../../src/commands/dev-mode.js')
-      await devModeCommand(['--help'])
+      await devModeCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('VAULTKEEPER_SKIP_DOCTOR')
     })
   })

--- a/packages/cli/test/unit/commands/doctor.test.ts
+++ b/packages/cli/test/unit/commands/doctor.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+const configDir = '/tmp/vaultkeeper-test-config-dir'
+
 // Capture mock fn references in the factory closure to avoid
 // accessing class methods through vi.mocked(), which triggers
 // @typescript-eslint/unbound-method on static class method types.
 const mockDoctor = vi.fn()
+const mockLoadConfig = vi.fn()
 
 vi.mock('vaultkeeper', () => ({
   VaultKeeper: {
     doctor: mockDoctor,
   },
+  loadConfig: mockLoadConfig,
 }))
 
 describe('doctorCommand', () => {
@@ -26,6 +30,7 @@ describe('doctorCommand', () => {
       stdoutOutput += String(chunk)
       return true
     })
+    mockLoadConfig.mockResolvedValue({ backends: [] })
   })
 
   afterEach(() => {
@@ -42,7 +47,7 @@ describe('doctorCommand', () => {
         nextSteps: [],
       })
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      const code = await doctorCommand([])
+      const code = await doctorCommand([], configDir)
       expect(code).toBe(0)
     })
 
@@ -54,7 +59,7 @@ describe('doctorCommand', () => {
         nextSteps: [],
       })
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      await doctorCommand([])
+      await doctorCommand([], configDir)
       expect(stdoutOutput).toContain('System ready.')
     })
 
@@ -66,7 +71,7 @@ describe('doctorCommand', () => {
         nextSteps: [],
       })
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      await doctorCommand([])
+      await doctorCommand([], configDir)
       expect(stdoutOutput).toContain('✓')
       expect(stdoutOutput).toContain('keychain')
       expect(stdoutOutput).toContain('1.2.3')
@@ -80,7 +85,7 @@ describe('doctorCommand', () => {
         nextSteps: [],
       })
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      await doctorCommand([])
+      await doctorCommand([], configDir)
       expect(stdoutOutput).toContain('Warnings:')
       expect(stdoutOutput).toContain('Keychain is locked')
     })
@@ -95,7 +100,7 @@ describe('doctorCommand', () => {
         nextSteps: ['Install keychain'],
       })
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      const code = await doctorCommand([])
+      const code = await doctorCommand([], configDir)
       expect(code).toBe(1)
     })
 
@@ -107,7 +112,7 @@ describe('doctorCommand', () => {
         nextSteps: ['Install keychain'],
       })
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      await doctorCommand([])
+      await doctorCommand([], configDir)
       expect(stdoutOutput).toContain('Next steps:')
       expect(stdoutOutput).toContain('Install keychain')
     })
@@ -120,7 +125,7 @@ describe('doctorCommand', () => {
         nextSteps: [],
       })
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      await doctorCommand([])
+      await doctorCommand([], configDir)
       expect(stdoutOutput).toContain('✗')
       expect(stdoutOutput).toContain('not available')
     })
@@ -130,14 +135,14 @@ describe('doctorCommand', () => {
     it('should return 1', async () => {
       mockDoctor.mockRejectedValue(new Error('doctor failed'))
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      const code = await doctorCommand([])
+      const code = await doctorCommand([], configDir)
       expect(code).toBe(1)
     })
 
     it('should write formatted error to stderr', async () => {
       mockDoctor.mockRejectedValue(new Error('doctor failed'))
       const { doctorCommand } = await import('../../../src/commands/doctor.js')
-      await doctorCommand([])
+      await doctorCommand([], configDir)
       expect(stderrOutput).toContain('doctor failed')
     })
   })

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -118,19 +118,18 @@ describe('execCommand', () => {
 
   describe('-- separator validation', () => {
     it('should return 2 when -- separator is missing', async () => {
-      const code = await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-      ], configDir)
+      const code = await execCommand(
+        ['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh'],
+        configDir,
+      )
       expect(code).toBe(2)
     })
 
     it('should write error message when -- separator is missing', async () => {
-      await execCommand(['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh'], configDir)
+      await execCommand(
+        ['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh'],
+        configDir,
+      )
       expect(stderrOutput).toContain('Must provide command after --')
     })
 
@@ -142,69 +141,44 @@ describe('execCommand', () => {
 
   describe('command after -- validation', () => {
     it('should return 2 when command after -- is empty', async () => {
-      const code = await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-      ], configDir)
+      const code = await execCommand(
+        ['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--'],
+        configDir,
+      )
       expect(code).toBe(2)
     })
 
     it('should write error message when command after -- is empty', async () => {
-      await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-      ], configDir)
+      await execCommand(
+        ['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--'],
+        configDir,
+      )
       expect(stderrOutput).toContain('No command provided after --')
     })
   })
 
   describe('required flag validation', () => {
     it('should return 2 when --secret is missing', async () => {
-      const code = await execCommand([
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      const code = await execCommand(
+        ['--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--', 'echo', 'hello'],
+        configDir,
+      )
       expect(code).toBe(2)
     })
 
     it('should return 2 when --env is missing', async () => {
-      const code = await execCommand([
-        '--secret',
-        'my-key',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      const code = await execCommand(
+        ['--secret', 'my-key', '--caller', '/path/to/script.sh', '--', 'echo', 'hello'],
+        configDir,
+      )
       expect(code).toBe(2)
     })
 
     it('should return 2 when --caller is missing', async () => {
-      const code = await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      const code = await execCommand(
+        ['--secret', 'my-key', '--env', 'MY_VAR', '--', 'echo', 'hello'],
+        configDir,
+      )
       expect(code).toBe(2)
     })
 
@@ -214,15 +188,10 @@ describe('execCommand', () => {
     })
 
     it('should write error message when required flags are missing', async () => {
-      await execCommand([
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      await execCommand(
+        ['--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--', 'echo', 'hello'],
+        configDir,
+      )
       expect(stderrOutput).toContain('--secret, --env, and --caller are required')
     })
   })
@@ -248,17 +217,20 @@ describe('execCommand', () => {
 
     it('should pass skipDoctor: false to VaultKeeper.init by default', async () => {
       mockInit.mockResolvedValue(pendingVaultMock())
-      await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      await execCommand(
+        [
+          '--secret',
+          'my-key',
+          '--env',
+          'MY_VAR',
+          '--caller',
+          '/path/to/script.sh',
+          '--',
+          'echo',
+          'hello',
+        ],
+        configDir,
+      )
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
       expect(promptApproval).toHaveBeenCalled()
       expect(stderrOutput).toContain('Access denied by user.')
@@ -266,18 +238,21 @@ describe('execCommand', () => {
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
       mockInit.mockResolvedValue(pendingVaultMock())
-      await execCommand([
-        '--skip-doctor',
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      await execCommand(
+        [
+          '--skip-doctor',
+          '--secret',
+          'my-key',
+          '--env',
+          'MY_VAR',
+          '--caller',
+          '/path/to/script.sh',
+          '--',
+          'echo',
+          'hello',
+        ],
+        configDir,
+      )
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
       expect(promptApproval).toHaveBeenCalled()
     })
@@ -285,17 +260,20 @@ describe('execCommand', () => {
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '1'
       mockInit.mockResolvedValue(pendingVaultMock())
-      await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      await execCommand(
+        [
+          '--secret',
+          'my-key',
+          '--env',
+          'MY_VAR',
+          '--caller',
+          '/path/to/script.sh',
+          '--',
+          'echo',
+          'hello',
+        ],
+        configDir,
+      )
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
       expect(promptApproval).toHaveBeenCalled()
     })
@@ -303,17 +281,20 @@ describe('execCommand', () => {
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '0'
       mockInit.mockResolvedValue(pendingVaultMock())
-      await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      await execCommand(
+        [
+          '--secret',
+          'my-key',
+          '--env',
+          'MY_VAR',
+          '--caller',
+          '/path/to/script.sh',
+          '--',
+          'echo',
+          'hello',
+        ],
+        configDir,
+      )
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
       expect(promptApproval).toHaveBeenCalled()
     })
@@ -321,17 +302,20 @@ describe('execCommand', () => {
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=true (non-numeric)', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = 'true'
       mockInit.mockResolvedValue(pendingVaultMock())
-      await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      await execCommand(
+        [
+          '--secret',
+          'my-key',
+          '--env',
+          'MY_VAR',
+          '--caller',
+          '/path/to/script.sh',
+          '--',
+          'echo',
+          'hello',
+        ],
+        configDir,
+      )
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
       expect(promptApproval).toHaveBeenCalled()
     })
@@ -339,17 +323,20 @@ describe('execCommand', () => {
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR is empty string', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = ''
       mockInit.mockResolvedValue(pendingVaultMock())
-      await execCommand([
-        '--secret',
-        'my-key',
-        '--env',
-        'MY_VAR',
-        '--caller',
-        '/path/to/script.sh',
-        '--',
-        'echo',
-        'hello',
-      ], configDir)
+      await execCommand(
+        [
+          '--secret',
+          'my-key',
+          '--env',
+          'MY_VAR',
+          '--caller',
+          '/path/to/script.sh',
+          '--',
+          'echo',
+          'hello',
+        ],
+        configDir,
+      )
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
       expect(promptApproval).toHaveBeenCalled()
     })

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -3,6 +3,8 @@ import { execCommand } from '../../../src/commands/exec.js'
 import { promptApproval } from '../../../src/approval.js'
 import { readCachedToken } from '../../../src/cache.js'
 
+const configDir = '/tmp/vaultkeeper-test-config-dir'
+
 const mockInit = vi.hoisted(() => vi.fn())
 
 // A real IdentityMismatchError subclass so `.name`/`.message` format exactly as
@@ -123,17 +125,17 @@ describe('execCommand', () => {
         'MY_VAR',
         '--caller',
         '/path/to/script.sh',
-      ])
+      ], configDir)
       expect(code).toBe(2)
     })
 
     it('should write error message when -- separator is missing', async () => {
-      await execCommand(['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh'])
+      await execCommand(['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '/path/to/script.sh'], configDir)
       expect(stderrOutput).toContain('Must provide command after --')
     })
 
     it('should include usage hint when -- separator is missing', async () => {
-      await execCommand([])
+      await execCommand([], configDir)
       expect(stderrOutput).toContain('Usage: vaultkeeper exec')
     })
   })
@@ -148,7 +150,7 @@ describe('execCommand', () => {
         '--caller',
         '/path/to/script.sh',
         '--',
-      ])
+      ], configDir)
       expect(code).toBe(2)
     })
 
@@ -161,7 +163,7 @@ describe('execCommand', () => {
         '--caller',
         '/path/to/script.sh',
         '--',
-      ])
+      ], configDir)
       expect(stderrOutput).toContain('No command provided after --')
     })
   })
@@ -176,7 +178,7 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
+      ], configDir)
       expect(code).toBe(2)
     })
 
@@ -189,7 +191,7 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
+      ], configDir)
       expect(code).toBe(2)
     })
 
@@ -202,12 +204,12 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
+      ], configDir)
       expect(code).toBe(2)
     })
 
     it('should return 2 when all required flags are missing', async () => {
-      const code = await execCommand(['--', 'echo', 'hello'])
+      const code = await execCommand(['--', 'echo', 'hello'], configDir)
       expect(code).toBe(2)
     })
 
@@ -220,7 +222,7 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
+      ], configDir)
       expect(stderrOutput).toContain('--secret, --env, and --caller are required')
     })
   })
@@ -256,8 +258,8 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      ], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
       expect(promptApproval).toHaveBeenCalled()
       expect(stderrOutput).toContain('Access denied by user.')
     })
@@ -275,8 +277,8 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      ], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
       expect(promptApproval).toHaveBeenCalled()
     })
 
@@ -293,8 +295,8 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      ], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
       expect(promptApproval).toHaveBeenCalled()
     })
 
@@ -311,8 +313,8 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      ], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
       expect(promptApproval).toHaveBeenCalled()
     })
 
@@ -329,8 +331,8 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      ], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
       expect(promptApproval).toHaveBeenCalled()
     })
 
@@ -347,8 +349,8 @@ describe('execCommand', () => {
         '--',
         'echo',
         'hello',
-      ])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      ], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
       expect(promptApproval).toHaveBeenCalled()
     })
   })
@@ -383,7 +385,7 @@ describe('execCommand', () => {
       })
       mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
 
-      const code = await execCommand(EXEC_ARGS)
+      const code = await execCommand(EXEC_ARGS, configDir)
 
       expect(code).toBe(1)
       expect(promptApproval).not.toHaveBeenCalled()
@@ -420,7 +422,7 @@ describe('execCommand', () => {
       // A previously cached token exists — but the gate must run before it is used.
       vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')
 
-      const code = await execCommand(['--cache', ...EXEC_ARGS])
+      const code = await execCommand(['--cache', ...EXEC_ARGS], configDir)
 
       expect(code).not.toBe(0)
       // The cached token was never used to authorize or read the secret.
@@ -449,7 +451,7 @@ describe('execCommand', () => {
       mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
       vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')
 
-      const code = await execCommand(['--cache', ...EXEC_ARGS])
+      const code = await execCommand(['--cache', ...EXEC_ARGS], configDir)
 
       expect(code).toBe(0)
       expect(promptApproval).not.toHaveBeenCalled()
@@ -478,7 +480,7 @@ describe('execCommand', () => {
       })
       mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
 
-      const code = await execCommand(['--yes', ...EXEC_ARGS])
+      const code = await execCommand(['--yes', ...EXEC_ARGS], configDir)
 
       expect(code).toBe(0)
       expect(promptApproval).not.toHaveBeenCalled()
@@ -507,7 +509,7 @@ describe('execCommand', () => {
       })
       mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
 
-      const code = await execCommand(EXEC_ARGS)
+      const code = await execCommand(EXEC_ARGS, configDir)
 
       expect(code).toBe(0)
       expect(promptApproval).not.toHaveBeenCalled()
@@ -539,7 +541,7 @@ describe('execCommand', () => {
       // that is only being approved this run.
       vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')
 
-      const code = await execCommand(['--cache', '--yes', ...EXEC_ARGS])
+      const code = await execCommand(['--cache', '--yes', ...EXEC_ARGS], configDir)
 
       expect(code).toBe(0)
       // The cache was not even consulted for a just-approved caller.
@@ -559,7 +561,7 @@ describe('execCommand', () => {
         const vault = pendingVaultMock()
         mockInit.mockResolvedValue(vault)
 
-        const code = await execCommand(EXEC_ARGS)
+        const code = await execCommand(EXEC_ARGS, configDir)
 
         expect(code).toBe(1)
         expect(promptApproval).not.toHaveBeenCalled()
@@ -576,25 +578,25 @@ describe('execCommand', () => {
 
   describe('--help flag', () => {
     it('should include --skip-doctor in help output', async () => {
-      await execCommand(['--help'])
+      await execCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('--skip-doctor')
     })
 
     it('should include VAULTKEEPER_SKIP_DOCTOR env var in help output', async () => {
-      await execCommand(['--help'])
+      await execCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('VAULTKEEPER_SKIP_DOCTOR')
     })
 
     // Issue #58, criterion 4: help documents the TTY requirement and both escape
     // hatches (--yes and VAULTKEEPER_YES), plus the approve alternative.
     it('documents the --yes flag and VAULTKEEPER_YES env var', async () => {
-      await execCommand(['--help'])
+      await execCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('--yes')
       expect(stdoutOutput).toContain('VAULTKEEPER_YES')
     })
 
     it('documents the TTY requirement and how to approve non-interactively', async () => {
-      await execCommand(['--help'])
+      await execCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('non-TTY')
       expect(stdoutOutput).toContain('vaultkeeper approve --script')
     })

--- a/packages/cli/test/unit/commands/revoke-key.test.ts
+++ b/packages/cli/test/unit/commands/revoke-key.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+const configDir = '/tmp/vaultkeeper-test-config-dir'
+
 // vi.hoisted ensures the mock factory can reference mockInit before imports are resolved.
 const mockInit = vi.hoisted(() => vi.fn())
 
@@ -35,19 +37,19 @@ describe('revokeKeyCommand', () => {
   describe('unknown flag handling', () => {
     it('should return 2 for unknown flags', async () => {
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      const code = await revokeKeyCommand(['--bogus'])
+      const code = await revokeKeyCommand(['--bogus'], configDir)
       expect(code).toBe(2)
     })
 
     it('should write error message for unknown flags', async () => {
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand(['--bogus'])
+      await revokeKeyCommand(['--bogus'], configDir)
       expect(stderrOutput).toContain('Error:')
     })
 
     it('should print help after unknown flag error', async () => {
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand(['--bogus'])
+      await revokeKeyCommand(['--bogus'], configDir)
       expect(stdoutOutput).toContain('Usage: vaultkeeper revoke-key')
     })
   })
@@ -56,14 +58,14 @@ describe('revokeKeyCommand', () => {
     it('should return 1', async () => {
       mockInit.mockRejectedValue(new Error('backend unavailable'))
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      const code = await revokeKeyCommand([])
+      const code = await revokeKeyCommand([], configDir)
       expect(code).toBe(1)
     })
 
     it('should write formatted error to stderr', async () => {
       mockInit.mockRejectedValue(new Error('backend unavailable'))
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand([])
+      await revokeKeyCommand([], configDir)
       expect(stderrOutput).toContain('backend unavailable')
     })
   })
@@ -73,7 +75,7 @@ describe('revokeKeyCommand', () => {
       const mockVault = { revokeKey: vi.fn().mockRejectedValue(new Error('revocation failed')) }
       mockInit.mockResolvedValue(mockVault)
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      const code = await revokeKeyCommand([])
+      const code = await revokeKeyCommand([], configDir)
       expect(code).toBe(1)
     })
 
@@ -81,7 +83,7 @@ describe('revokeKeyCommand', () => {
       const mockVault = { revokeKey: vi.fn().mockRejectedValue(new Error('revocation failed')) }
       mockInit.mockResolvedValue(mockVault)
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand([])
+      await revokeKeyCommand([], configDir)
       expect(stderrOutput).toContain('revocation failed')
     })
   })
@@ -91,7 +93,7 @@ describe('revokeKeyCommand', () => {
       const mockVault = { revokeKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      const code = await revokeKeyCommand([])
+      const code = await revokeKeyCommand([], configDir)
       expect(code).toBe(0)
     })
 
@@ -99,7 +101,7 @@ describe('revokeKeyCommand', () => {
       const mockVault = { revokeKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand([])
+      await revokeKeyCommand([], configDir)
       expect(stdoutOutput).toContain('Key revoked successfully')
     })
   })
@@ -109,16 +111,16 @@ describe('revokeKeyCommand', () => {
       const mockVault = { revokeKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand([])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await revokeKeyCommand([], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
       const mockVault = { revokeKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand(['--skip-doctor'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await revokeKeyCommand(['--skip-doctor'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
@@ -126,8 +128,8 @@ describe('revokeKeyCommand', () => {
       const mockVault = { revokeKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand([])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await revokeKeyCommand([], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
@@ -135,21 +137,21 @@ describe('revokeKeyCommand', () => {
       const mockVault = { revokeKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand([])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await revokeKeyCommand([], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
   })
 
   describe('--help flag', () => {
     it('should include --skip-doctor in help output', async () => {
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand(['--help'])
+      await revokeKeyCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('--skip-doctor')
     })
 
     it('should include VAULTKEEPER_SKIP_DOCTOR env var in help output', async () => {
       const { revokeKeyCommand } = await import('../../../src/commands/revoke-key.js')
-      await revokeKeyCommand(['--help'])
+      await revokeKeyCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('VAULTKEEPER_SKIP_DOCTOR')
     })
   })

--- a/packages/cli/test/unit/commands/rotate-key.test.ts
+++ b/packages/cli/test/unit/commands/rotate-key.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+const configDir = '/tmp/vaultkeeper-test-config-dir'
+
 // vi.hoisted ensures the mock factory can reference mockInit before imports are resolved.
 const mockInit = vi.hoisted(() => vi.fn())
 
@@ -35,19 +37,19 @@ describe('rotateKeyCommand', () => {
   describe('unknown flag handling', () => {
     it('should return 2 for unknown flags', async () => {
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      const code = await rotateKeyCommand(['--bogus'])
+      const code = await rotateKeyCommand(['--bogus'], configDir)
       expect(code).toBe(2)
     })
 
     it('should write error message for unknown flags', async () => {
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand(['--bogus'])
+      await rotateKeyCommand(['--bogus'], configDir)
       expect(stderrOutput).toContain('Error:')
     })
 
     it('should print help after unknown flag error', async () => {
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand(['--bogus'])
+      await rotateKeyCommand(['--bogus'], configDir)
       expect(stdoutOutput).toContain('Usage: vaultkeeper rotate-key')
     })
   })
@@ -56,14 +58,14 @@ describe('rotateKeyCommand', () => {
     it('should return 1', async () => {
       mockInit.mockRejectedValue(new Error('backend unavailable'))
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      const code = await rotateKeyCommand([])
+      const code = await rotateKeyCommand([], configDir)
       expect(code).toBe(1)
     })
 
     it('should write formatted error to stderr', async () => {
       mockInit.mockRejectedValue(new Error('backend unavailable'))
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand([])
+      await rotateKeyCommand([], configDir)
       expect(stderrOutput).toContain('backend unavailable')
     })
 
@@ -76,7 +78,7 @@ describe('rotateKeyCommand', () => {
       }
       mockInit.mockRejectedValue(new RotationError('key rotation failed'))
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand([])
+      await rotateKeyCommand([], configDir)
       expect(stderrOutput).toContain('RotationError')
     })
   })
@@ -86,7 +88,7 @@ describe('rotateKeyCommand', () => {
       const mockVault = { rotateKey: vi.fn().mockRejectedValue(new Error('rotation failed')) }
       mockInit.mockResolvedValue(mockVault)
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      const code = await rotateKeyCommand([])
+      const code = await rotateKeyCommand([], configDir)
       expect(code).toBe(1)
     })
 
@@ -94,7 +96,7 @@ describe('rotateKeyCommand', () => {
       const mockVault = { rotateKey: vi.fn().mockRejectedValue(new Error('rotation failed')) }
       mockInit.mockResolvedValue(mockVault)
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand([])
+      await rotateKeyCommand([], configDir)
       expect(stderrOutput).toContain('rotation failed')
     })
   })
@@ -104,7 +106,7 @@ describe('rotateKeyCommand', () => {
       const mockVault = { rotateKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      const code = await rotateKeyCommand([])
+      const code = await rotateKeyCommand([], configDir)
       expect(code).toBe(0)
     })
 
@@ -112,7 +114,7 @@ describe('rotateKeyCommand', () => {
       const mockVault = { rotateKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand([])
+      await rotateKeyCommand([], configDir)
       expect(stdoutOutput).toContain('Key rotated successfully')
     })
   })
@@ -122,16 +124,16 @@ describe('rotateKeyCommand', () => {
       const mockVault = { rotateKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand([])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await rotateKeyCommand([], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
       const mockVault = { rotateKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand(['--skip-doctor'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await rotateKeyCommand(['--skip-doctor'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
@@ -139,8 +141,8 @@ describe('rotateKeyCommand', () => {
       const mockVault = { rotateKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand([])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await rotateKeyCommand([], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
@@ -148,21 +150,21 @@ describe('rotateKeyCommand', () => {
       const mockVault = { rotateKey: vi.fn().mockResolvedValue(undefined) }
       mockInit.mockResolvedValue(mockVault)
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand([])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await rotateKeyCommand([], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
   })
 
   describe('--help flag', () => {
     it('should include --skip-doctor in help output', async () => {
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand(['--help'])
+      await rotateKeyCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('--skip-doctor')
     })
 
     it('should include VAULTKEEPER_SKIP_DOCTOR env var in help output', async () => {
       const { rotateKeyCommand } = await import('../../../src/commands/rotate-key.js')
-      await rotateKeyCommand(['--help'])
+      await rotateKeyCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('VAULTKEEPER_SKIP_DOCTOR')
     })
   })

--- a/packages/cli/test/unit/commands/store.test.ts
+++ b/packages/cli/test/unit/commands/store.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
+const configDir = '/tmp/vaultkeeper-test-config-dir'
+
 // vi.hoisted ensures the mock factory can reference mockInit before imports are resolved.
 const mockInit = vi.hoisted(() => vi.fn())
 const mockStore = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
@@ -51,19 +53,19 @@ describe('storeCommand', () => {
   describe('--name flag validation', () => {
     it('should return 2 when --name is missing', async () => {
       const { storeCommand } = await import('../../../src/commands/store.js')
-      const code = await storeCommand([])
+      const code = await storeCommand([], configDir)
       expect(code).toBe(2)
     })
 
     it('should write error to stderr when --name is missing', async () => {
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand([])
+      await storeCommand([], configDir)
       expect(stderrOutput).toContain('--name is required')
     })
 
     it('should include usage hint when --name is missing', async () => {
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand([])
+      await storeCommand([], configDir)
       expect(stderrOutput).toContain('Usage:')
     })
   })
@@ -72,14 +74,14 @@ describe('storeCommand', () => {
     it('should return 1 when stdin is empty', async () => {
       mockStdinWith('')
       const { storeCommand } = await import('../../../src/commands/store.js')
-      const code = await storeCommand(['--name', 'my-secret'])
+      const code = await storeCommand(['--name', 'my-secret'], configDir)
       expect(code).toBe(1)
     })
 
     it('should write error when stdin is empty', async () => {
       mockStdinWith('')
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret'])
+      await storeCommand(['--name', 'my-secret'], configDir)
       expect(stderrOutput).toContain('No secret provided on stdin')
     })
   })
@@ -89,7 +91,7 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockRejectedValue(new Error('backend unavailable'))
       const { storeCommand } = await import('../../../src/commands/store.js')
-      const code = await storeCommand(['--name', 'my-secret'])
+      const code = await storeCommand(['--name', 'my-secret'], configDir)
       expect(code).toBe(1)
     })
 
@@ -97,7 +99,7 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockRejectedValue(new Error('backend unavailable'))
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret'])
+      await storeCommand(['--name', 'my-secret'], configDir)
       expect(stderrOutput).toContain('backend unavailable')
     })
   })
@@ -107,7 +109,7 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
-      const code = await storeCommand(['--name', 'my-secret'])
+      const code = await storeCommand(['--name', 'my-secret'], configDir)
       expect(code).toBe(0)
     })
 
@@ -115,7 +117,7 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret'])
+      await storeCommand(['--name', 'my-secret'], configDir)
       expect(stdoutOutput).toContain('stored successfully')
     })
   })
@@ -125,16 +127,16 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await storeCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
       mockStdinWith('my-secret-value')
       mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret', '--skip-doctor'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await storeCommand(['--name', 'my-secret', '--skip-doctor'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
@@ -142,8 +144,8 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: true })
+      await storeCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
@@ -151,8 +153,8 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await storeCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=true (non-numeric)', async () => {
@@ -160,8 +162,8 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await storeCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR is empty string', async () => {
@@ -169,21 +171,21 @@ describe('storeCommand', () => {
       mockStdinWith('my-secret-value')
       mockInit.mockResolvedValue({ store: mockStore })
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--name', 'my-secret'])
-      expect(mockInit).toHaveBeenCalledWith({ skipDoctor: false })
+      await storeCommand(['--name', 'my-secret'], configDir)
+      expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
   })
 
   describe('--help flag', () => {
     it('should include --skip-doctor in help output', async () => {
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--help'])
+      await storeCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('--skip-doctor')
     })
 
     it('should include VAULTKEEPER_SKIP_DOCTOR env var in help output', async () => {
       const { storeCommand } = await import('../../../src/commands/store.js')
-      await storeCommand(['--help'])
+      await storeCommand(['--help'], configDir)
       expect(stdoutOutput).toContain('VAULTKEEPER_SKIP_DOCTOR')
     })
   })

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -131,6 +131,9 @@ export class FilesystemError extends VaultError {
 }
 
 // @public
+export function getDefaultConfigDir(): string;
+
+// @public
 export class IdentityMismatchError extends VaultError {
     constructor(message: string, previousHash: string, currentHash: string);
     readonly currentHash: string;
@@ -174,6 +177,9 @@ export type KeyStatus = 'current' | 'previous' | 'deprecated';
 export interface ListableBackend extends SecretBackend {
     list(): Promise<string[]>;
 }
+
+// @public
+export function loadConfig(configDir?: string): Promise<VaultConfig>;
 
 // @public
 export type Platform = 'darwin' | 'win32' | 'linux';

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -246,10 +246,16 @@ export function validateConfig(config: unknown): VaultConfig {
 }
 
 /**
- * Load the vaultkeeper config from disk, falling back to defaults if the file
- * does not exist.
+ * Load the vaultkeeper config from disk, falling back to defaults if the
+ * file cannot be read — this currently includes both a missing file and any
+ * other read failure (e.g. a permissions error), not only "file does not
+ * exist". Narrowing the fallback to ENOENT specifically, and surfacing other
+ * read errors instead of silently defaulting, is tracked in issue #68
+ * (config validation) and not yet implemented.
  *
- * @param configDir - Directory containing config.json. Defaults to platform-appropriate path.
+ * @param configDir - Directory containing config.json. Defaults to
+ * `getDefaultConfigDir()`, which itself honors `VAULTKEEPER_CONFIG_DIR`
+ * before falling back to the platform-appropriate path.
  * @public
  */
 export async function loadConfig(configDir?: string): Promise<VaultConfig> {

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -10,7 +10,14 @@ import { ConfigValidationError } from './errors.js'
 
 /**
  * Return the platform-appropriate default config directory.
- * @internal
+ *
+ * Resolution order: the `VAULTKEEPER_CONFIG_DIR` environment variable, then
+ * the platform default (`%APPDATA%/vaultkeeper` on Windows,
+ * `~/.config/vaultkeeper` elsewhere). Consumers that also support a
+ * higher-precedence override (e.g. a CLI flag) should check that first and
+ * only fall back to this function when no override was supplied.
+ *
+ * @public
  */
 export function getDefaultConfigDir(): string {
   const envOverride = process.env.VAULTKEEPER_CONFIG_DIR
@@ -243,7 +250,7 @@ export function validateConfig(config: unknown): VaultConfig {
  * does not exist.
  *
  * @param configDir - Directory containing config.json. Defaults to platform-appropriate path.
- * @internal
+ * @public
  */
 export async function loadConfig(configDir?: string): Promise<VaultConfig> {
   const dir = configDir ?? getDefaultConfigDir()

--- a/packages/vaultkeeper/src/index.ts
+++ b/packages/vaultkeeper/src/index.ts
@@ -71,6 +71,7 @@ export type {
 } from './vault.js'
 
 export { platformDefaultBackendType } from './config.js'
+export { getDefaultConfigDir, loadConfig } from './config.js'
 
 export { runDoctor } from './doctor/runner.js'
 export type { RunDoctorOptions } from './doctor/runner.js'


### PR DESCRIPTION
## Summary

- Every CLI command that reads or writes vault state (`store`, `delete`, `exec`, `approve`, `dev-mode`, `doctor`, `config`, `rotate-key`, `revoke-key`) now accepts a config directory override, resolved once in `bin.ts`: `--config-dir <path>` flag wins over `VAULTKEEPER_CONFIG_DIR`, which wins over the platform default.
- `config init` creates the override directory as needed; `config show` reports the path it loaded from.
- `--help` documents the flag and env var for every command.
- `vaultkeeper`'s `getDefaultConfigDir()` and `loadConfig()` are promoted from `@internal` to `@public` so the CLI and other embedders share the same resolution logic.
- `@vaultkeeper/cli-test-helpers`'s `createCliTestEnv()` gains a `configDirMode` option (`'env'` | `'flag'`) and no longer manipulates the subprocess `HOME` directory for isolation — it uses `VAULTKEEPER_CONFIG_DIR` (or an explicit `--config-dir` for `'flag'` mode) instead.

Refs #65

## Test plan

- [x] `pnpm check` (typecheck + lint + API report validation) is green across the workspace
- [x] `pnpm --filter @vaultkeeper/cli test` — 206 tests passing, including per-command `configDir` wiring and `--help` output coverage
- [x] `pnpm --filter @vaultkeeper/cli-test-helpers test` — `createCliTestEnv()` self-tests passing
- [x] `pnpm --filter @vaultkeeper/cli-tests test` — new `test/e2e/config-dir.test.ts` UATs cover env-var isolation, flag isolation, flag-over-env precedence, `config show` path reporting, `config init` creating nested directories, `doctor` scoping, two simultaneous isolated config dirs, and negative cases (missing flag value, `--config-dir` after `exec`'s `--` separator not being consumed)
- [x] `pnpm --filter vaultkeeper test` — 602 tests passing
- [x] `pnpm test` (full workspace) — all suites green