### PR TITLE
Detect invalid config in doctor and config show, with actionable errors

### DIFF
--- a/.changeset/config-validation-and-doctor.md
+++ b/.changeset/config-validation-and-doctor.md
@@ -1,0 +1,12 @@
+---
+'vaultkeeper': minor
+'@vaultkeeper/cli': minor
+---
+
+`doctor` and `config show` now detect an invalid config file instead of silently ignoring it. `doctor` validates the config file (when present) as part of its preflight checks and reports a failing `config` check with the parse/validation error and file path, exiting non-zero. `config show` on invalid JSON now exits non-zero with the parse error (including a line/column location when available) instead of dumping the raw file with exit 0. Every config parse/validation error raised by `loadConfig()` — surfaced through `store`, `delete`, `exec`, `config show`, and `doctor` alike — now includes the config file path, the parse location where available, and a remediation hint naming `vaultkeeper config init`.
+
+`loadConfig()` now falls back to platform defaults only when the config file is missing (`ENOENT`). A present-but-unreadable file (e.g. a permissions error) is rethrown as a typed `FilesystemError` instead of being silently treated as "no config" — a genuinely broken config was previously invisible to `doctor` and `config show`.
+
+The "no config file" story is now uniform across `store`, `delete`, `exec`, `config show`, and `doctor`: each falls back to platform defaults and prints a one-line notice naming the resolved backend and `vaultkeeper config init` (e.g. `No config file found; using platform defaults (keychain). Run 'vaultkeeper config init' to persist one.`). Previously `config show` errored with exit 1 on a missing config file while the other commands defaulted silently; `config show` now defaults and reports it like the rest.
+
+New public `ConfigParseError` (with `path` and `location` fields) is thrown on invalid config JSON. `ConfigValidationError` gains an optional `configFilePath` field. `PreflightCheckStatus` gains an `'invalid'` value, and `RunDoctorOptions` gains an optional `configDir` field that lets `runDoctor`/`VaultKeeper.doctor()` load and validate the config itself.

--- a/packages/cli-tests/test/e2e/config.test.ts
+++ b/packages/cli-tests/test/e2e/config.test.ts
@@ -151,11 +151,48 @@ describe('config command', () => {
     expect(showResult.stderr).toContain('Active backend: file')
   })
 
-  it('should exit 1 for config show when no config exists', async () => {
+  // No-config story (issue #68): commands that need config fall back to
+  // platform defaults and say so, rather than erroring. `config show`
+  // previously exited 1 with "No config file found"; it now exits 0,
+  // prints the resolved defaults, and reports the fallback on stderr — the
+  // same story store/delete/exec/doctor use.
+  it('should exit 0 and print platform defaults for config show when no config exists (regression: issue #68 uniform no-config story)', async () => {
     env = await freshEnv()
     const result = await env.run(['config', 'show'])
-    expect(result.exitCode).toBe(1)
+    expect(result.exitCode).toBe(0)
+    const parsed: unknown = JSON.parse(result.stdout)
+    expect(parsed).toHaveProperty('version', 1)
+    expect(parsed).toHaveProperty('backends[0].type', platformDefaultBackend)
     expect(result.stderr).toContain('No config file found')
+    expect(result.stderr).toContain('using platform defaults')
+    expect(result.stderr).toContain('vaultkeeper config init')
+  })
+
+  // Repro from issue #68: a syntactically invalid config.json must never be
+  // dumped verbatim with exit 0 — it must fail with the parse error, the
+  // file path, a parse location, and a remediation hint.
+  it('should exit non-zero with path, parse location, and remediation hint for corrupt config.json (issue #68 repro)', async () => {
+    env = await createCliTestEnv()
+    await fs.writeFile(path.join(env.configDir, 'config.json'), '{ bad json', 'utf8')
+    const result = await env.run(['config', 'show'])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toContain(path.join(env.configDir, 'config.json'))
+    expect(result.stderr).toMatch(/line \d+, column \d+/)
+    expect(result.stderr).toContain('vaultkeeper config init')
+  })
+
+  it('should exit non-zero with path and remediation hint for a structurally invalid config.json', async () => {
+    env = await createCliTestEnv()
+    await fs.writeFile(
+      path.join(env.configDir, 'config.json'),
+      JSON.stringify({ version: 99 }),
+      'utf8',
+    )
+    const result = await env.run(['config', 'show'])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain(path.join(env.configDir, 'config.json'))
+    expect(result.stderr).toContain('version must be 1')
     expect(result.stderr).toContain('vaultkeeper config init')
   })
 

--- a/packages/cli-tests/test/e2e/doctor.test.ts
+++ b/packages/cli-tests/test/e2e/doctor.test.ts
@@ -5,6 +5,8 @@
  * These tests verify the command runs and produces structured check output.
  */
 import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
 import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
 import type { CliTestEnv } from '@vaultkeeper/cli-test-helpers'
 
@@ -27,5 +29,47 @@ describe('doctor command', () => {
     // Output should contain check markers (✓ or ✗)
     const hasChecks = result.stdout.includes('✓') || result.stdout.includes('✗')
     expect(hasChecks).toBe(true)
+  })
+
+  // Repro from issue #68: with a corrupt config.json, doctor previously
+  // never touched the config and reported "System ready." with exit 0. It
+  // must now report a failing "config" check with the parse error and file
+  // path, and exit non-zero.
+  it('should report a failing config check and exit non-zero for corrupt config.json (issue #68 repro)', async () => {
+    env = await createCliTestEnv()
+    await fs.writeFile(path.join(env.configDir, 'config.json'), '{ bad json', 'utf8')
+    const result = await env.run(['doctor'])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stdout).toContain('✗')
+    expect(result.stdout).toContain('config')
+    expect(result.stdout).toContain(path.join(env.configDir, 'config.json'))
+    expect(result.stdout).toMatch(/line \d+, column \d+/)
+    expect(result.stdout).toContain('vaultkeeper config init')
+    expect(result.stdout).not.toContain('System ready.')
+  })
+
+  it('should report a failing config check for a structurally invalid config.json', async () => {
+    env = await createCliTestEnv()
+    await fs.writeFile(
+      path.join(env.configDir, 'config.json'),
+      JSON.stringify({ version: 99 }),
+      'utf8',
+    )
+    const result = await env.run(['doctor'])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stdout).toContain('config')
+    expect(result.stdout).toContain('version must be 1')
+  })
+
+  // No-config story (issue #68): doctor falls back to platform defaults and
+  // says so, uniformly with store/delete/exec/config show, rather than
+  // silently defaulting or erroring.
+  it('should report a "using platform defaults" message when no config file exists', async () => {
+    env = await createCliTestEnv()
+    await fs.rm(path.join(env.configDir, 'config.json'))
+    const result = await env.run(['doctor'])
+    expect(result.stderr).toContain('No config file found')
+    expect(result.stderr).toContain('using platform defaults')
+    expect(result.stderr).toContain('vaultkeeper config init')
   })
 })

--- a/packages/cli-tests/test/e2e/store-delete.test.ts
+++ b/packages/cli-tests/test/e2e/store-delete.test.ts
@@ -76,4 +76,35 @@ describe('store and delete lifecycle', () => {
       await fs.rm(fakeHome, { recursive: true, force: true })
     }
   })
+
+  // Repro from issue #68: store previously failed on a corrupt config with
+  // "Failed to parse config file at <path>" and no location or remediation.
+  // The error must now include the file path, a parse location, and a
+  // remediation hint naming `vaultkeeper config init`.
+  it('store should exit non-zero with path, parse location, and remediation hint for corrupt config.json (issue #68 repro)', async () => {
+    env = await createCliTestEnv()
+    await fs.writeFile(path.join(env.configDir, 'config.json'), '{ bad json', 'utf8')
+    const result = await env.runWithStdin(
+      ['store', '--name', 'test-secret', '--skip-doctor'],
+      'sk-live-abc123',
+    )
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain(path.join(env.configDir, 'config.json'))
+    expect(result.stderr).toMatch(/line \d+, column \d+/)
+    expect(result.stderr).toContain('vaultkeeper config init')
+  })
+
+  // No-config story (issue #68): store falls back to platform defaults and
+  // says so, the same as config show/doctor/delete/exec.
+  it('store should report a "using platform defaults" message when no config file exists', async () => {
+    env = await createCliTestEnv()
+    await fs.rm(path.join(env.configDir, 'config.json'))
+    const result = await env.runWithStdin(
+      ['store', '--name', 'test-secret', '--skip-doctor'],
+      'sk-live-abc123',
+    )
+    expect(result.stderr).toContain('No config file found')
+    expect(result.stderr).toContain('using platform defaults')
+    expect(result.stderr).toContain('vaultkeeper config init')
+  })
 })

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,9 +1,10 @@
 import { parseArgs } from 'node:util'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { BackendRegistry, platformDefaultBackendType } from 'vaultkeeper'
+import { BackendRegistry, platformDefaultBackendType, loadConfig } from 'vaultkeeper'
 import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
+import { configFileExists, noConfigMessage } from '../config-status.js'
 
 /** Human-readable name for the current platform, for user-facing messages. */
 function platformLabel(): string {
@@ -99,11 +100,6 @@ function printConfigHelp(): void {
   )
 }
 
-/** Return true if err is a Node.js ENOENT error (file not found). */
-function isEnoent(err: unknown): boolean {
-  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
-}
-
 async function configInit(rest: string[], configDir: string): Promise<number> {
   const unknownFlag = findUnknownFlag(rest, new Set(['backend']))
   if (unknownFlag !== undefined) {
@@ -187,8 +183,31 @@ async function configShow(rest: string[], configDir: string): Promise<number> {
     return 2
   }
 
+  const configPath = path.join(configDir, 'config.json')
   try {
-    const configPath = path.join(configDir, 'config.json')
+    const exists = await configFileExists(configDir)
+
+    // loadConfig is the single source of truth for "is this config valid":
+    // it throws a typed, path-and-remediation-bearing error (ConfigParseError
+    // / ConfigValidationError / FilesystemError) on anything but a missing
+    // file, and never returns from a present-but-broken config. This makes
+    // an invalid config a hard failure (never a raw dump with exit 0), per
+    // issue #68.
+    const config = await loadConfig(configDir)
+
+    if (!exists) {
+      // No config file: fall back to platform defaults and say so, the same
+      // story store/delete/exec/doctor use (issue #68) — never error here.
+      const activeType =
+        config.backends.find((b) => b.enabled)?.type ?? platformDefaultBackendType()
+      process.stderr.write(noConfigMessage(activeType))
+      process.stdout.write(`${JSON.stringify(config, null, 2)}\n`)
+      process.stderr.write(`Active backend: ${activeType} (platform default)\n`)
+      return 0
+    }
+
+    // File exists and is valid — dump the raw file content (preserving its
+    // exact formatting) rather than the re-serialized, normalized config.
     const content = await fs.readFile(configPath, 'utf8')
     // The loaded path is a diagnostic, so it goes to stderr — stdout
     // stays pure JSON for consumers that pipe/parse `config show`.
@@ -206,13 +225,6 @@ async function configShow(rest: string[], configDir: string): Promise<number> {
     }
     return 0
   } catch (err) {
-    // Show a user-friendly message when the config file is missing.
-    if (isEnoent(err)) {
-      process.stderr.write(
-        "Error: No config file found. Run 'vaultkeeper config init' to create one.\n",
-      )
-      return 1
-    }
     process.stderr.write(`${formatError(err)}\n`)
     return 1
   }

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -1,8 +1,9 @@
 import { parseArgs } from 'node:util'
-import { VaultKeeper } from 'vaultkeeper'
+import { VaultKeeper, platformDefaultBackendType } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
+import { configFileExists, noConfigMessage } from '../config-status.js'
 
 function printDeleteHelp(): void {
   process.stdout.write(
@@ -44,6 +45,13 @@ export async function deleteCommand(args: string[], configDir: string): Promise<
   const skipDoctor = shouldSkipDoctor(values['skip-doctor'])
 
   try {
+    // No-config story is uniform across store/delete/exec/config show/doctor
+    // (issue #68): fall back to platform defaults and say so, rather than
+    // silently defaulting.
+    if (!(await configFileExists(configDir))) {
+      process.stderr.write(noConfigMessage(platformDefaultBackendType()))
+    }
+
     // Delete via VaultKeeper, which resolves the first enabled backend from the
     // loaded config and forwards that backend's config (including `path`).
     const vault = await VaultKeeper.init({ configDir, skipDoctor })

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,6 +1,7 @@
-import { VaultKeeper, loadConfig } from 'vaultkeeper'
+import { VaultKeeper, platformDefaultBackendType } from 'vaultkeeper'
 import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
+import { configFileExists, noConfigMessage } from '../config-status.js'
 
 function printDoctorHelp(): void {
   process.stdout.write(
@@ -22,10 +23,14 @@ export async function doctorCommand(args: string[], configDir: string): Promise<
   }
 
   try {
-    // Scope checks to the backends configured under configDir, so doctor
-    // reflects the same config the other commands will read/write.
-    const config = await loadConfig(configDir)
-    const result = await VaultKeeper.doctor({ backends: config.backends })
+    // Scope checks to the config under configDir: runDoctor loads and
+    // validates it itself (via `configDir`), so a present-but-invalid config
+    // file surfaces as a failing "config" check rather than being silently
+    // skipped or crashing doctor outright (issue #68).
+    if (!(await configFileExists(configDir))) {
+      process.stderr.write(noConfigMessage(platformDefaultBackendType()))
+    }
+    const result = await VaultKeeper.doctor({ configDir })
 
     for (const check of result.checks) {
       const icon = check.status === 'ok' ? '✓' : '✗'

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -29,7 +29,7 @@
 import { parseArgs } from 'node:util'
 import { spawn } from 'node:child_process'
 import * as path from 'node:path'
-import { VaultKeeper, IdentityMismatchError } from 'vaultkeeper'
+import { VaultKeeper, IdentityMismatchError, platformDefaultBackendType } from 'vaultkeeper'
 import { promptApproval } from '../approval.js'
 import { readCachedToken, writeCachedToken, invalidateCache } from '../cache.js'
 import { RedactingStream } from '../redact.js'
@@ -38,6 +38,7 @@ import { shouldAutoApprove } from '../auto-approve.js'
 import { shellQuote } from '../shell-quote.js'
 import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
+import { configFileExists, noConfigMessage } from '../config-status.js'
 
 /**
  * Outcome of the TOFU trust gate.
@@ -246,6 +247,13 @@ export async function execCommand(args: string[], configDir: string): Promise<nu
   const autoApprove = shouldAutoApprove(values.yes)
 
   try {
+    // No-config story is uniform across store/delete/exec/config show/doctor
+    // (issue #68): fall back to platform defaults and say so, rather than
+    // silently defaulting.
+    if (!(await configFileExists(configDir))) {
+      process.stderr.write(noConfigMessage(platformDefaultBackendType()))
+    }
+
     const vault = await VaultKeeper.init({ configDir, skipDoctor })
 
     // Enforce the trust gate BEFORE touching the cache or retrieving the

--- a/packages/cli/src/commands/store.ts
+++ b/packages/cli/src/commands/store.ts
@@ -1,8 +1,9 @@
 import { parseArgs } from 'node:util'
-import { VaultKeeper } from 'vaultkeeper'
+import { VaultKeeper, platformDefaultBackendType } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
+import { configFileExists, noConfigMessage } from '../config-status.js'
 
 function printStoreHelp(): void {
   process.stdout.write(
@@ -60,6 +61,13 @@ export async function storeCommand(args: string[], configDir: string): Promise<n
     if (secret.length === 0) {
       process.stderr.write('Error: No secret provided on stdin\n')
       return 1
+    }
+
+    // No-config story is uniform across store/delete/exec/config show/doctor
+    // (issue #68): fall back to platform defaults and say so, rather than
+    // silently defaulting.
+    if (!(await configFileExists(configDir))) {
+      process.stderr.write(noConfigMessage(platformDefaultBackendType()))
     }
 
     // Store via VaultKeeper, which resolves the first enabled backend from the

--- a/packages/cli/src/config-status.ts
+++ b/packages/cli/src/config-status.ts
@@ -11,13 +11,31 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 
-/** Return `true` if `config.json` exists under `configDir`. */
+/** `true` if `fs.access` failed because the config file truly does not exist. */
+function isEnoent(err: unknown): boolean {
+  return err instanceof Error && 'code' in err && err.code === 'ENOENT'
+}
+
+/**
+ * Return `true` if `config.json` exists under `configDir` and is at least
+ * readable-checkable, `false` if it is genuinely absent (`ENOENT`).
+ *
+ * Any other `fs.access` failure (e.g. `EACCES` on a parent directory, or a
+ * permissions error on the file itself) is a real problem, not "no config" —
+ * treating it as "no config" would silently fall back to platform defaults
+ * for a config that actually exists but is broken, the same class of bug
+ * `loadConfig`'s ENOENT-only fallback fixes (issue #68). Such errors rethrow
+ * so the caller's own `loadConfig()` call surfaces the typed error instead.
+ */
 export async function configFileExists(configDir: string): Promise<boolean> {
   try {
     await fs.access(path.join(configDir, 'config.json'))
     return true
-  } catch {
-    return false
+  } catch (err) {
+    if (isEnoent(err)) {
+      return false
+    }
+    throw err
   }
 }
 

--- a/packages/cli/src/config-status.ts
+++ b/packages/cli/src/config-status.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared "is there a config file, and if not, what do we tell the user"
+ * helpers, used uniformly across store/delete/exec/config show/doctor so all
+ * five commands agree on the no-config story (issue #68): fall back to
+ * platform defaults and say so, rather than silently defaulting (the old
+ * store/delete/exec behavior) or erroring (the old `config show` behavior).
+ *
+ * @internal
+ */
+
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+
+/** Return `true` if `config.json` exists under `configDir`. */
+export async function configFileExists(configDir: string): Promise<boolean> {
+  try {
+    await fs.access(path.join(configDir, 'config.json'))
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * One-line advisory printed when a command falls back to platform defaults
+ * because no config file exists. Always names the active backend and points
+ * at `vaultkeeper config init` so the user can persist a real config.
+ */
+export function noConfigMessage(activeBackendType: string): string {
+  return (
+    `No config file found; using platform defaults (${activeBackendType}). ` +
+    "Run 'vaultkeeper config init' to persist one.\n"
+  )
+}

--- a/packages/cli/test/unit/commands/config.test.ts
+++ b/packages/cli/test/unit/commands/config.test.ts
@@ -90,22 +90,65 @@ describe('configCommand', () => {
       expect(parsed).toMatchObject({ version: 1 })
     })
 
-    it('should return 1 when config does not exist', async () => {
+    // No-config story (issue #68): commands that need config fall back to
+    // platform defaults and say so — never an error, and never exit non-zero
+    // — uniformly across store/delete/exec/config show/doctor. `config show`
+    // previously erred with "No config file found" and exit 1; it now prints
+    // the resolved default config and exits 0, matching the other commands.
+    it('should return 0 and print platform defaults when config does not exist (regression: issue #68 uniform no-config story)', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
       const code = await configCommand(['show'], configDir)
-      expect(code).toBe(1)
+      expect(code).toBe(0)
     })
 
-    it('should write error to stderr when config does not exist', async () => {
+    it('should write default config JSON to stdout when no config file exists', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
       await configCommand(['show'], configDir)
-      expect(stderrOutput.length).toBeGreaterThan(0)
+      const parsed: unknown = JSON.parse(stdoutOutput)
+      expect(parsed).toMatchObject({ version: 1 })
     })
 
-    it('should show a user-friendly message when no config file exists', async () => {
+    it('should show a user-friendly "using platform defaults" message when no config file exists', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
       await configCommand(['show'], configDir)
       expect(stderrOutput).toContain('No config file found')
+      expect(stderrOutput).toContain('using platform defaults')
+      expect(stderrOutput).toContain('vaultkeeper config init')
+    })
+
+    it('should exit non-zero with a parse error, path, location, and remediation hint on invalid JSON (issue #68)', async () => {
+      await fs.mkdir(configDir, { recursive: true })
+      await fs.writeFile(path.join(configDir, 'config.json'), '{ bad json', 'utf8')
+      const { configCommand } = await import('../../../src/commands/config.js')
+      const code = await configCommand(['show'], configDir)
+      expect(code).toBe(1)
+      expect(stdoutOutput).toBe('')
+      expect(stderrOutput).toContain(path.join(configDir, 'config.json'))
+      expect(stderrOutput).toMatch(/line \d+, column \d+/)
+      expect(stderrOutput).toContain('vaultkeeper config init')
+    })
+
+    it('never dumps invalid JSON with exit 0 (regression: issue #68 repro)', async () => {
+      await fs.mkdir(configDir, { recursive: true })
+      await fs.writeFile(path.join(configDir, 'config.json'), '{ bad json', 'utf8')
+      const { configCommand } = await import('../../../src/commands/config.js')
+      const code = await configCommand(['show'], configDir)
+      expect(code).not.toBe(0)
+      expect(stdoutOutput).not.toContain('bad json')
+    })
+
+    it('exits non-zero with a schema validation error, path, and remediation hint on structurally invalid config', async () => {
+      await fs.mkdir(configDir, { recursive: true })
+      await fs.writeFile(
+        path.join(configDir, 'config.json'),
+        JSON.stringify({ version: 99 }),
+        'utf8',
+      )
+      const { configCommand } = await import('../../../src/commands/config.js')
+      const code = await configCommand(['show'], configDir)
+      expect(code).toBe(1)
+      expect(stderrOutput).toContain(path.join(configDir, 'config.json'))
+      expect(stderrOutput).toContain('version must be 1')
       expect(stderrOutput).toContain('vaultkeeper config init')
     })
   })

--- a/packages/cli/test/unit/commands/delete.test.ts
+++ b/packages/cli/test/unit/commands/delete.test.ts
@@ -16,6 +16,7 @@ vi.mock('vaultkeeper', () => ({
     getTypes: mockGetTypes,
     create: mockCreate,
   },
+  platformDefaultBackendType: vi.fn().mockReturnValue('file'),
 }))
 
 describe('deleteCommand', () => {

--- a/packages/cli/test/unit/commands/doctor.test.ts
+++ b/packages/cli/test/unit/commands/doctor.test.ts
@@ -13,6 +13,7 @@ vi.mock('vaultkeeper', () => ({
     doctor: mockDoctor,
   },
   loadConfig: mockLoadConfig,
+  platformDefaultBackendType: vi.fn().mockReturnValue('file'),
 }))
 
 describe('doctorCommand', () => {

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -33,6 +33,7 @@ vi.mock('vaultkeeper', () => ({
     init: mockInit,
   },
   IdentityMismatchError,
+  platformDefaultBackendType: vi.fn().mockReturnValue('file'),
 }))
 
 // Prevent any real approval prompts from blocking tests

--- a/packages/cli/test/unit/commands/store.test.ts
+++ b/packages/cli/test/unit/commands/store.test.ts
@@ -16,6 +16,7 @@ vi.mock('vaultkeeper', () => ({
     getTypes: mockGetTypes,
     create: mockCreate,
   },
+  platformDefaultBackendType: vi.fn().mockReturnValue('file'),
 }))
 
 function mockStdinWith(value: string): void {

--- a/packages/cli/test/unit/config-status.test.ts
+++ b/packages/cli/test/unit/config-status.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+vi.mock('node:fs/promises', () => ({
+  access: vi.fn(),
+}))
+
+// Must import after mock declaration
+const { access } = await import('node:fs/promises')
+const { configFileExists, noConfigMessage } = await import('../../src/config-status.js')
+
+/** Build a Node.js-shaped filesystem error with a `code` (e.g. 'ENOENT'). */
+function fsError(code: string, message: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code })
+}
+
+describe('configFileExists', () => {
+  afterEach(() => {
+    vi.mocked(access).mockReset()
+  })
+
+  it('returns true when config.json is accessible', async () => {
+    vi.mocked(access).mockResolvedValue(undefined)
+    await expect(configFileExists('/fake')).resolves.toBe(true)
+  })
+
+  it('returns false when config.json does not exist (ENOENT)', async () => {
+    vi.mocked(access).mockRejectedValue(fsError('ENOENT', 'no such file or directory'))
+    await expect(configFileExists('/fake')).resolves.toBe(false)
+  })
+
+  // Regression test (PR #94 review): configFileExists previously treated
+  // ANY fs.access failure as "no config file", so a config that exists but
+  // isn't readable (EACCES on a parent directory, EPERM, etc.) was silently
+  // reported as absent — the same class of bug loadConfig's ENOENT-only
+  // fallback fixes for issue #68. It must now rethrow non-ENOENT errors
+  // instead of reporting "no config file".
+  it('rethrows a non-ENOENT error instead of reporting "no config file" (regression: PR #94 review)', async () => {
+    vi.mocked(access).mockRejectedValue(fsError('EACCES', 'permission denied'))
+    await expect(configFileExists('/fake')).rejects.toMatchObject({ code: 'EACCES' })
+  })
+
+  it('rethrows an EPERM error instead of reporting "no config file"', async () => {
+    vi.mocked(access).mockRejectedValue(fsError('EPERM', 'operation not permitted'))
+    await expect(configFileExists('/fake')).rejects.toMatchObject({ code: 'EPERM' })
+  })
+})
+
+describe('noConfigMessage', () => {
+  it('names the resolved backend and points at config init', () => {
+    const message = noConfigMessage('keychain')
+    expect(message).toContain('keychain')
+    expect(message).toContain('vaultkeeper config init')
+  })
+})

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -68,8 +68,16 @@ export class CapabilityToken {
 }
 
 // @public
+export class ConfigParseError extends VaultError {
+    constructor(message: string, path: string, location: string | undefined);
+    readonly location: string | undefined;
+    readonly path: string;
+}
+
+// @public
 export class ConfigValidationError extends VaultError {
-    constructor(message: string, field: string);
+    constructor(message: string, field: string, configFilePath?: string);
+    readonly configFilePath: string | undefined;
     readonly field: string;
 }
 
@@ -203,7 +211,7 @@ export interface PreflightCheck {
 }
 
 // @public
-export type PreflightCheckStatus = 'ok' | 'missing' | 'version-unsupported';
+export type PreflightCheckStatus = 'ok' | 'missing' | 'version-unsupported' | 'invalid';
 
 // @public
 export interface PreflightResult {
@@ -224,6 +232,7 @@ export function runDoctor(options?: RunDoctorOptions): Promise<PreflightResult>;
 // @public
 export interface RunDoctorOptions {
     backends?: BackendConfig[];
+    configDir?: string;
     platform?: Platform;
 }
 

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -6,7 +6,54 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import type { VaultConfig, BackendConfig, TrustTier } from './types.js'
-import { ConfigValidationError } from './errors.js'
+import { ConfigValidationError, ConfigParseError, FilesystemError } from './errors.js'
+
+/**
+ * Remediation hint appended to every config-loading error message so a user
+ * always has a concrete next step, regardless of whether the failure was a
+ * read error, a JSON syntax error, or a schema validation error (issue #68).
+ */
+const CONFIG_REMEDIATION_HINT = "Run 'vaultkeeper config init' to create a valid config."
+
+/** `true` if `err` is a Node.js filesystem error with the given `code`. */
+function hasErrorCode(err: unknown, code: string): boolean {
+  return err instanceof Error && 'code' in err && err.code === code
+}
+
+/** Extract a readable message from an unknown thrown value. */
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+/**
+ * Best-effort human-readable location (`'line X, column Y'`) derived from a
+ * JSON `SyntaxError`. Modern V8 (Node 20+) already includes `line N column N`
+ * in the message; older engines only report a character offset (`position
+ * N`), which this falls back to converting by counting newlines in `raw`.
+ * Returns `undefined` when no location can be determined.
+ */
+function describeJsonSyntaxLocation(err: unknown, raw: string): string | undefined {
+  const message = describeError(err)
+
+  const lineColMatch = /line (\d+) column (\d+)/.exec(message)
+  if (lineColMatch) {
+    return `line ${lineColMatch[1] ?? ''}, column ${lineColMatch[2] ?? ''}`
+  }
+
+  const positionMatch = /position (\d+)/.exec(message)
+  if (positionMatch) {
+    const posStr = positionMatch[1]
+    const pos = posStr !== undefined ? Number(posStr) : NaN
+    if (!Number.isNaN(pos) && pos >= 0 && pos <= raw.length) {
+      const upToPos = raw.slice(0, pos)
+      const line = upToPos.split('\n').length
+      const column = pos - upToPos.lastIndexOf('\n')
+      return `line ${String(line)}, column ${String(column)}`
+    }
+  }
+
+  return undefined
+}
 
 /**
  * Return the platform-appropriate default config directory.
@@ -246,12 +293,17 @@ export function validateConfig(config: unknown): VaultConfig {
 }
 
 /**
- * Load the vaultkeeper config from disk, falling back to defaults if the
- * file cannot be read — this currently includes both a missing file and any
- * other read failure (e.g. a permissions error), not only "file does not
- * exist". Narrowing the fallback to ENOENT specifically, and surfacing other
- * read errors instead of silently defaulting, is tracked in issue #68
- * (config validation) and not yet implemented.
+ * Load the vaultkeeper config from disk, falling back to platform defaults
+ * only when the config file is missing (`ENOENT`).
+ *
+ * Any other read failure (e.g. `EACCES`, `EISDIR`) is a genuinely broken or
+ * unreadable config and is rethrown as a {@link FilesystemError} rather than
+ * silently defaulted — silently defaulting on a permissions error would hide
+ * the problem from `doctor` and `config show` (issue #68). A present file
+ * that fails to parse as JSON throws {@link ConfigParseError}; a present file
+ * that parses but fails schema validation throws {@link ConfigValidationError}.
+ * All three error messages include the config file path and a remediation
+ * hint naming `vaultkeeper config init`.
  *
  * @param configDir - Directory containing config.json. Defaults to
  * `getDefaultConfigDir()`, which itself honors `VAULTKEEPER_CONFIG_DIR`
@@ -265,16 +317,41 @@ export async function loadConfig(configDir?: string): Promise<VaultConfig> {
   let raw: string
   try {
     raw = await fs.readFile(configPath, 'utf-8')
-  } catch {
-    return defaultConfig()
+  } catch (err) {
+    if (hasErrorCode(err, 'ENOENT')) {
+      return defaultConfig()
+    }
+    throw new FilesystemError(
+      `Cannot read config file at ${configPath}: ${describeError(err)}. ${CONFIG_REMEDIATION_HINT}`,
+      configPath,
+      'read',
+    )
   }
 
   let parsed: unknown
   try {
     parsed = JSON.parse(raw)
-  } catch {
-    throw new Error(`Failed to parse config file at ${configPath}`)
+  } catch (err) {
+    const location = describeJsonSyntaxLocation(err, raw)
+    const locationSuffix = location !== undefined ? ` at ${location}` : ''
+    throw new ConfigParseError(
+      `Failed to parse config file at ${configPath}${locationSuffix}: ${describeError(err)}. ` +
+        CONFIG_REMEDIATION_HINT,
+      configPath,
+      location,
+    )
   }
 
-  return validateConfig(parsed)
+  try {
+    return validateConfig(parsed)
+  } catch (err) {
+    if (err instanceof ConfigValidationError) {
+      throw new ConfigValidationError(
+        `Invalid config at ${configPath}: ${err.message} ${CONFIG_REMEDIATION_HINT}`,
+        err.field,
+        configPath,
+      )
+    }
+    throw err
+  }
 }

--- a/packages/vaultkeeper/src/doctor/runner.ts
+++ b/packages/vaultkeeper/src/doctor/runner.ts
@@ -2,6 +2,7 @@
  * Doctor runner: orchestrates platform-appropriate checks and aggregates results.
  */
 
+import * as path from 'node:path'
 import {
   checkOpenssl,
   checkBash,
@@ -12,6 +13,7 @@ import {
   checkYkman,
 } from './checks.js'
 import { currentPlatform } from '../util/platform.js'
+import { loadConfig } from '../config.js'
 import type { BackendConfig, PreflightCheck, PreflightResult } from '../types.js'
 import type { Platform } from '../util/platform.js'
 
@@ -34,6 +36,18 @@ export interface RunDoctorOptions {
    * (backward-compatible behavior).
    */
   backends?: BackendConfig[]
+  /**
+   * When provided (and `backends` is not explicitly given), doctor loads and
+   * validates the config file under this directory, adding a `config`
+   * preflight check to the result. A present-but-invalid config file (parse
+   * or schema failure) becomes a failing, required check — with the
+   * underlying error's message (file path, parse location, remediation hint)
+   * as `reason` — so an invalid config is visible in `doctor`'s output and
+   * fails the overall `ready` result (issue #68). A missing config file is
+   * not an error: `loadConfig` resolves platform defaults and the check
+   * reports `ok`.
+   */
+  configDir?: string
 }
 
 /** A doctor check entry pairing the check function with whether it is required. */
@@ -65,7 +79,30 @@ export async function runDoctor(options?: RunDoctorOptions): Promise<PreflightRe
     }
   }
 
-  const enabledTypes = enabledBackendTypes(options?.backends)
+  // Resolve the config check and backend list together: an explicit
+  // `backends` option always wins (backward-compatible, and used by callers
+  // that already loaded/validated the config themselves, e.g. VaultKeeper.init
+  // after a successful loadConfig). Otherwise, when `configDir` is given,
+  // doctor loads and validates the config itself so an invalid config file
+  // surfaces as a failing check instead of being invisible to doctor.
+  let backends = options?.backends
+  let configCheck: PreflightCheck | undefined
+  if (backends === undefined && options?.configDir !== undefined) {
+    const configPath = path.join(options.configDir, 'config.json')
+    try {
+      const config = await loadConfig(options.configDir)
+      backends = config.backends
+      configCheck = { name: 'config', status: 'ok', version: configPath }
+    } catch (err) {
+      configCheck = {
+        name: 'config',
+        status: 'invalid',
+        reason: err instanceof Error ? err.message : String(err),
+      }
+    }
+  }
+
+  const enabledTypes = enabledBackendTypes(backends)
   const entries: CheckEntry[] = buildCheckList(platform, enabledTypes)
 
   const resolved: ResolvedEntry[] = await Promise.all(
@@ -75,13 +112,23 @@ export async function runDoctor(options?: RunDoctorOptions): Promise<PreflightRe
     }),
   )
 
-  const ready = resolved.every(({ required, result }) => {
-    if (!required) return true
-    return result.status === 'ok'
-  })
+  const configReady = configCheck === undefined || configCheck.status === 'ok'
+  const ready =
+    configReady &&
+    resolved.every(({ required, result }) => {
+      if (!required) return true
+      return result.status === 'ok'
+    })
 
   const warnings: string[] = []
   const nextSteps: string[] = []
+
+  if (configCheck !== undefined && configCheck.status !== 'ok') {
+    // The config check is always required — an invalid config means the
+    // vault cannot operate, so it always contributes a nextStep, never a
+    // mere warning.
+    nextSteps.push(configCheck.reason ?? 'Config file is invalid.')
+  }
 
   for (const { required, result } of resolved) {
     const reasonSuffix = result.reason !== undefined ? ` — ${result.reason}` : ''
@@ -102,7 +149,10 @@ export async function runDoctor(options?: RunDoctorOptions): Promise<PreflightRe
     }
   }
 
-  const checks = resolved.map(({ result }) => result)
+  const checks = [
+    ...(configCheck !== undefined ? [configCheck] : []),
+    ...resolved.map(({ result }) => result),
+  ]
 
   return { checks, ready, warnings, nextSteps }
 }
@@ -112,9 +162,7 @@ export async function runDoctor(options?: RunDoctorOptions): Promise<PreflightRe
  * Returns `null` when no backend list was provided, signalling that the
  * caller should fall back to platform defaults (backward-compatible).
  */
-function enabledBackendTypes(
-  backends: BackendConfig[] | undefined,
-): Set<string> | null {
+function enabledBackendTypes(backends: BackendConfig[] | undefined): Set<string> | null {
   if (backends === undefined) return null
   const types = new Set<string>()
   for (const b of backends) {
@@ -123,10 +171,7 @@ function enabledBackendTypes(
   return types
 }
 
-function buildCheckList(
-  platform: Platform,
-  enabledTypes: Set<string> | null,
-): CheckEntry[] {
+function buildCheckList(platform: Platform, enabledTypes: Set<string> | null): CheckEntry[] {
   // Core checks are always required regardless of backends.
   const entries: CheckEntry[] = [{ check: checkOpenssl, required: true }]
 

--- a/packages/vaultkeeper/src/errors.ts
+++ b/packages/vaultkeeper/src/errors.ts
@@ -338,10 +338,47 @@ export class ConfigValidationError extends VaultError {
    */
   readonly field: string
 
-  constructor(message: string, field: string) {
+  /**
+   * The absolute path of the config file that failed validation, when the
+   * error originated from loading a file on disk (via `loadConfig`) rather
+   * than from validating an in-memory value directly.
+   */
+  readonly configFilePath: string | undefined
+
+  constructor(message: string, field: string, configFilePath?: string) {
     super(message)
     this.name = 'ConfigValidationError'
     this.field = field
+    this.configFilePath = configFilePath
+  }
+}
+
+/**
+ * Thrown when a config file's contents cannot be parsed as JSON.
+ *
+ * The `message` already embeds the file path, the parse location (when the
+ * underlying `SyntaxError` exposes one), and a remediation hint pointing at
+ * `vaultkeeper config init` — see issue #68. `path` and `location` are also
+ * exposed individually for callers (e.g. `doctor`) that want to report them
+ * as structured fields rather than re-parsing the message.
+ */
+export class ConfigParseError extends VaultError {
+  /**
+   * The absolute path of the config file that failed to parse.
+   */
+  readonly path: string
+
+  /**
+   * A human-readable parse location (e.g. `'line 3, column 12'`), when one
+   * could be derived from the underlying `SyntaxError`.
+   */
+  readonly location: string | undefined
+
+  constructor(message: string, path: string, location: string | undefined) {
+    super(message)
+    this.name = 'ConfigParseError'
+    this.path = path
+    this.location = location
   }
 }
 

--- a/packages/vaultkeeper/src/errors.ts
+++ b/packages/vaultkeeper/src/errors.ts
@@ -339,9 +339,12 @@ export class ConfigValidationError extends VaultError {
   readonly field: string
 
   /**
-   * The absolute path of the config file that failed validation, when the
-   * error originated from loading a file on disk (via `loadConfig`) rather
-   * than from validating an in-memory value directly.
+   * The path of the config file that failed validation, when the error
+   * originated from loading a file on disk (via `loadConfig`) rather than
+   * from validating an in-memory value directly. This is `configDir` joined
+   * with `config.json` exactly as provided to `loadConfig` — it is not
+   * guaranteed to be absolute (`loadConfig` does not resolve a relative
+   * `configDir`).
    */
   readonly configFilePath: string | undefined
 
@@ -364,7 +367,10 @@ export class ConfigValidationError extends VaultError {
  */
 export class ConfigParseError extends VaultError {
   /**
-   * The absolute path of the config file that failed to parse.
+   * The path of the config file that failed to parse. This is `configDir`
+   * joined with `config.json` exactly as provided to `loadConfig` — it is
+   * not guaranteed to be absolute (`loadConfig` does not resolve a relative
+   * `configDir`).
    */
   readonly path: string
 
@@ -405,7 +411,10 @@ export class SetupError extends VaultError {
  */
 export class FilesystemError extends VaultError {
   /**
-   * The absolute path of the file or directory that caused the error.
+   * The path of the file or directory that caused the error, as provided by
+   * the caller. Not guaranteed to be absolute — e.g. `loadConfig` throws this
+   * with `configDir` joined with `config.json` exactly as given, without
+   * resolving a relative `configDir`.
    */
   readonly path: string
 

--- a/packages/vaultkeeper/src/index.ts
+++ b/packages/vaultkeeper/src/index.ts
@@ -31,6 +31,7 @@ export {
   FilesystemError,
   RotationInProgressError,
   ConfigValidationError,
+  ConfigParseError,
 } from './errors.js'
 
 export type {

--- a/packages/vaultkeeper/src/types.ts
+++ b/packages/vaultkeeper/src/types.ts
@@ -10,8 +10,13 @@ export type TrustTier = 1 | 2 | 3
 /** Key status in the rotation lifecycle. */
 export type KeyStatus = 'current' | 'previous' | 'deprecated'
 
-/** Status of a preflight check. */
-export type PreflightCheckStatus = 'ok' | 'missing' | 'version-unsupported'
+/**
+ * Status of a preflight check.
+ *
+ * `'invalid'` applies specifically to the `config` check: the config file
+ * exists but fails to parse or fails schema validation (see issue #68).
+ */
+export type PreflightCheckStatus = 'ok' | 'missing' | 'version-unsupported' | 'invalid'
 
 /** Result of a preflight check for a single dependency. */
 export interface PreflightCheck {

--- a/packages/vaultkeeper/test/unit/config.test.ts
+++ b/packages/vaultkeeper/test/unit/config.test.ts
@@ -5,7 +5,7 @@ import {
   getDefaultConfigDir,
   platformDefaultBackendType,
 } from '../../src/config.js'
-import { ConfigValidationError } from '../../src/errors.js'
+import { ConfigValidationError, ConfigParseError, FilesystemError } from '../../src/errors.js'
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
@@ -13,6 +13,11 @@ vi.mock('node:fs/promises', () => ({
 
 // Must import after mock declaration
 const { readFile } = await import('node:fs/promises')
+
+/** Build a Node.js-shaped filesystem error with a `code` (e.g. 'ENOENT'). */
+function fsError(code: string, message: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code })
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -302,8 +307,8 @@ describe('loadConfig', () => {
     vi.mocked(readFile).mockReset()
   })
 
-  it('should return default config when file does not exist', async () => {
-    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'))
+  it('should return default config when file does not exist (ENOENT)', async () => {
+    vi.mocked(readFile).mockRejectedValue(fsError('ENOENT', 'no such file or directory'))
     const config = await loadConfig('/nonexistent')
     expect(config.version).toBe(1)
     expect(config.backends).toHaveLength(1)
@@ -321,16 +326,78 @@ describe('loadConfig', () => {
     await expect(loadConfig('/fake')).rejects.toThrow('Failed to parse config file')
   })
 
+  it('should throw a ConfigParseError with the file path, a parse location, and a remediation hint on invalid JSON (issue #68)', async () => {
+    vi.mocked(readFile).mockResolvedValue('{ bad json')
+    try {
+      await loadConfig('/fake')
+      expect.unreachable('loadConfig should have thrown')
+    } catch (err) {
+      if (!(err instanceof ConfigParseError)) {
+        throw err
+      }
+      expect(err.path).toBe('/fake/config.json')
+      expect(err.location).toMatch(/line \d+, column \d+/)
+      expect(err.message).toContain('/fake/config.json')
+      const location = err.location
+      if (location === undefined) {
+        expect.unreachable('location should be defined')
+      }
+      expect(err.message).toContain(location)
+      expect(err.message).toContain('vaultkeeper config init')
+    }
+  })
+
   it('should throw on invalid config structure', async () => {
     vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: 99 }))
     await expect(loadConfig('/fake')).rejects.toThrow('version must be 1')
   })
 
+  it('should throw a ConfigValidationError with the file path and a remediation hint on invalid config structure (issue #68)', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: 99 }))
+    try {
+      await loadConfig('/fake')
+      expect.unreachable('loadConfig should have thrown')
+    } catch (err) {
+      if (!(err instanceof ConfigValidationError)) {
+        throw err
+      }
+      expect(err.message).toContain('/fake/config.json')
+      expect(err.message).toContain('vaultkeeper config init')
+      expect(err.field).toBe('version')
+    }
+  })
+
   it('should resolve the platform-default backend when no config file exists', async () => {
-    vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'))
+    vi.mocked(readFile).mockRejectedValue(fsError('ENOENT', 'no such file or directory'))
     const config = await loadConfig('/nonexistent')
     const firstBackend = config.backends[0]
     expect(firstBackend?.type).toBe(platformDefaultBackendType())
+  })
+
+  // Regression test for issue #68's loadConfig hardening (folded in from #92's
+  // review): before this fix, loadConfig fell back to defaultConfig() on ANY
+  // read error, not just ENOENT — so a genuinely broken/unreadable config
+  // (e.g. a permissions error) silently returned defaults instead of
+  // surfacing the problem.
+  it('should rethrow a non-ENOENT read error as a typed FilesystemError instead of silently defaulting (regression: issue #68 / #92 review)', async () => {
+    vi.mocked(readFile).mockRejectedValue(fsError('EACCES', 'permission denied'))
+    try {
+      await loadConfig('/fake')
+      expect.unreachable('loadConfig should have thrown, not silently defaulted')
+    } catch (err) {
+      if (!(err instanceof FilesystemError)) {
+        throw err
+      }
+      expect(err.path).toBe('/fake/config.json')
+      expect(err.permission).toBe('read')
+      expect(err.message).toContain('/fake/config.json')
+      expect(err.message).toContain('vaultkeeper config init')
+    }
+  })
+
+  it('should rethrow an EISDIR read error as a typed FilesystemError instead of silently defaulting', async () => {
+    vi.mocked(readFile).mockRejectedValue(fsError('EISDIR', 'illegal operation on a directory'))
+    await expect(loadConfig('/fake')).rejects.toBeInstanceOf(FilesystemError)
   })
 })
 

--- a/packages/vaultkeeper/test/unit/doctor/runner.test.ts
+++ b/packages/vaultkeeper/test/unit/doctor/runner.test.ts
@@ -16,6 +16,12 @@ vi.mock('../../../src/doctor/checks.js', () => ({
   checkYkman: vi.fn(),
 }))
 
+vi.mock('../../../src/config.js', () => ({
+  loadConfig: vi.fn(),
+}))
+
+import { loadConfig } from '../../../src/config.js'
+import { ConfigParseError } from '../../../src/errors.js'
 import {
   checkOpenssl,
   checkBash,
@@ -35,6 +41,7 @@ const mockCheckSecretTool = vi.mocked(checkSecretTool)
 const mockCheckOp = vi.mocked(checkOp)
 const mockCheckYkman = vi.mocked(checkYkman)
 const mockCurrentPlatform = vi.mocked(currentPlatform)
+const mockLoadConfig = vi.mocked(loadConfig)
 
 beforeEach(() => {
   vi.resetAllMocks()
@@ -584,5 +591,75 @@ describe('backend-aware checks ignore disabled backends', () => {
 
     expect(result.ready).toBe(true)
     expect(result.warnings.some((w) => w.includes('security'))).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// configDir option — doctor loads and validates the config itself, adding a
+// "config" check. An invalid config is a failing, required check (issue #68).
+// ---------------------------------------------------------------------------
+
+describe('runDoctor with configDir', () => {
+  it('adds an ok "config" check and scopes backend checks when the config loads successfully', async () => {
+    mockCheckOpenssl.mockReturnValue(mockOk('openssl'))
+    mockCheckBash.mockReturnValue(mockOk('bash'))
+    mockCheckSecretTool.mockReturnValue(mockMissing('secret-tool', 'not found'))
+    mockCheckOp.mockReturnValue(mockMissing('op'))
+    mockCheckYkman.mockReturnValue(mockMissing('ykman'))
+    mockLoadConfig.mockResolvedValue({
+      version: 1,
+      backends: [{ type: 'file', enabled: true }],
+      keyRotation: { gracePeriodDays: 7 },
+      defaults: { ttlMinutes: 60, trustTier: 3 },
+    })
+
+    const result = await runDoctor({ platform: 'linux', configDir: '/fake' })
+
+    const configCheck = result.checks.find((c) => c.name === 'config')
+    expect(configCheck?.status).toBe('ok')
+    // file backend does not require secret-tool -> demoted to optional, ready stays true
+    expect(result.ready).toBe(true)
+    expect(mockLoadConfig).toHaveBeenCalledWith('/fake')
+  })
+
+  it('reports a failing required "config" check with the underlying error message when the config is invalid', async () => {
+    mockCheckOpenssl.mockReturnValue(mockOk('openssl'))
+    mockCheckBash.mockReturnValue(mockOk('bash'))
+    mockCheckSecretTool.mockReturnValue(mockOk('secret-tool'))
+    mockCheckOp.mockReturnValue(mockMissing('op'))
+    mockCheckYkman.mockReturnValue(mockMissing('ykman'))
+    mockLoadConfig.mockRejectedValue(
+      new ConfigParseError(
+        "Failed to parse config file at /fake/config.json at line 1, column 3: Unexpected token. Run 'vaultkeeper config init' to create a valid config.",
+        '/fake/config.json',
+        'line 1, column 3',
+      ),
+    )
+
+    const result = await runDoctor({ platform: 'linux', configDir: '/fake' })
+
+    const configCheck = result.checks.find((c) => c.name === 'config')
+    expect(configCheck?.status).toBe('invalid')
+    expect(configCheck?.reason).toContain('/fake/config.json')
+    expect(configCheck?.reason).toContain('line 1, column 3')
+    expect(result.ready).toBe(false)
+    expect(result.nextSteps.some((s) => s.includes('/fake/config.json'))).toBe(true)
+  })
+
+  it('does not load config when an explicit backends option is also provided', async () => {
+    mockCheckOpenssl.mockReturnValue(mockOk('openssl'))
+    mockCheckBash.mockReturnValue(mockOk('bash'))
+    mockCheckSecretTool.mockReturnValue(mockOk('secret-tool'))
+    mockCheckOp.mockReturnValue(mockOk('op'))
+    mockCheckYkman.mockReturnValue(mockOk('ykman'))
+
+    const result = await runDoctor({
+      platform: 'linux',
+      configDir: '/fake',
+      backends: [{ type: 'file', enabled: true }],
+    })
+
+    expect(mockLoadConfig).not.toHaveBeenCalled()
+    expect(result.checks.find((c) => c.name === 'config')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Refs #68

- `doctor` now validates the config file (when present) as part of its preflight checks. An invalid config is a failing, required `config` check with the parse/validation error and file path, and `doctor` exits non-zero. Previously it never touched the config and reported "System ready." with exit 0.
- `config show` on invalid JSON now exits non-zero with the parse error (including line/column when available) instead of dumping the raw file with exit 0.
- `loadConfig()` in `packages/vaultkeeper/src/config.ts` now falls back to platform defaults only on `ENOENT` (missing file). A present-but-unreadable file (`EACCES`, `EISDIR`, ...) is rethrown as a typed `FilesystemError` instead of being silently treated as "no config" (hardening called out in the issue's follow-up comment, folded in from #92's review).
- Every config error surfaced through `store`/`delete`/`exec`/`config show`/`doctor` now includes the file path, a parse location where available, and a remediation hint naming `vaultkeeper config init`.
- The no-config story is now uniform: `store`, `delete`, `exec`, `config show`, and `doctor` all fall back to platform defaults and print a one-line notice (`No config file found; using platform defaults (<type>). Run 'vaultkeeper config init' to persist one.`) instead of silently defaulting (the old store/delete/exec behavior) or erroring (the old `config show` behavior).

New public surface (changeset included): `ConfigParseError` (`path`, `location`), `ConfigValidationError.configFilePath`, `PreflightCheckStatus` gains `'invalid'`, `RunDoctorOptions.configDir`.

## Before / after (repro from the issue)

```
$ echo '{ bad json' > ~/.config/vaultkeeper/config.json

# Before
$ vaultkeeper config show   # exit 0, raw garbage dumped
$ vaultkeeper doctor        # exit 0, "System ready."

# After
$ vaultkeeper config show
ConfigParseError: Failed to parse config file at /.../config.json at line 1, column 3: Expected property name or '}' in JSON at position 2 (line 1 column 3). Run 'vaultkeeper config init' to create a valid config.
$ echo $?
1

$ vaultkeeper doctor
  ✗ config — Failed to parse config file at /.../config.json at line 1, column 3: ... Run 'vaultkeeper config init' to create a valid config.
  ✓ openssl (...)
  ...
Next steps:
  → Failed to parse config file at /.../config.json at line 1, column 3: ... Run 'vaultkeeper config init' to create a valid config.
$ echo $?
1
```

## Test plan

- [x] `packages/vaultkeeper/test/unit/config.test.ts`: `ConfigParseError`/`ConfigValidationError`/`FilesystemError` cases, including the non-ENOENT regression test called out in the issue's follow-up comment
- [x] `packages/vaultkeeper/test/unit/doctor/runner.test.ts`: `runDoctor({ configDir })` config-check behavior (ok / invalid / explicit-backends-skip-load)
- [x] `packages/cli/test/unit/commands/*.test.ts`: updated mocks for the new `platformDefaultBackendType` import; `config.test.ts` covers the new no-config and corrupt-config exit codes
- [x] `packages/cli-tests/test/e2e/{config,doctor,store-delete}.test.ts`: subprocess regression tests for corrupt-config (doctor/config show/store) and no-config messaging (store/config show/doctor), per the issue's criterion 5
- [x] `pnpm check` (typecheck + lint + API report) green
- [x] `pnpm test` green across all packages (639 vaultkeeper, 209 CLI, 95 cli-tests, 25 conformance skipped — no Rust binary in this env)