### PR TITLE
Persist key material across processes; fix exec --cache, KeyRevokedError masking, and rotation grace period

### DIFF
--- a/.changeset/persist-key-material.md
+++ b/.changeset/persist-key-material.md
@@ -1,0 +1,12 @@
+---
+'vaultkeeper': minor
+'@vaultkeeper/cli': patch
+---
+
+Persist key material across processes so cached tokens and the rotation grace period work between CLI invocations.
+
+- `KeyManager` encryption keys are now persisted under the config directory, encrypted at rest with AES-256-GCM under an owner-only (`0600`) wrapping key — reusing the same authenticated-cipher primitives as the file backend. Persistence is active only when `VaultKeeper` loads its configuration from disk (no injected `config`/`backend`); instances built with an injected `config` or `backend` keep keys in memory, so tests and embedders stay hermetic.
+- A JWE minted by one process is now authorizable by a later process within its validity window: its `kid` still resolves after the minting process exits. Previously every process generated fresh keys, so a cached token always failed with `KeyRevokedError`.
+- `vaultkeeper exec --cache` now genuinely reuses a cached token on a second run by the same trusted caller — without re-minting and without the misleading "Cached token expired" message. Cached tokens are reusable until they expire (the secret's TTL) or the key is rotated/revoked, after which `exec` transparently mints a fresh one.
+- The cached-token path no longer collapses every authorization failure into a generic "expired" message. Each failure now surfaces its actual cause (e.g. `KeyRevokedError`, `TokenExpiredError`).
+- The rotation grace-period guard now survives across processes: running `rotate-key` twice while the previous key is still in its grace period fails the second time with `RotationInProgressError` (non-zero exit) instead of silently rotating again.

--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ if (vaultResponse.rotatedJwt !== undefined) {
 await vault.revokeKey()
 ```
 
+Key material is persisted across processes. When `VaultKeeper` loads its configuration from the config directory (the CLI's normal mode — no injected `config` or `backend`), the encryption keys are written there, encrypted at rest with AES-256-GCM under an owner-only (`0600`) wrapping key. This means a token minted by one CLI process stays authorizable by a later process within its validity window, and the rotation grace period is enforced across invocations: `rotate-key` run twice while the previous key is still in its grace period fails the second time with `RotationInProgressError`. Instances created with an injected `config` or `backend` keep keys in memory only, so tests and embedders stay hermetic.
+
 ## Trust tiers
 
 Executable identity is verified during `setup()`. A `trustTier` value can be attached to the resulting token as a policy label.

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -16,8 +16,13 @@
  * record the approval, and an untrusted caller on non-TTY stdin fails with
  * actionable remediation.
  *
+ * Issue #59 adds coverage for cross-process cached-token reuse (persisted key
+ * material) and accurate error surfacing on the cached-token path: a revoked
+ * key must be reported as `KeyRevokedError`, not a generic "expired" message.
+ *
  * @see https://github.com/mike-north/vaultkeeper/issues/57
  * @see https://github.com/mike-north/vaultkeeper/issues/58
+ * @see https://github.com/mike-north/vaultkeeper/issues/59
  */
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
@@ -209,6 +214,56 @@ describe('exec trust gate', () => {
     } finally {
       await yesEnv.cleanup()
     }
+  })
+
+  // Issue #59, criterion 3 (definitive cross-process proof): two sequential
+  // exec --cache invocations by the same trusted caller — separate node
+  // subprocesses sharing the config dir and HOME. The second run reuses the
+  // token cached by the first (persisted key material lets its kid still
+  // resolve) and must NOT re-mint or print the "expired"/re-auth notice.
+  it('reuses a cached token across processes without re-authenticating', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+    await env.run(['approve', '--script', caller])
+
+    const first = await env.run(execArgs(caller, ['--cache']))
+    expect(first.exitCode).toBe(0)
+    expect(first.stdout).toContain('ready=yes')
+
+    const second = await env.run(execArgs(caller, ['--cache']))
+    expect(second.exitCode).toBe(0)
+    expect(second.stdout).toContain('ready=yes')
+    expect(second.stderr).toContain('Trust: verified')
+    // The cached token authorized cleanly — no re-mint, no misleading notice.
+    expect(second.stderr).not.toContain('re-authenticating')
+    expect(second.stderr).not.toContain('expired')
+    expect(second.stderr).not.toContain('could not be authorized')
+  })
+
+  // Issue #59, criterion 4: when the key behind a cached token is revoked
+  // between runs, the cached-token path reports the ACTUAL failure
+  // (KeyRevokedError) rather than collapsing it into a generic "expired"
+  // message, and still recovers by minting a fresh token for the trusted caller.
+  it('surfaces KeyRevokedError (not "expired") when a cached token\'s key was revoked', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+    await env.run(['approve', '--script', caller])
+
+    // Mint and cache a token.
+    const first = await env.run(execArgs(caller, ['--cache']))
+    expect(first.exitCode).toBe(0)
+
+    // Revoke the key — the cached token's kid is now unresolvable.
+    const revoked = await env.run(['revoke-key'])
+    expect(revoked.exitCode).toBe(0)
+
+    const second = await env.run(execArgs(caller, ['--cache']))
+    // Recovers (fresh mint for the trusted caller)…
+    expect(second.exitCode).toBe(0)
+    expect(second.stdout).toContain('ready=yes')
+    // …but the notice names the real cause, not a bogus "expired".
+    expect(second.stderr).toContain('KeyRevokedError')
+    expect(second.stderr).not.toContain('Cached token expired')
   })
 
   // Issue #58, criterion 4: exec --help documents the TTY requirement and both

--- a/packages/cli-tests/test/e2e/rotate-key.test.ts
+++ b/packages/cli-tests/test/e2e/rotate-key.test.ts
@@ -22,10 +22,24 @@ describe('rotate-key', () => {
   it('should rotate key or fail with doctor error', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['rotate-key'])
-    const succeeded =
-      result.exitCode === 0 && result.stdout.includes('rotated successfully')
-    const doctorFailed =
-      result.exitCode === 1 && result.stderr.includes('System not ready')
+    const succeeded = result.exitCode === 0 && result.stdout.includes('rotated successfully')
+    const doctorFailed = result.exitCode === 1 && result.stderr.includes('System not ready')
     expect(succeeded || doctorFailed).toBe(true)
+  })
+
+  // Issue #59, criterion 5: the rotation grace-period guard survives across
+  // processes. Two sequential rotate-key invocations sharing a config dir: the
+  // first succeeds, the second fails with the documented RotationInProgressError
+  // (non-zero exit, clear message) while the grace period is still active.
+  it('rejects a second rotate-key while the previous key is in its grace period', async () => {
+    env = await createCliTestEnv({ env: { VAULTKEEPER_SKIP_DOCTOR: '1' } })
+
+    const first = await env.run(['rotate-key'])
+    expect(first.exitCode).toBe(0)
+    expect(first.stdout).toContain('rotated successfully')
+
+    const second = await env.run(['rotate-key'])
+    expect(second.exitCode).not.toBe(0)
+    expect(second.stderr).toContain('rotation is already in progress')
   })
 })

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -138,6 +138,19 @@ async function enforceTrustGate(
     : 'denied'
 }
 
+/**
+ * Render a concise, accurate description of why authorizing a cached token
+ * failed, for the re-authentication notice. Preserves the error's class name
+ * (e.g. `KeyRevokedError`, `TokenExpiredError`) so distinct failures are no
+ * longer collapsed into a single misleading "expired" message.
+ */
+function describeAuthzFailure(err: unknown): string {
+  if (err instanceof Error) {
+    return err.name !== '' ? `${err.name}: ${err.message}` : err.message
+  }
+  return String(err)
+}
+
 function printExecHelp(): void {
   process.stdout.write(
     'Usage: vaultkeeper exec --secret <name> --env <VAR> --caller <path> [options] -- <command...>\n\n' +
@@ -149,7 +162,11 @@ function printExecHelp(): void {
       '  --yes              Approve an untrusted caller for this invocation without\n' +
       '                     an interactive prompt, recording it in the trust manifest\n' +
       '                     (for CI/non-interactive use; never the default)\n' +
-      '  --cache            Cache the JWE token for subsequent invocations\n' +
+      '  --cache            Cache the JWE token so a later invocation by the same\n' +
+      '                     trusted caller reuses it without re-minting. The token\n' +
+      "                     is reusable until it expires (the secret's TTL); after\n" +
+      '                     that, or after a key rotation/revocation, exec mints a\n' +
+      '                     fresh one automatically\n' +
       '  --no-redact        Do not redact the secret from output\n' +
       '  --skip-doctor      Skip doctor preflight checks\n' +
       '  -h, --help         Show this help message\n\n' +
@@ -246,8 +263,10 @@ export async function execCommand(args: string[]): Promise<number> {
     // manifest) must never short-circuit that recording, or the approval would
     // not persist for later runs.
     let jwe: string | undefined
+    let jweFromCache = false
     if (useCache && outcome === 'trusted') {
       jwe = await readCachedToken(callerPath, secret)
+      jweFromCache = jwe !== undefined
     }
 
     if (jwe === undefined) {
@@ -268,22 +287,30 @@ export async function execCommand(args: string[]): Promise<number> {
         secretValue = buf.toString('utf8')
       })
     } catch (err) {
-      // If the cached token failed (e.g. expired), invalidate and mint a fresh
-      // one. Trust was already enforced above, so no re-prompt is needed.
-      if (useCache) {
-        await invalidateCache(callerPath, secret)
-        process.stderr.write('Cached token expired, re-authenticating...\n')
-        jwe = await vault.setup(secret, { executablePath: callerPath })
-        // Write the new token back to cache so subsequent invocations benefit
-        await writeCachedToken(callerPath, secret, jwe)
-        const retryResult = await vault.authorize(jwe)
-        const retryAccessor = vault.getSecret(retryResult.token)
-        retryAccessor.read((buf) => {
-          secretValue = buf.toString('utf8')
-        })
-      } else {
+      // Only a token that came from the cache is transparently recoverable: the
+      // caller was already trusted (the trust gate ran above), so we can mint a
+      // fresh token without re-prompting. A freshly-minted token that fails to
+      // authorize is a genuine error and must surface unchanged.
+      //
+      // Crucially, we report the ACTUAL failure (e.g. KeyRevokedError,
+      // TokenExpiredError) rather than mislabeling every failure as "expired" —
+      // the previous behavior hid key-revocation and other faults behind a
+      // generic "Cached token expired" message.
+      if (!jweFromCache) {
         throw err
       }
+      await invalidateCache(callerPath, secret)
+      process.stderr.write(
+        `Cached token could not be authorized (${describeAuthzFailure(err)}); re-authenticating...\n`,
+      )
+      jwe = await vault.setup(secret, { executablePath: callerPath })
+      // Write the new token back to cache so subsequent invocations benefit
+      await writeCachedToken(callerPath, secret, jwe)
+      const retryResult = await vault.authorize(jwe)
+      const retryAccessor = vault.getSecret(retryResult.token)
+      retryAccessor.read((buf) => {
+        secretValue = buf.toString('utf8')
+      })
     }
 
     if (secretValue === undefined) {

--- a/packages/vaultkeeper/src/backend/file-backend.ts
+++ b/packages/vaultkeeper/src/backend/file-backend.ts
@@ -14,15 +14,12 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as os from 'node:os'
-import * as crypto from 'node:crypto'
 import { SecretNotFoundError, FilesystemError } from '../errors.js'
+import { encryptGcm, decryptGcm, getOrCreateWrapKey } from '../util/at-rest.js'
 import type { ListableBackend } from './types.js'
 
 const STORAGE_DIR_NAME = path.join('.vaultkeeper', 'file')
 const KEY_FILE = '.key'
-const GCM_IV_BYTES = 12
-const GCM_KEY_BYTES = 32
-const GCM_TAG_LENGTH = 128 // bits
 
 /**
  * Resolve the storage directory for a FileBackend instance.
@@ -60,50 +57,7 @@ async function ensureStorageDir(storageDir: string): Promise<void> {
 }
 
 async function getOrCreateKey(storageDir: string): Promise<Buffer> {
-  const keyPath = path.join(storageDir, KEY_FILE)
-  try {
-    const data = await fs.readFile(keyPath)
-    return data
-  } catch (err) {
-    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
-      // Generate a random 32-byte key
-      const key = crypto.randomBytes(GCM_KEY_BYTES)
-      await fs.writeFile(keyPath, key, { mode: 0o600 })
-      return key
-    }
-    throw err
-  }
-}
-
-function encryptGcm(key: Buffer, plaintext: string): string {
-  const iv = crypto.randomBytes(GCM_IV_BYTES)
-  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv, {
-    authTagLength: GCM_TAG_LENGTH / 8,
-  })
-  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
-  const authTag = cipher.getAuthTag()
-  return [iv.toString('base64'), authTag.toString('base64'), encrypted.toString('base64')].join(':')
-}
-
-function decryptGcm(key: Buffer, encoded: string): string {
-  const parts = encoded.split(':')
-  if (parts.length !== 3) {
-    throw new Error('Invalid encrypted file format: expected iv:authTag:ciphertext')
-  }
-  const [ivB64, authTagB64, ciphertextB64] = parts
-  if (ivB64 === undefined || authTagB64 === undefined || ciphertextB64 === undefined) {
-    throw new Error('Invalid encrypted file format: missing part')
-  }
-  const iv = Buffer.from(ivB64, 'base64')
-  const authTag = Buffer.from(authTagB64, 'base64')
-  const ciphertext = Buffer.from(ciphertextB64, 'base64')
-
-  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv, {
-    authTagLength: GCM_TAG_LENGTH / 8,
-  })
-  decipher.setAuthTag(authTag)
-  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
-  return decrypted.toString('utf8')
+  return getOrCreateWrapKey(path.join(storageDir, KEY_FILE))
 }
 
 /**

--- a/packages/vaultkeeper/src/keys/manager.ts
+++ b/packages/vaultkeeper/src/keys/manager.ts
@@ -5,17 +5,24 @@
 
 import * as crypto from 'node:crypto'
 import { RotationInProgressError, SetupError } from '../errors.js'
-import type { KeyMaterial, KeyState } from './types.js'
+import type { KeyMaterial, KeyState, KeyStateSnapshot } from './types.js'
 
 /**
  * Manage cryptographic keys with rotation and grace-period semantics.
+ *
+ * @remarks
+ * Whether a rotation is "in progress" is derived entirely from
+ * {@link KeyManager.isInGracePeriod} — a grace period is active exactly while a
+ * previous key is still usable. This makes the state serializable via
+ * {@link KeyManager.snapshot}/{@link KeyManager.hydrate}, so the guard against a
+ * second rotation survives a process restart (see `keys/storage.ts`) rather than
+ * relying on a live in-process timer.
  * @internal
  */
 export class KeyManager {
   #state: KeyState | undefined = undefined
   #gracePeriodTimer: ReturnType<typeof setTimeout> | undefined = undefined
   #gracePeriodExpiresAt: number | undefined = undefined
-  #rotating = false
 
   /** Generate a new 32-byte key with a timestamp-based id. */
   generateKey(): KeyMaterial {
@@ -38,6 +45,50 @@ export class KeyManager {
     return Promise.resolve()
   }
 
+  /**
+   * Replace the in-memory state with a persisted snapshot.
+   *
+   * An expired grace period in the snapshot is dropped: the previous key is
+   * discarded and no grace period is restored. When the grace period is still
+   * active, a fresh timer is armed for the remaining duration so the previous
+   * key is eventually freed in long-running processes; correctness never depends
+   * on that timer (grace is always re-checked against the wall clock).
+   * @internal
+   */
+  hydrate(snapshot: KeyStateSnapshot): void {
+    this.#clearGracePeriodTimer()
+
+    if (
+      snapshot.previous !== undefined &&
+      snapshot.gracePeriodExpiresAt !== undefined &&
+      Date.now() < snapshot.gracePeriodExpiresAt
+    ) {
+      this.#state = { current: snapshot.current, previous: snapshot.previous }
+      this.#gracePeriodExpiresAt = snapshot.gracePeriodExpiresAt
+      this.#armGracePeriodTimer(snapshot.gracePeriodExpiresAt - Date.now())
+    } else {
+      this.#state = { current: snapshot.current }
+      this.#gracePeriodExpiresAt = undefined
+    }
+  }
+
+  /**
+   * Capture the current state as a serializable snapshot for persistence.
+   * The previous key and grace expiry are included only while the grace period
+   * is still active.
+   * @internal
+   */
+  snapshot(): KeyStateSnapshot {
+    const state = this.#requireState()
+    const result: KeyStateSnapshot = { current: state.current }
+    const previous = this.getPreviousKey()
+    if (previous !== undefined && this.#gracePeriodExpiresAt !== undefined) {
+      result.previous = previous
+      result.gracePeriodExpiresAt = this.#gracePeriodExpiresAt
+    }
+    return result
+  }
+
   /** Return the current (encryption) key. Throws if not initialized. */
   getCurrentKey(): KeyMaterial {
     const state = this.#requireState()
@@ -50,6 +101,11 @@ export class KeyManager {
    */
   getPreviousKey(): KeyMaterial | undefined {
     const state = this.#requireState()
+    // Grace is authoritative: even if a timer has not yet fired to clear the
+    // reference, an expired grace period means the previous key is unusable.
+    if (!this.isInGracePeriod()) {
+      return undefined
+    }
     return state.previous
   }
 
@@ -63,11 +119,8 @@ export class KeyManager {
     if (state.current.id === kid) {
       return state.current
     }
-    const { previous } = state
+    const previous = this.getPreviousKey()
     if (previous?.id === kid) {
-      // previous?.id === kid is only true when previous is defined and its id
-      // matches, so we can safely return it here. TypeScript does not narrow
-      // the optional-chain result back to KeyMaterial, so we guard explicitly.
       return previous
     }
     return undefined
@@ -78,37 +131,24 @@ export class KeyManager {
    * becomes current. A grace-period timer is started; when it fires the
    * previous key is cleared automatically.
    *
-   * @throws {RotationInProgressError} if a rotation is already underway.
+   * @throws {RotationInProgressError} if a rotation is already underway (i.e. a
+   *   previous key is still within its grace period).
    */
   rotateKey(gracePeriodMs: number): void {
-    if (this.#rotating) {
+    const state = this.#requireState()
+
+    if (this.isInGracePeriod()) {
       throw new RotationInProgressError('A key rotation is already in progress')
     }
 
-    const state = this.#requireState()
-    this.#rotating = true
-
-    // Cancel any existing grace-period timer before starting a new rotation.
+    // Cancel any stale timer (e.g. from a grace period that has already
+    // elapsed) before starting a new rotation.
     this.#clearGracePeriodTimer()
 
     const newKey = this.generateKey()
     this.#state = { current: newKey, previous: state.current }
     this.#gracePeriodExpiresAt = Date.now() + gracePeriodMs
-
-    this.#gracePeriodTimer = setTimeout(() => {
-      if (this.#state !== undefined) {
-        // Remove the previous key once the grace period elapses.
-        this.#state = { current: this.#state.current }
-      }
-      this.#gracePeriodExpiresAt = undefined
-      this.#gracePeriodTimer = undefined
-      this.#rotating = false
-    }, gracePeriodMs)
-
-    // Allow the timer to be GC'd without keeping the process alive.
-    if (typeof this.#gracePeriodTimer.unref === 'function') {
-      this.#gracePeriodTimer.unref()
-    }
+    this.#armGracePeriodTimer(gracePeriodMs)
   }
 
   /**
@@ -117,7 +157,6 @@ export class KeyManager {
    */
   revokeKey(): void {
     this.#clearGracePeriodTimer()
-    this.#rotating = false
     this.#gracePeriodExpiresAt = undefined
 
     const newKey = this.generateKey()
@@ -141,12 +180,25 @@ export class KeyManager {
 
   #requireState(): KeyState {
     if (this.#state === undefined) {
-      throw new SetupError(
-        'KeyManager has not been initialized — call init() first',
-        'KeyManager',
-      )
+      throw new SetupError('KeyManager has not been initialized — call init() first', 'KeyManager')
     }
     return this.#state
+  }
+
+  #armGracePeriodTimer(delayMs: number): void {
+    this.#gracePeriodTimer = setTimeout(() => {
+      if (this.#state !== undefined) {
+        // Remove the previous key once the grace period elapses.
+        this.#state = { current: this.#state.current }
+      }
+      this.#gracePeriodExpiresAt = undefined
+      this.#gracePeriodTimer = undefined
+    }, delayMs)
+
+    // Allow the timer to be GC'd without keeping the process alive.
+    if (typeof this.#gracePeriodTimer.unref === 'function') {
+      this.#gracePeriodTimer.unref()
+    }
   }
 
   #clearGracePeriodTimer(): void {

--- a/packages/vaultkeeper/src/keys/storage.ts
+++ b/packages/vaultkeeper/src/keys/storage.ts
@@ -1,0 +1,181 @@
+/**
+ * Persistence for {@link KeyManager} state.
+ *
+ * @remarks
+ * Key material is written under the vaultkeeper config directory, encrypted at
+ * rest with AES-256-GCM via the shared {@link encryptGcm}/{@link decryptGcm}
+ * helpers (the same authenticated cipher the {@link FileBackend} uses — no
+ * bespoke crypto). Two owner-only (mode `0o600`) files are used:
+ *
+ * - `keys.enc` — the AES-256-GCM envelope of the JSON-serialized key state.
+ * - `.keys.wrap` — the random 32-byte wrapping key that protects `keys.enc`.
+ *
+ * Persisting key material lets a JWE minted by one CLI process be authorized by
+ * a later process within the token's validity window: the `kid` a token embeds
+ * still resolves to a known key after the minting process exits. Without this,
+ * every process generated fresh keys, so a cached token always failed
+ * authorization with {@link KeyRevokedError}.
+ *
+ * @internal
+ */
+
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { encryptGcm, decryptGcm, getOrCreateWrapKey } from '../util/at-rest.js'
+import type { KeyMaterial, KeyStateSnapshot } from './types.js'
+
+const KEY_STATE_FILE = 'keys.enc'
+const KEY_WRAP_FILE = '.keys.wrap'
+
+/** On-disk JSON shape for a single key (raw bytes base64-encoded). */
+interface RawKeyMaterial {
+  id: string
+  key: string
+  createdAt: string
+}
+
+/** On-disk JSON shape for the whole key state. */
+interface RawKeyState {
+  version: number
+  current: RawKeyMaterial
+  previous?: RawKeyMaterial
+  gracePeriodExpiresAt?: number
+}
+
+function serializeKey(key: KeyMaterial): RawKeyMaterial {
+  return {
+    id: key.id,
+    key: Buffer.from(key.key).toString('base64'),
+    createdAt: key.createdAt.toISOString(),
+  }
+}
+
+/**
+ * Type guard for a single {@link RawKeyMaterial}. Validates every field so a
+ * corrupt or truncated file is treated as "no persisted state" rather than
+ * yielding a malformed key.
+ */
+function isRawKeyMaterial(value: unknown): value is RawKeyMaterial {
+  if (typeof value !== 'object' || value === null) return false
+  if (!('id' in value) || typeof value.id !== 'string' || value.id === '') return false
+  if (!('key' in value) || typeof value.key !== 'string' || value.key === '') return false
+  if (!('createdAt' in value) || typeof value.createdAt !== 'string') return false
+  return true
+}
+
+function deserializeKey(raw: RawKeyMaterial): KeyMaterial | undefined {
+  const bytes = Buffer.from(raw.key, 'base64')
+  // A 32-byte AES-256 key is required; reject anything else as corrupt.
+  if (bytes.byteLength !== 32) return undefined
+  const createdAt = new Date(raw.createdAt)
+  if (Number.isNaN(createdAt.getTime())) return undefined
+  return { id: raw.id, key: new Uint8Array(bytes), createdAt }
+}
+
+/**
+ * Type guard for {@link RawKeyState}.
+ */
+function isRawKeyState(value: unknown): value is RawKeyState {
+  if (typeof value !== 'object' || value === null) return false
+  if (!('version' in value) || typeof value.version !== 'number') return false
+  if (!('current' in value) || !isRawKeyMaterial(value.current)) return false
+  if ('previous' in value && value.previous !== undefined && !isRawKeyMaterial(value.previous)) {
+    return false
+  }
+  if (
+    'gracePeriodExpiresAt' in value &&
+    value.gracePeriodExpiresAt !== undefined &&
+    typeof value.gracePeriodExpiresAt !== 'number'
+  ) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Load persisted key state from `configDir`, or `undefined` when no valid state
+ * exists yet (first run, or an unreadable/corrupt file).
+ * @internal
+ */
+export async function loadKeyState(configDir: string): Promise<KeyStateSnapshot | undefined> {
+  const statePath = path.join(configDir, KEY_STATE_FILE)
+
+  let envelope: string
+  try {
+    envelope = await fs.readFile(statePath, 'utf8')
+  } catch {
+    return undefined
+  }
+
+  const wrapKey = await getOrCreateWrapKey(path.join(configDir, KEY_WRAP_FILE))
+  let json: string
+  try {
+    json = decryptGcm(wrapKey, envelope)
+  } catch {
+    // Envelope failed authentication (tampered, or wrap key lost/rotated).
+    // Treat as absent so a fresh key state is generated rather than crashing.
+    return undefined
+  } finally {
+    wrapKey.fill(0)
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(json)
+  } catch {
+    return undefined
+  }
+
+  if (!isRawKeyState(parsed)) return undefined
+
+  const current = deserializeKey(parsed.current)
+  if (current === undefined) return undefined
+
+  const snapshot: KeyStateSnapshot = { current }
+
+  if (parsed.previous !== undefined && parsed.gracePeriodExpiresAt !== undefined) {
+    const previous = deserializeKey(parsed.previous)
+    // Only surface the previous key while its grace period is still active; an
+    // expired grace period is equivalent to no previous key at all.
+    if (previous !== undefined && Date.now() < parsed.gracePeriodExpiresAt) {
+      snapshot.previous = previous
+      snapshot.gracePeriodExpiresAt = parsed.gracePeriodExpiresAt
+    }
+  }
+
+  return snapshot
+}
+
+/**
+ * Persist `snapshot` to `configDir`, creating the directory if necessary. The
+ * state file and its wrapping key are both written owner-only (`0o600`).
+ *
+ * Uses atomic write-then-rename so a concurrent {@link loadKeyState} never sees
+ * a half-written envelope.
+ * @internal
+ */
+export async function saveKeyState(configDir: string, snapshot: KeyStateSnapshot): Promise<void> {
+  await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
+
+  const raw: RawKeyState = {
+    version: 1,
+    current: serializeKey(snapshot.current),
+  }
+  if (snapshot.previous !== undefined && snapshot.gracePeriodExpiresAt !== undefined) {
+    raw.previous = serializeKey(snapshot.previous)
+    raw.gracePeriodExpiresAt = snapshot.gracePeriodExpiresAt
+  }
+
+  const wrapKey = await getOrCreateWrapKey(path.join(configDir, KEY_WRAP_FILE))
+  let envelope: string
+  try {
+    envelope = encryptGcm(wrapKey, JSON.stringify(raw))
+  } finally {
+    wrapKey.fill(0)
+  }
+
+  const statePath = path.join(configDir, KEY_STATE_FILE)
+  const tmpPath = `${statePath}.${String(process.pid)}.tmp`
+  await fs.writeFile(tmpPath, envelope, { encoding: 'utf8', mode: 0o600 })
+  await fs.rename(tmpPath, statePath)
+}

--- a/packages/vaultkeeper/src/keys/types.ts
+++ b/packages/vaultkeeper/src/keys/types.ts
@@ -34,3 +34,26 @@ export interface KeyRotationConfig {
   /** How long (in milliseconds) the previous key remains valid after rotation */
   gracePeriodMs: number
 }
+
+/**
+ * A point-in-time snapshot of {@link KeyManager} state, suitable for persisting
+ * across processes. Produced by {@link KeyManager.snapshot} and consumed by
+ * {@link KeyManager.hydrate}.
+ *
+ * The rotation grace period is represented purely as an absolute expiry
+ * timestamp; whether a rotation is "in progress" is derived by comparing it to
+ * the current time, so the guard survives process restarts without a live
+ * timer.
+ * @internal
+ */
+export interface KeyStateSnapshot {
+  /** The currently active encryption key. */
+  current: KeyMaterial
+  /** The previous key, present only while its grace period is still active. */
+  previous?: KeyMaterial
+  /**
+   * Absolute epoch-millisecond time at which the current grace period ends.
+   * Present only while a rotation grace period is active.
+   */
+  gracePeriodExpiresAt?: number
+}

--- a/packages/vaultkeeper/src/util/at-rest.ts
+++ b/packages/vaultkeeper/src/util/at-rest.ts
@@ -72,9 +72,17 @@ export function decryptGcm(key: Buffer, encoded: string): string {
 
 /**
  * Read the 32-byte wrapping key at `keyPath`, generating and persisting a fresh
- * random one (mode `0o600`) if the file does not yet exist.
+ * random one (mode `0o600`) when the file does not yet exist **or** holds a
+ * value that is not exactly 32 bytes.
  *
  * @remarks
+ * Regenerating on a wrong-length key is safe, not data loss: a wrapping key of
+ * the wrong length cannot decrypt anything it previously encrypted (the AES-256
+ * cipher requires a 32-byte key), so any ciphertext under a corrupt key is
+ * already unrecoverable. Without this guard, a truncated/corrupt key file would
+ * make {@link encryptGcm} throw "Invalid key length" on every write, wedging the
+ * consumer instead of degrading to a fresh key.
+ *
  * The caller is responsible for ensuring the parent directory exists. The
  * returned {@link Buffer} holds key material; zero it after use where practical.
  *
@@ -82,14 +90,21 @@ export function decryptGcm(key: Buffer, encoded: string): string {
  * @internal
  */
 export async function getOrCreateWrapKey(keyPath: string): Promise<Buffer> {
+  let existing: Buffer | undefined
   try {
-    return await fs.readFile(keyPath)
+    existing = await fs.readFile(keyPath)
   } catch (err) {
-    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
-      const key = crypto.randomBytes(GCM_KEY_BYTES)
-      await fs.writeFile(keyPath, key, { mode: 0o600 })
-      return key
+    if (!(err instanceof Error && 'code' in err && err.code === 'ENOENT')) {
+      throw err
     }
-    throw err
   }
+
+  if (existing?.byteLength === GCM_KEY_BYTES) {
+    return existing
+  }
+
+  // Missing or corrupt (wrong length): (re)generate a fresh key in place.
+  const key = crypto.randomBytes(GCM_KEY_BYTES)
+  await fs.writeFile(keyPath, key, { mode: 0o600 })
+  return key
 }

--- a/packages/vaultkeeper/src/util/at-rest.ts
+++ b/packages/vaultkeeper/src/util/at-rest.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared AES-256-GCM helpers for encrypting data at rest under a locally
+ * stored wrapping key.
+ *
+ * @remarks
+ * These primitives back both the encrypted {@link FileBackend} secret store and
+ * the persisted {@link KeyManager} key material. Keeping a single implementation
+ * ensures every at-rest write in the codebase uses the same authenticated
+ * cipher (AES-256-GCM, never AES-CBC) and the same on-disk envelope, rather than
+ * re-deriving crypto per consumer.
+ *
+ * Envelope format (all parts base64, colon-separated):
+ *   `<iv>:<authTag>:<ciphertext>`
+ *
+ * @internal
+ */
+
+import * as fs from 'node:fs/promises'
+import * as crypto from 'node:crypto'
+
+const GCM_IV_BYTES = 12
+const GCM_KEY_BYTES = 32
+const GCM_TAG_LENGTH_BITS = 128
+
+/**
+ * Encrypt `plaintext` with AES-256-GCM under `key`, returning the
+ * `iv:authTag:ciphertext` envelope described in the module docs.
+ *
+ * @param key - 32-byte AES-256 wrapping key.
+ * @param plaintext - UTF-8 string to encrypt.
+ * @internal
+ */
+export function encryptGcm(key: Buffer, plaintext: string): string {
+  const iv = crypto.randomBytes(GCM_IV_BYTES)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv, {
+    authTagLength: GCM_TAG_LENGTH_BITS / 8,
+  })
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()])
+  const authTag = cipher.getAuthTag()
+  return [iv.toString('base64'), authTag.toString('base64'), encrypted.toString('base64')].join(':')
+}
+
+/**
+ * Decrypt an `iv:authTag:ciphertext` envelope produced by {@link encryptGcm}.
+ *
+ * @param key - The same 32-byte AES-256 wrapping key used to encrypt.
+ * @param encoded - The colon-separated envelope.
+ * @returns The decrypted UTF-8 plaintext.
+ * @throws {Error} If the envelope is malformed or authentication fails.
+ * @internal
+ */
+export function decryptGcm(key: Buffer, encoded: string): string {
+  const parts = encoded.split(':')
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted envelope: expected iv:authTag:ciphertext')
+  }
+  const [ivB64, authTagB64, ciphertextB64] = parts
+  if (ivB64 === undefined || authTagB64 === undefined || ciphertextB64 === undefined) {
+    throw new Error('Invalid encrypted envelope: missing part')
+  }
+  const iv = Buffer.from(ivB64, 'base64')
+  const authTag = Buffer.from(authTagB64, 'base64')
+  const ciphertext = Buffer.from(ciphertextB64, 'base64')
+
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv, {
+    authTagLength: GCM_TAG_LENGTH_BITS / 8,
+  })
+  decipher.setAuthTag(authTag)
+  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+  return decrypted.toString('utf8')
+}
+
+/**
+ * Read the 32-byte wrapping key at `keyPath`, generating and persisting a fresh
+ * random one (mode `0o600`) if the file does not yet exist.
+ *
+ * @remarks
+ * The caller is responsible for ensuring the parent directory exists. The
+ * returned {@link Buffer} holds key material; zero it after use where practical.
+ *
+ * @param keyPath - Absolute path to the wrapping-key file.
+ * @internal
+ */
+export async function getOrCreateWrapKey(keyPath: string): Promise<Buffer> {
+  try {
+    return await fs.readFile(keyPath)
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      const key = crypto.randomBytes(GCM_KEY_BYTES)
+      await fs.writeFile(keyPath, key, { mode: 0o600 })
+      return key
+    }
+    throw err
+  }
+}

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -20,6 +20,7 @@ import type {
 } from './types.js'
 import { loadConfig, getDefaultConfigDir } from './config.js'
 import { KeyManager } from './keys/manager.js'
+import { loadKeyState, saveKeyState } from './keys/storage.js'
 import { BackendRegistry } from './backend/registry.js'
 import type { SecretBackend } from './backend/types.js'
 import { createToken, decryptToken, extractKid, validateClaims, blockToken } from './jwe/index.js'
@@ -200,17 +201,27 @@ export class VaultKeeper {
   readonly #config: VaultConfig
   readonly #keyManager: KeyManager
   readonly #configDir: string
+  /**
+   * Whether key material is persisted to (and reloaded from) `#configDir`.
+   * Enabled only when the vault operates against a real on-disk config — i.e.
+   * neither `config` nor `backend` was injected in-process (see
+   * {@link VaultKeeper.init}). Injected-config/backend instances keep keys
+   * purely in memory so tests and embedders stay hermetic.
+   */
+  readonly #persistKeys: boolean
   #backend: SecretBackend | undefined
 
   private constructor(
     config: VaultConfig,
     keyManager: KeyManager,
     configDir: string,
+    persistKeys: boolean,
     backend?: SecretBackend,
   ) {
     this.#config = config
     this.#keyManager = keyManager
     this.#configDir = configDir
+    this.#persistKeys = persistKeys
     this.#backend = backend
   }
 
@@ -239,10 +250,26 @@ export class VaultKeeper {
       }
     }
 
-    const keyManager = new KeyManager()
-    await keyManager.init()
+    // Persist key material to disk only when operating against a real on-disk
+    // config directory. When either `config` or `backend` is injected, the
+    // caller is assembling the vault in-process (tests, embedders), so keys stay
+    // in memory and never touch the config dir.
+    const persistKeys = options?.config === undefined && options?.backend === undefined
 
-    return new VaultKeeper(config, keyManager, configDir, options?.backend)
+    const keyManager = new KeyManager()
+    if (persistKeys) {
+      const loaded = await loadKeyState(configDir)
+      if (loaded !== undefined) {
+        keyManager.hydrate(loaded)
+      } else {
+        await keyManager.init()
+        await saveKeyState(configDir, keyManager.snapshot())
+      }
+    } else {
+      await keyManager.init()
+    }
+
+    return new VaultKeeper(config, keyManager, configDir, persistKeys, options?.backend)
   }
 
   /**
@@ -593,8 +620,10 @@ export class VaultKeeper {
    */
   async rotateKey(): Promise<void> {
     const gracePeriodMs = this.#config.keyRotation.gracePeriodDays * 24 * 60 * 60 * 1000
+    // Throws RotationInProgressError synchronously if a prior rotation's grace
+    // period is still active — including one persisted by an earlier process.
     this.#keyManager.rotateKey(gracePeriodMs)
-    await Promise.resolve()
+    await this.#persistKeyState()
   }
 
   /**
@@ -606,7 +635,18 @@ export class VaultKeeper {
    */
   async revokeKey(): Promise<void> {
     this.#keyManager.revokeKey()
-    await Promise.resolve()
+    await this.#persistKeyState()
+  }
+
+  /**
+   * Persist the current key state to the config dir when persistence is
+   * enabled. A no-op for injected-config/backend instances (in-memory keys).
+   */
+  async #persistKeyState(): Promise<void> {
+    if (!this.#persistKeys) {
+      return
+    }
+    await saveKeyState(this.#configDir, this.#keyManager.snapshot())
   }
 
   /**

--- a/packages/vaultkeeper/test/integration/key-persistence.test.ts
+++ b/packages/vaultkeeper/test/integration/key-persistence.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for cross-process key persistence (issue #59).
+ *
+ * Each `VaultKeeper.init({ configDir })` below models a separate CLI process:
+ * it loads its configuration from the shared config directory (no injected
+ * `config`/`backend`), so key material is persisted to and reloaded from disk.
+ * A token minted by one instance must authorize in a later instance, the
+ * rotation grace-period guard must survive across instances, and a revoked key
+ * must surface `KeyRevokedError` — not a generic failure.
+ *
+ * Uses the real Node crypto file backend under isolated temp directories; dev
+ * mode is used for identity so no trust manifest or real executable is needed.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/59
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { VaultKeeper } from '../../src/vault.js'
+import { registerBuiltinBackends } from '../../src/backend/register-builtins.js'
+import { KeyRevokedError, RotationInProgressError } from '../../src/errors.js'
+
+const SECRET_NAME = 'API_KEY'
+const SECRET_VALUE = 's3cr3t-value'
+
+let configDir = ''
+let secretsDir = ''
+
+async function writeConfig(gracePeriodDays: number): Promise<void> {
+  const config = {
+    version: 1,
+    backends: [{ type: 'file', enabled: true, path: secretsDir }],
+    keyRotation: { gracePeriodDays },
+    defaults: { ttlMinutes: 60, trustTier: 3 },
+    developmentMode: { executables: ['dev'] },
+  }
+  await fs.writeFile(path.join(configDir, 'config.json'), JSON.stringify(config), {
+    mode: 0o600,
+  })
+}
+
+/** A fresh vault built from the shared config dir — models a new process. */
+function newProcess(): Promise<VaultKeeper> {
+  return VaultKeeper.init({ skipDoctor: true, configDir })
+}
+
+beforeEach(async () => {
+  registerBuiltinBackends()
+  configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-persist-cfg-'))
+  secretsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-persist-secrets-'))
+  await writeConfig(7)
+})
+
+afterEach(async () => {
+  await fs.rm(configDir, { recursive: true, force: true })
+  await fs.rm(secretsDir, { recursive: true, force: true })
+})
+
+describe('cross-process token reuse (criterion 2)', () => {
+  it('authorizes a token minted by an earlier instance in a later instance', async () => {
+    const minter = await newProcess()
+    await minter.store(SECRET_NAME, SECRET_VALUE)
+    const jwe = await minter.setup(SECRET_NAME, { executablePath: 'dev' })
+
+    // A brand-new instance (fresh KeyManager) reloads the persisted keys.
+    const authorizer = await newProcess()
+    const { token, vaultResponse } = await authorizer.authorize(jwe)
+    expect(vaultResponse.keyStatus).toBe('current')
+
+    let secret: string | undefined
+    authorizer.getSecret(token).read((buf) => {
+      secret = buf.toString('utf8')
+    })
+    expect(secret).toBe(SECRET_VALUE)
+  })
+
+  it('persists a keys.enc file under the config dir', async () => {
+    await newProcess()
+    const entries = await fs.readdir(configDir)
+    expect(entries).toContain('keys.enc')
+  })
+})
+
+describe('cross-process rotation guard (criterion 5)', () => {
+  it('rejects a second rotation while the previous rotation is still in grace', async () => {
+    const first = await newProcess()
+    await first.rotateKey()
+
+    // A separate instance sees the persisted grace period and refuses to rotate.
+    const second = await newProcess()
+    await expect(second.rotateKey()).rejects.toBeInstanceOf(RotationInProgressError)
+  })
+})
+
+describe('revoked-key error accuracy (criterion 4)', () => {
+  it('surfaces KeyRevokedError when authorizing a token whose key was revoked', async () => {
+    const minter = await newProcess()
+    await minter.store(SECRET_NAME, SECRET_VALUE)
+    const jwe = await minter.setup(SECRET_NAME, { executablePath: 'dev' })
+
+    // Revoke in a second process: the minting key is discarded and replaced.
+    const revoker = await newProcess()
+    await revoker.revokeKey()
+
+    // A third process cannot resolve the revoked kid — the error is specific.
+    const authorizer = await newProcess()
+    await expect(authorizer.authorize(jwe)).rejects.toBeInstanceOf(KeyRevokedError)
+  })
+})

--- a/packages/vaultkeeper/test/unit/keys/manager.test.ts
+++ b/packages/vaultkeeper/test/unit/keys/manager.test.ts
@@ -48,9 +48,7 @@ describe('KeyManager.generateKey', () => {
     const a = mgr.generateKey()
     const b = mgr.generateKey()
     // Keys should not share the same raw bytes (astronomically unlikely).
-    expect(Buffer.from(a.key).toString('hex')).not.toBe(
-      Buffer.from(b.key).toString('hex'),
-    )
+    expect(Buffer.from(a.key).toString('hex')).not.toBe(Buffer.from(b.key).toString('hex'))
   })
 })
 
@@ -102,8 +100,12 @@ describe('KeyManager before init', () => {
 
   it('rotateKey throws SetupError if not initialized', () => {
     const mgr = makeManager()
-    expect(() => { mgr.rotateKey(1000) }).toThrow(SetupError)
-    expect(() => { mgr.rotateKey(1000) }).toThrow('KeyManager has not been initialized')
+    expect(() => {
+      mgr.rotateKey(1000)
+    }).toThrow(SetupError)
+    expect(() => {
+      mgr.rotateKey(1000)
+    }).toThrow('KeyManager has not been initialized')
   })
 })
 
@@ -201,7 +203,9 @@ describe('KeyManager.rotateKey — concurrent rotation guard', () => {
     const mgr = await makeInitializedManager()
     mgr.rotateKey(5_000)
 
-    expect(() => { mgr.rotateKey(5_000) }).toThrowError(RotationInProgressError)
+    expect(() => {
+      mgr.rotateKey(5_000)
+    }).toThrowError(RotationInProgressError)
   })
 
   it('allows a new rotation after the grace period expires', async () => {
@@ -210,7 +214,9 @@ describe('KeyManager.rotateKey — concurrent rotation guard', () => {
 
     vi.advanceTimersByTime(1_001)
 
-    expect(() => { mgr.rotateKey(1_000) }).not.toThrow()
+    expect(() => {
+      mgr.rotateKey(1_000)
+    }).not.toThrow()
   })
 })
 
@@ -259,12 +265,16 @@ describe('KeyManager.revokeKey', () => {
     mgr.rotateKey(1_000)
     mgr.revokeKey()
 
-    expect(() => { mgr.rotateKey(1_000) }).not.toThrow()
+    expect(() => {
+      mgr.rotateKey(1_000)
+    }).not.toThrow()
   })
 
   it('can be called without a prior rotation', async () => {
     const mgr = await makeInitializedManager()
-    expect(() => { mgr.revokeKey() }).not.toThrow()
+    expect(() => {
+      mgr.revokeKey()
+    }).not.toThrow()
     expect(mgr.getPreviousKey()).toBeUndefined()
   })
 })
@@ -272,6 +282,80 @@ describe('KeyManager.revokeKey', () => {
 // ---------------------------------------------------------------------------
 // findKeyById
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// hydrate / snapshot — cross-process state (issue #59)
+// ---------------------------------------------------------------------------
+
+describe('KeyManager.snapshot / hydrate', () => {
+  it('round-trips the current key into a fresh manager', async () => {
+    const mgr = await makeInitializedManager()
+    const current = mgr.getCurrentKey()
+
+    const restored = makeManager()
+    restored.hydrate(mgr.snapshot())
+
+    expect(restored.getCurrentKey().id).toBe(current.id)
+    expect(Buffer.from(restored.getCurrentKey().key).toString('hex')).toBe(
+      Buffer.from(current.key).toString('hex'),
+    )
+  })
+
+  it('a snapshot taken mid-grace-period restores the previous key and the rotation guard', async () => {
+    const mgr = await makeInitializedManager()
+    const original = mgr.getCurrentKey()
+    mgr.rotateKey(60_000)
+
+    const restored = makeManager()
+    restored.hydrate(mgr.snapshot())
+
+    // Previous key and grace state survive into the new manager…
+    expect(restored.findKeyById(original.id)?.id).toBe(original.id)
+    expect(restored.isInGracePeriod()).toBe(true)
+    // …so a second rotation is rejected across the "process" boundary.
+    expect(() => {
+      restored.rotateKey(60_000)
+    }).toThrow(RotationInProgressError)
+  })
+
+  it('does not restore an already-expired grace period (previous key dropped)', async () => {
+    vi.useFakeTimers()
+    try {
+      const mgr = await makeInitializedManager()
+      const original = mgr.getCurrentKey()
+      mgr.rotateKey(5_000)
+      const snap = mgr.snapshot()
+
+      // Time passes beyond the grace period before the next manager loads it.
+      vi.advanceTimersByTime(5_001)
+
+      const restored = makeManager()
+      restored.hydrate(snap)
+      expect(restored.isInGracePeriod()).toBe(false)
+      expect(restored.findKeyById(original.id)).toBeUndefined()
+      // A fresh rotation is permitted again.
+      expect(() => {
+        restored.rotateKey(5_000)
+      }).not.toThrow()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('snapshot omits the previous key once the grace period has expired', async () => {
+    vi.useFakeTimers()
+    try {
+      const mgr = await makeInitializedManager()
+      mgr.rotateKey(5_000)
+      vi.advanceTimersByTime(5_001)
+      const snap = mgr.snapshot()
+      expect(snap.previous).toBeUndefined()
+      expect(snap.gracePeriodExpiresAt).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
 
 describe('KeyManager.findKeyById', () => {
   it('finds the current key by id', async () => {

--- a/packages/vaultkeeper/test/unit/keys/storage.test.ts
+++ b/packages/vaultkeeper/test/unit/keys/storage.test.ts
@@ -133,4 +133,26 @@ describe('corrupt / tampered state degrades safely', () => {
     await fs.writeFile(statePath, `${iv ?? ''}:${tag ?? ''}:${tampered.toString('base64')}`, 'utf8')
     expect(await loadKeyState(dir)).toBeUndefined()
   })
+
+  it('recovers from a corrupt (wrong-length) wrapping key by regenerating it', async () => {
+    // First save establishes both keys.enc and a valid .keys.wrap.
+    await saveKeyState(dir, { current: makeKey('k-old-aaaa', 0x11) })
+
+    // Truncate the wrapping key to a non-32-byte length, as a partial write or
+    // disk corruption would. The old state is now unrecoverable (load degrades
+    // to "no state") — but a subsequent save must not throw "Invalid key
+    // length"; it regenerates the wrap key and persists fresh state.
+    const wrapPath = path.join(dir, '.keys.wrap')
+    await fs.writeFile(wrapPath, Buffer.alloc(7, 0xab), { mode: 0o600 })
+
+    // Load degrades gracefully rather than crashing.
+    expect(await loadKeyState(dir)).toBeUndefined()
+
+    // Save succeeds (no throw) and the freshly wrapped state round-trips.
+    const fresh = makeKey('k-new-bbbb', 0x22)
+    await saveKeyState(dir, { current: fresh })
+    expect((await fs.stat(wrapPath)).size).toBe(32)
+    const loaded = await loadKeyState(dir)
+    expect(loaded?.current.id).toBe('k-new-bbbb')
+  })
 })

--- a/packages/vaultkeeper/test/unit/keys/storage.test.ts
+++ b/packages/vaultkeeper/test/unit/keys/storage.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for persisted KeyManager state (`keys/storage.ts`).
+ *
+ * Verifies the acceptance-criteria contract for issue #59:
+ * - key material persists across "processes" (independent load calls),
+ * - it is encrypted at rest (never written as plaintext JSON),
+ * - the on-disk files are owner-only (mode 0600),
+ * - an expired grace period is dropped on load,
+ * - a tampered/corrupt envelope degrades to "no state" rather than crashing.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/59
+ */
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { loadKeyState, saveKeyState } from '../../../src/keys/storage.js'
+import type { KeyMaterial, KeyStateSnapshot } from '../../../src/keys/types.js'
+
+const CREATED_AT = new Date('2024-01-15T10:30:00.000Z')
+
+function makeKey(id: string, byte: number): KeyMaterial {
+  return { id, key: new Uint8Array(32).fill(byte), createdAt: CREATED_AT }
+}
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-keystore-'))
+})
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true })
+})
+
+describe('saveKeyState / loadKeyState round-trip', () => {
+  it('persists the current key so a later load resolves the same id and bytes', async () => {
+    const current = makeKey('k-1-aaaa', 0x11)
+    await saveKeyState(dir, { current })
+
+    const loaded = await loadKeyState(dir)
+    expect(loaded?.current.id).toBe('k-1-aaaa')
+    expect(loaded?.current.createdAt.toISOString()).toBe(CREATED_AT.toISOString())
+    expect(Buffer.from(loaded?.current.key ?? new Uint8Array()).toString('hex')).toBe(
+      Buffer.from(current.key).toString('hex'),
+    )
+  })
+
+  it('returns undefined when no state file exists yet', async () => {
+    expect(await loadKeyState(dir)).toBeUndefined()
+  })
+
+  it('persists the previous key and grace expiry while the grace period is active', async () => {
+    const snapshot: KeyStateSnapshot = {
+      current: makeKey('k-2-bbbb', 0x22),
+      previous: makeKey('k-1-aaaa', 0x11),
+      gracePeriodExpiresAt: Date.now() + 60_000,
+    }
+    await saveKeyState(dir, snapshot)
+
+    const loaded = await loadKeyState(dir)
+    expect(loaded?.previous?.id).toBe('k-1-aaaa')
+    expect(loaded?.gracePeriodExpiresAt).toBe(snapshot.gracePeriodExpiresAt)
+  })
+})
+
+describe('grace-period expiry on load', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2024-01-15T10:00:00.000Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('drops the previous key once the persisted grace period has elapsed', async () => {
+    const snapshot: KeyStateSnapshot = {
+      current: makeKey('k-2-bbbb', 0x22),
+      previous: makeKey('k-1-aaaa', 0x11),
+      gracePeriodExpiresAt: Date.now() + 5_000,
+    }
+    await saveKeyState(dir, snapshot)
+
+    // Advance past the grace period, then load in the "next process".
+    vi.setSystemTime(new Date('2024-01-15T10:00:06.000Z'))
+    const loaded = await loadKeyState(dir)
+    expect(loaded?.current.id).toBe('k-2-bbbb')
+    expect(loaded?.previous).toBeUndefined()
+    expect(loaded?.gracePeriodExpiresAt).toBeUndefined()
+  })
+})
+
+describe('encryption at rest and file permissions', () => {
+  it('writes the state as an iv:authTag:ciphertext envelope, not plaintext', async () => {
+    const current = makeKey('k-secret-id', 0x33)
+    await saveKeyState(dir, { current })
+
+    const raw = await fs.readFile(path.join(dir, 'keys.enc'), 'utf8')
+    // The key id and base64 key bytes must not appear in cleartext.
+    expect(raw).not.toContain('k-secret-id')
+    expect(raw).not.toContain(Buffer.from(current.key).toString('base64'))
+    // Envelope shape: three base64 segments separated by colons.
+    expect(raw.split(':')).toHaveLength(3)
+  })
+
+  it('writes the state file and wrapping key owner-only (0600)', async () => {
+    // File-mode bits are POSIX-only; skip the assertion on Windows.
+    if (process.platform === 'win32') return
+    await saveKeyState(dir, { current: makeKey('k-1-aaaa', 0x11) })
+
+    const stateMode = (await fs.stat(path.join(dir, 'keys.enc'))).mode & 0o777
+    const wrapMode = (await fs.stat(path.join(dir, '.keys.wrap'))).mode & 0o777
+    expect(stateMode).toBe(0o600)
+    expect(wrapMode).toBe(0o600)
+  })
+})
+
+describe('corrupt / tampered state degrades safely', () => {
+  it('returns undefined for a non-envelope (garbage) state file', async () => {
+    await saveKeyState(dir, { current: makeKey('k-1-aaaa', 0x11) })
+    await fs.writeFile(path.join(dir, 'keys.enc'), 'not-an-envelope', 'utf8')
+    expect(await loadKeyState(dir)).toBeUndefined()
+  })
+
+  it('returns undefined when the ciphertext fails authentication (tampered)', async () => {
+    await saveKeyState(dir, { current: makeKey('k-1-aaaa', 0x11) })
+    const statePath = path.join(dir, 'keys.enc')
+    const envelope = await fs.readFile(statePath, 'utf8')
+    const [iv, tag, ct] = envelope.split(':')
+    // Flip the ciphertext so GCM authentication fails on decrypt.
+    const tampered = Buffer.from(ct ?? '', 'base64')
+    if (tampered.length > 0) tampered[0] ^= 0xff
+    await fs.writeFile(statePath, `${iv ?? ''}:${tag ?? ''}:${tampered.toString('base64')}`, 'utf8')
+    expect(await loadKeyState(dir)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Refs #59

## Summary

`KeyManager` key material previously lived only in process memory, so every CLI process minted fresh keys. This made `exec --cache` architecturally non-functional (a cached JWE always failed `authorize()` with `KeyRevokedError`, which was then swallowed into a misleading "Cached token expired" message) and made the `rotate-key` grace-period guard unenforceable across invocations. This change persists key material and fixes the downstream error-surfacing and rotation-guard behavior.

## What changed

- **Key persistence (encrypted at rest).** Encryption keys are now written under the config directory, encrypted with AES-256-GCM under an owner-only (`0600`) wrapping key — reusing the file backend's authenticated-cipher primitives (no new crypto). The envelope encrypt/decrypt and wrapping-key management were extracted into a shared `util/at-rest` module used by both the file backend and key storage.
- **Persistence is scoped to real on-disk config.** Keys persist only when `VaultKeeper` loads its configuration from disk (no injected `config`/`backend`). Instances built with an injected `config` or `backend` keep keys in memory, so tests and embedders stay hermetic.
- **Cross-process token reuse.** A JWE minted by one process is authorizable by a later process within its validity window — its `kid` still resolves after the minting process exits.
- **`exec --cache` design decision.** `--cache` mints an unlimited-use token bounded by the secret's TTL (the existing `use: null` setup), so it is reusable within that TTL window rather than being single-use/blocklisted. On a second run by the same trusted caller it reuses the cached token with no re-mint and no "expired" notice; after the TTL, or a key rotation/revocation, `exec` transparently mints a fresh one. Documented in `exec --help` and the README.
- **Accurate error surfacing.** The cached-token path no longer collapses every authorization failure into "expired". Each failure now reports its real cause (e.g. `KeyRevokedError`, `TokenExpiredError`); `exec` still recovers by minting a fresh token for the trusted caller.
- **Rotation grace-period guard across processes.** The guard is derived from the persisted grace expiry, so `rotate-key` run twice while the previous key is still in grace fails the second time with `RotationInProgressError` (non-zero exit).

The exec trust gate is unchanged and still runs before any cache read — a cached token never bypasses trust.

## Tests

- Library unit: `keys/storage` round-trip, encryption-at-rest, `0600` permissions, expired-grace drop, tamper/corruption safety; `KeyManager` `snapshot`/`hydrate` and the cross-restart rotation guard.
- Library integration: token minted by one `VaultKeeper` instance authorized by a fresh instance sharing a config dir; cross-instance double-rotation guard; revoked-key `KeyRevokedError`.
- CLI e2e (definitive cross-process proof): two sequential `exec --cache` subprocesses sharing a config dir reuse the cached token without re-authenticating; a revoked key surfaces `KeyRevokedError` (not "expired") and still recovers; `rotate-key` twice surfaces `RotationInProgressError`.

### `vaultkeeper exec --help`: `--cache` description

```diff
-  --cache            Cache the JWE token for subsequent invocations
+  --cache            Cache the JWE token so a later invocation by the same
+                     trusted caller reuses it without re-minting. The token
+                     is reusable until it expires (the secret's TTL); after
+                     that, or after a key rotation/revocation, exec mints a
+                     fresh one automatically
```

`pnpm check` and the full TS test suite pass (the skipped tests are the Rust-binary conformance cases). Rust core parity is a documented non-goal.