### PR TITLE
Uniform CLI exit codes, reject empty --name, validate secret before TTY gate

### DIFF
--- a/.changeset/cli-error-surface-polish.md
+++ b/.changeset/cli-error-surface-polish.md
@@ -1,0 +1,12 @@
+---
+'vaultkeeper': minor
+'@vaultkeeper/cli': minor
+---
+
+Uniform CLI exit-code taxonomy (0 success / 1 runtime failure / 2 usage error) applied everywhere: a top-level typo like `vaultkeeper --bogus` now exits 2 with an error instead of silently exiting 0, and an unrecognized flag on `store`, `delete`, `exec`, `approve`, `dev-mode`, or `doctor` now exits 2 instead of a bare fatal error (exit 1).
+
+`store` (and `delete`, for consistency) now reject an empty or whitespace-only `--name` with exit 2 and the same error style as a missing flag, instead of persisting a near-unreachable secret or surfacing a generic runtime error. Allowed `--name` characters (letters, digits, `.`, `_`, `-`, `/`) are documented in `--help`.
+
+`exec` now validates that the secret exists before the caller-approval/TTY gate, so `exec --secret <nonexistent> ...` reports a clear `SecretNotFoundError` regardless of TTY, instead of being masked by the generic "requires interactive approval" message. This is backed by a new public `VaultKeeper.secretExists(name)` method — a side-effect-free existence check that never touches the TOFU trust manifest.
+
+`config init --help` and `config show --help` now print help for that subcommand instead of the parent `config` help. `exec --help` includes a worked `--caller` example.

--- a/packages/cli-tests/test/e2e/argument-validation.test.ts
+++ b/packages/cli-tests/test/e2e/argument-validation.test.ts
@@ -25,6 +25,34 @@ describe('argument validation', () => {
     expect(result.stderr).toContain('--name is required')
   })
 
+  // Issue #69, criterion 2: an empty/whitespace-only --name must exit 2 with
+  // the same usage-error style as a missing flag, and must never persist a
+  // secret. Repro: `store --name ""` previously reached VaultKeeper.store(),
+  // which threw a generic VaultError with exit 1 instead of a usage error,
+  // and the near-unreachable secret would still have been written for any
+  // charset that passed the (nonexistent) validation.
+  it('store should exit 2 for an empty --name and not persist a secret (regression: issue #69)', async () => {
+    env = await createCliTestEnv()
+    const result = await env.runWithStdin(['store', '--name', ''], 'some-secret')
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('--name must be non-empty')
+    expect(result.stdout).not.toContain('stored successfully')
+  })
+
+  it('store should exit 2 for a whitespace-only --name', async () => {
+    env = await createCliTestEnv()
+    const result = await env.runWithStdin(['store', '--name', '   '], 'some-secret')
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('--name must be non-empty')
+  })
+
+  it('delete should exit 2 for an empty --name, consistent with store', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['delete', '--name', ''])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('--name must be non-empty')
+  })
+
   it('delete should exit 2 when --name is missing', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['delete'])

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -277,4 +277,46 @@ describe('exec trust gate', () => {
     expect(result.stdout).toContain('non-TTY')
     expect(result.stdout).toContain('vaultkeeper approve --script')
   })
+
+  // Issue #69, criterion 3: exec validates secret existence BEFORE the
+  // interactivity/TTY gate. Repro: a nonexistent secret with a NEVER-approved
+  // caller on non-TTY stdin previously hit the trust gate first and reported
+  // the generic "requires approval, but stdin is not a TTY" error, masking
+  // the real problem. It must now report SecretNotFoundError-style messaging
+  // regardless of TTY, and the caller must never be prompted or recorded.
+  it('reports secret-not-found before the TTY/approval gate for a never-approved caller (issue #69 repro)', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    // A caller that has never been approved and is NOT pre-approved here —
+    // if the trust gate ran first, this would fail with the TTY/approval
+    // message instead of a secret-not-found error.
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+
+    const result = await env.run(
+      execArgs(caller).map((a) => (a === SECRET_NAME ? 'no-such-secret' : a)),
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain('SecretNotFoundError')
+    expect(result.stderr).toContain('no-such-secret')
+    expect(result.stderr).not.toContain('requires approval')
+    expect(result.stderr).not.toContain('is not a TTY')
+    expect(result.stderr).not.toMatch(/Allow\?|\[y\/N\]/)
+  })
+
+  // Complement: the same precondition check must not bypass or weaken the
+  // trust gate for a caller that IS approved but the secret is missing.
+  it('reports secret-not-found for an already-trusted caller too, without touching the wrapped command', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+    const approved = await env.run(['approve', '--script', caller])
+    expect(approved.exitCode).toBe(0)
+
+    const result = await env.run(
+      execArgs(caller).map((a) => (a === SECRET_NAME ? 'no-such-secret' : a)),
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain('SecretNotFoundError')
+    expect(result.stdout).not.toContain('ready=')
+  })
 })

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -117,8 +117,27 @@ async function main(): Promise<number> {
     return 0
   }
 
-  // Handle --help / -h and no-argument invocations at the top level.
-  if (firstArg === '--help' || firstArg === '-h' || subcommand === undefined) {
+  // A bare invocation (no arguments at all) or --help/-h prints help and
+  // exits 0 — this is the "getting started" case.
+  if (filteredArgv.length === 0 || firstArg === '--help' || firstArg === '-h') {
+    printHelp()
+    return 0
+  }
+
+  // A first token that looks like a flag (starts with '-') but isn't a
+  // recognized top-level flag is a typo, not "no command given" — it must
+  // exit 2, never silently print help with exit 0 (regression: issue #69,
+  // `vaultkeeper --bogus` previously exited 0).
+  if (firstArg?.startsWith('-') === true) {
+    process.stderr.write(`Error: unknown option '${firstArg}'\n`)
+    // Exit code 2: usage error (unknown top-level flag)
+    return 2
+  }
+
+  // Defensive fallback: parseArgs with allowPositionals should always set
+  // subcommand to firstArg when firstArg doesn't start with '-', but if it
+  // somehow didn't, treat it the same as a bare invocation.
+  if (subcommand === undefined) {
     printHelp()
     return 0
   }

--- a/packages/cli/src/commands/approve.ts
+++ b/packages/cli/src/commands/approve.ts
@@ -26,13 +26,25 @@ export async function approveCommand(args: string[], configDir: string): Promise
     return 0
   }
 
-  const { values } = parseArgs({
-    args,
-    options: {
-      script: { type: 'string' },
-    },
-    strict: true,
-  })
+  let values: { script?: string }
+  try {
+    ;({ values } = parseArgs({
+      args,
+      options: {
+        script: { type: 'string' },
+      },
+      strict: true,
+    }))
+  } catch (err) {
+    // Regression: issue #69 — an unrecognized flag previously propagated
+    // uncaught and exited 1 via bin.ts's fatal-error handler instead of the
+    // usage-error exit code 2.
+    if (err instanceof Error) {
+      process.stderr.write(`Error: ${err.message}\n`)
+    }
+    process.stderr.write('Usage: vaultkeeper approve --script <path>\n')
+    return 2
+  }
 
   if (values.script === undefined) {
     process.stderr.write('Error: --script is required\n')

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -95,12 +95,47 @@ function printConfigHelp(): void {
       'Options:\n' +
       CONFIG_DIR_HELP_OPTION +
       '  -h, --help   Show this help message\n\n' +
+      'Run "vaultkeeper config <subcommand> --help" for subcommand-specific help.\n\n' +
+      'Environment variables:\n' +
+      CONFIG_DIR_HELP_ENV,
+  )
+}
+
+function printConfigInitHelp(): void {
+  process.stdout.write(
+    'Usage: vaultkeeper config init [--backend <type>]\n\n' +
+      'Create a default config file.\n\n' +
+      'Options:\n' +
+      '  --backend <type>   Backend to configure as the active store\n' +
+      `                     (valid: ${BackendRegistry.getTypes().join(', ')})\n` +
+      CONFIG_DIR_HELP_OPTION +
+      '  -h, --help         Show this help message\n\n' +
+      'Environment variables:\n' +
+      CONFIG_DIR_HELP_ENV,
+  )
+}
+
+function printConfigShowHelp(): void {
+  process.stdout.write(
+    'Usage: vaultkeeper config show\n\n' +
+      'Print the current config file (or platform defaults, with a notice on\n' +
+      'stderr, when no config file exists).\n\n' +
+      'Options:\n' +
+      CONFIG_DIR_HELP_OPTION +
+      '  -h, --help   Show this help message\n\n' +
       'Environment variables:\n' +
       CONFIG_DIR_HELP_ENV,
   )
 }
 
 async function configInit(rest: string[], configDir: string): Promise<number> {
+  // Handle --help / -h before findUnknownFlag so it isn't rejected as an
+  // unrecognized flag for 'config init'.
+  if (rest.includes('--help') || rest.includes('-h')) {
+    printConfigInitHelp()
+    return 0
+  }
+
   const unknownFlag = findUnknownFlag(rest, new Set(['backend']))
   if (unknownFlag !== undefined) {
     process.stderr.write(`Error: unknown option '${unknownFlag}' for 'config init'\n`)
@@ -177,6 +212,13 @@ async function configInit(rest: string[], configDir: string): Promise<number> {
 }
 
 async function configShow(rest: string[], configDir: string): Promise<number> {
+  // Handle --help / -h before findUnknownFlag so it isn't rejected as an
+  // unrecognized flag for 'config show'.
+  if (rest.includes('--help') || rest.includes('-h')) {
+    printConfigShowHelp()
+    return 0
+  }
+
   const unknownFlag = findUnknownFlag(rest, new Set())
   if (unknownFlag !== undefined) {
     process.stderr.write(`Error: unknown option '${unknownFlag}' for 'config show'\n`)
@@ -231,21 +273,26 @@ async function configShow(rest: string[], configDir: string): Promise<number> {
 }
 
 export async function configCommand(args: string[], configDir: string): Promise<number> {
-  // Handle --help / -h before subcommand dispatch.
-  if (args.includes('--help') || args.includes('-h')) {
-    printConfigHelp()
-    return 0
-  }
-
   const subcommand = args[0]
   const rest = args.slice(1)
 
   switch (subcommand) {
     case 'init':
+      // --help / -h is handled inside configInit so it prints init-specific
+      // help, not the parent 'config' help (regression: issue #69).
       return configInit(rest, configDir)
 
     case 'show':
+      // --help / -h is handled inside configShow so it prints show-specific
+      // help, not the parent 'config' help (regression: issue #69).
       return configShow(rest, configDir)
+
+    // Only a bare 'config --help'/'config -h' (no subcommand) shows the
+    // parent help — a subcommand's own --help is handled above instead.
+    case '--help':
+    case '-h':
+      printConfigHelp()
+      return 0
 
     default:
       process.stderr.write('Error: missing or unknown config subcommand\n')

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -5,11 +5,15 @@ import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 import { configFileExists, noConfigMessage } from '../config-status.js'
 
+// Same character policy as `store --name` (see store.ts) — keep in sync.
+const SECRET_NAME_PATTERN = /^[A-Za-z0-9._/-]+$/
+
 function printDeleteHelp(): void {
   process.stdout.write(
     'Usage: vaultkeeper delete --name <name>\n\n' +
       'Options:\n' +
-      '  --name <name>      Name of the secret to delete\n' +
+      '  --name <name>      Name of the secret to delete. Must be non-empty\n' +
+      '                     and contain only letters, digits, and . _ - /\n' +
       '  --skip-doctor      Skip doctor preflight checks\n' +
       CONFIG_DIR_HELP_OPTION +
       '  -h, --help         Show this help message\n\n' +
@@ -26,19 +30,43 @@ export async function deleteCommand(args: string[], configDir: string): Promise<
     return 0
   }
 
-  const { values } = parseArgs({
-    args,
-    options: {
-      name: { type: 'string' },
-      'skip-doctor': { type: 'boolean', default: false },
-    },
-    strict: true,
-  })
+  let values: { name?: string; 'skip-doctor': boolean }
+  try {
+    ;({ values } = parseArgs({
+      args,
+      options: {
+        name: { type: 'string' },
+        'skip-doctor': { type: 'boolean', default: false },
+      },
+      strict: true,
+    }))
+  } catch (err) {
+    // Regression: issue #69 — an unrecognized flag previously propagated
+    // uncaught and exited 1 via bin.ts's fatal-error handler instead of the
+    // usage-error exit code 2.
+    if (err instanceof Error) {
+      process.stderr.write(`Error: ${err.message}\n`)
+    }
+    process.stderr.write('Usage: vaultkeeper delete --name <name>\n')
+    return 2
+  }
 
   if (values.name === undefined) {
     process.stderr.write('Error: --name is required\n')
     process.stderr.write('Usage: vaultkeeper delete --name <name>\n')
     // Exit code 2: usage error (missing required flag)
+    return 2
+  }
+
+  // Reject empty/whitespace-only (and otherwise invalid-character) names
+  // with the same exit code and error style as a missing flag — same
+  // consistency fix as `store --name` (issue #69).
+  if (!SECRET_NAME_PATTERN.test(values.name)) {
+    process.stderr.write(
+      'Error: --name must be non-empty and contain only letters, digits, and . _ - /\n',
+    )
+    process.stderr.write('Usage: vaultkeeper delete --name <name>\n')
+    // Exit code 2: usage error (invalid flag value)
     return 2
   }
 

--- a/packages/cli/src/commands/dev-mode.ts
+++ b/packages/cli/src/commands/dev-mode.ts
@@ -30,15 +30,28 @@ export async function devModeCommand(args: string[], configDir: string): Promise
     return 0
   }
 
-  const { positionals, values } = parseArgs({
-    args,
-    allowPositionals: true,
-    options: {
-      script: { type: 'string' },
-      'skip-doctor': { type: 'boolean', default: false },
-    },
-    strict: true,
-  })
+  let positionals: string[]
+  let values: { script?: string; 'skip-doctor': boolean }
+  try {
+    ;({ positionals, values } = parseArgs({
+      args,
+      allowPositionals: true,
+      options: {
+        script: { type: 'string' },
+        'skip-doctor': { type: 'boolean', default: false },
+      },
+      strict: true,
+    }))
+  } catch (err) {
+    // Regression: issue #69 — an unrecognized flag previously propagated
+    // uncaught and exited 1 via bin.ts's fatal-error handler instead of the
+    // usage-error exit code 2.
+    if (err instanceof Error) {
+      process.stderr.write(`Error: ${err.message}\n`)
+    }
+    process.stderr.write('Usage: vaultkeeper dev-mode <enable|disable> --script <path>\n')
+    return 2
+  }
 
   const action = positionals[0]
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1,3 +1,4 @@
+import { parseArgs } from 'node:util'
 import { VaultKeeper, platformDefaultBackendType } from 'vaultkeeper'
 import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
@@ -20,6 +21,20 @@ export async function doctorCommand(args: string[], configDir: string): Promise<
   if (args.includes('--help') || args.includes('-h')) {
     printDoctorHelp()
     return 0
+  }
+
+  // doctor takes no flags of its own (--config-dir is stripped by bin.ts
+  // before dispatch). Previously any unrecognized flag was silently
+  // ignored — `doctor --bogus` ran the real checks and could exit 0
+  // (regression: issue #69) instead of failing as a usage error.
+  try {
+    parseArgs({ args, strict: true })
+  } catch (err) {
+    if (err instanceof Error) {
+      process.stderr.write(`Error: ${err.message}\n`)
+    }
+    process.stderr.write('Usage: vaultkeeper doctor\n')
+    return 2
   }
 
   try {

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -29,7 +29,12 @@
 import { parseArgs } from 'node:util'
 import { spawn } from 'node:child_process'
 import * as path from 'node:path'
-import { VaultKeeper, IdentityMismatchError, platformDefaultBackendType } from 'vaultkeeper'
+import {
+  VaultKeeper,
+  IdentityMismatchError,
+  SecretNotFoundError,
+  platformDefaultBackendType,
+} from 'vaultkeeper'
 import { promptApproval } from '../approval.js'
 import { readCachedToken, writeCachedToken, invalidateCache } from '../cache.js'
 import { RedactingStream } from '../redact.js'
@@ -179,6 +184,12 @@ function printExecHelp(): void {
       '  no prompt, so you must either pre-approve the caller with\n' +
       '  "vaultkeeper approve --script <caller>" or pass --yes (or VAULTKEEPER_YES=1)\n' +
       '  to approve this invocation. Once trusted, exec never prompts again.\n\n' +
+      'Example (--caller identifies the invoking script or binary, not the\n' +
+      'wrapped command after --):\n' +
+      '  vaultkeeper exec --secret db-password --env DB_PASSWORD \\\n' +
+      '    --caller ./deploy.sh -- psql -U admin\n' +
+      '  # deploy.sh is the trusted caller; psql is the command that receives\n' +
+      '  # DB_PASSWORD in its environment.\n\n' +
       'Environment variables:\n' +
       '  VAULTKEEPER_YES=1           Approve an untrusted caller non-interactively\n' +
       '                              (same as --yes)\n' +
@@ -214,20 +225,43 @@ export async function execCommand(args: string[], configDir: string): Promise<nu
     return 2
   }
 
-  const { values } = parseArgs({
-    args: flagArgs,
-    options: {
-      secret: { type: 'string' },
-      env: { type: 'string' },
-      caller: { type: 'string' },
-      reason: { type: 'string' },
-      yes: { type: 'boolean', default: false },
-      cache: { type: 'boolean', default: false },
-      'no-redact': { type: 'boolean', default: false },
-      'skip-doctor': { type: 'boolean', default: false },
-    },
-    strict: true,
-  })
+  let values: {
+    secret?: string
+    env?: string
+    caller?: string
+    reason?: string
+    yes: boolean
+    cache: boolean
+    'no-redact': boolean
+    'skip-doctor': boolean
+  }
+  try {
+    ;({ values } = parseArgs({
+      args: flagArgs,
+      options: {
+        secret: { type: 'string' },
+        env: { type: 'string' },
+        caller: { type: 'string' },
+        reason: { type: 'string' },
+        yes: { type: 'boolean', default: false },
+        cache: { type: 'boolean', default: false },
+        'no-redact': { type: 'boolean', default: false },
+        'skip-doctor': { type: 'boolean', default: false },
+      },
+      strict: true,
+    }))
+  } catch (err) {
+    // Regression: issue #69 — an unrecognized flag previously propagated
+    // uncaught and exited 1 via bin.ts's fatal-error handler instead of the
+    // usage-error exit code 2.
+    if (err instanceof Error) {
+      process.stderr.write(`Error: ${err.message}\n`)
+    }
+    process.stderr.write(
+      'Usage: vaultkeeper exec --secret <name> --env <VAR> --caller <path> [options] -- <command...>\n',
+    )
+    return 2
+  }
 
   const secret = values.secret
   const envVar = values.env
@@ -255,6 +289,19 @@ export async function execCommand(args: string[], configDir: string): Promise<nu
     }
 
     const vault = await VaultKeeper.init({ configDir, skipDoctor })
+
+    // Validate input preconditions (secret existence) BEFORE the trust gate.
+    // The trust gate's non-TTY path fails fast with an approval-required
+    // error, which previously masked a simple "secret not found" — a
+    // nonexistent secret now reports SecretNotFoundError-style messaging
+    // regardless of TTY (issue #69). This check is side-effect-free (unlike
+    // `setup()`, it never touches the TOFU trust manifest), so it cannot be
+    // used to bypass caller approval.
+    if (!(await vault.secretExists(secret))) {
+      throw new SecretNotFoundError(
+        `Secret "${secret}" not found in ${vault.activeBackendType} backend`,
+      )
+    }
 
     // Enforce the trust gate BEFORE touching the cache or retrieving the
     // secret. This runs on every invocation — including a `--cache` hit — so a

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -273,6 +273,27 @@ export async function execCommand(args: string[], configDir: string): Promise<nu
     return 2
   }
 
+  // Reject empty/whitespace-only values with the same exit code and error
+  // style as a missing flag (consistent with store/delete's --name check).
+  // Before this fix each had its own gap:
+  //   --secret ""  -> vault.secretExists() threw VaultError, exit 1
+  //   --caller ""  -> path.resolve('') resolves to cwd, a directory; hashing
+  //                   it threw FilesystemError (EISDIR), exit 1
+  //   --env ""     -> silently succeeded (exit 0): '' is a syntactically
+  //                   valid env var key, so the secret was injected into an
+  //                   unusable key and the wrapped command ran normally —
+  //                   the worst of the three, since it failed silently.
+  if (secret.trim() === '' || envVar.trim() === '' || caller.trim() === '') {
+    process.stderr.write(
+      'Error: --secret, --env, and --caller must not be empty or whitespace-only\n',
+    )
+    process.stderr.write(
+      'Usage: vaultkeeper exec --secret <name> --env <VAR> --caller <path> [options] -- <command...>\n',
+    )
+    // Exit code 2: usage error (invalid flag value)
+    return 2
+  }
+
   const callerPath = path.resolve(caller)
   // parseArgs with default: false types these as boolean (never undefined)
   const useCache: boolean = values.cache

--- a/packages/cli/src/commands/store.ts
+++ b/packages/cli/src/commands/store.ts
@@ -5,11 +5,21 @@ import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 import { configFileExists, noConfigMessage } from '../config-status.js'
 
+/**
+ * Allowed characters for a secret `--name`: letters, digits, `.`, `_`, `-`,
+ * and `/` (for path-like names such as `env/prod/db-password`). This mirrors
+ * `printStoreHelp`'s documented character set (issue #69) — keep both in
+ * sync if it changes. Non-empty is enforced separately by the regex's `+`
+ * quantifier: it never matches an empty string.
+ */
+const SECRET_NAME_PATTERN = /^[A-Za-z0-9._/-]+$/
+
 function printStoreHelp(): void {
   process.stdout.write(
     'Usage: echo "secret" | vaultkeeper store --name <name>\n\n' +
       'Options:\n' +
-      '  --name <name>      Name to store the secret under\n' +
+      '  --name <name>      Name to store the secret under. Must be non-empty\n' +
+      '                     and contain only letters, digits, and . _ - /\n' +
       '  --skip-doctor      Skip doctor preflight checks\n' +
       CONFIG_DIR_HELP_OPTION +
       '  -h, --help         Show this help message\n\n' +
@@ -26,19 +36,45 @@ export async function storeCommand(args: string[], configDir: string): Promise<n
     return 0
   }
 
-  const { values } = parseArgs({
-    args,
-    options: {
-      name: { type: 'string' },
-      'skip-doctor': { type: 'boolean', default: false },
-    },
-    strict: true,
-  })
+  let values: { name?: string; 'skip-doctor': boolean }
+  try {
+    ;({ values } = parseArgs({
+      args,
+      options: {
+        name: { type: 'string' },
+        'skip-doctor': { type: 'boolean', default: false },
+      },
+      strict: true,
+    }))
+  } catch (err) {
+    // An unrecognized flag throws synchronously from parseArgs — convert it
+    // to the same usage-error exit code as a missing/invalid flag value
+    // (regression: issue #69, this previously propagated uncaught and
+    // exited 1 via bin.ts's fatal-error handler instead of 2).
+    if (err instanceof Error) {
+      process.stderr.write(`Error: ${err.message}\n`)
+    }
+    process.stderr.write('Usage: echo "secret" | vaultkeeper store --name <name>\n')
+    return 2
+  }
 
   if (values.name === undefined) {
     process.stderr.write('Error: --name is required\n')
     process.stderr.write('Usage: echo "secret" | vaultkeeper store --name <name>\n')
     // Exit code 2: usage error (missing required flag)
+    return 2
+  }
+
+  // Reject empty/whitespace-only (and otherwise invalid-character) names
+  // with the same exit code and error style as a missing flag — previously
+  // `store --name ""` reached VaultKeeper.store(), which threw a generic
+  // VaultError with exit 1 instead of a usage error (issue #69).
+  if (!SECRET_NAME_PATTERN.test(values.name)) {
+    process.stderr.write(
+      'Error: --name must be non-empty and contain only letters, digits, and . _ - /\n',
+    )
+    process.stderr.write('Usage: echo "secret" | vaultkeeper store --name <name>\n')
+    // Exit code 2: usage error (invalid flag value)
     return 2
   }
 

--- a/packages/cli/test/unit/bin.test.ts
+++ b/packages/cli/test/unit/bin.test.ts
@@ -161,11 +161,56 @@ describe('bin.ts entry point', () => {
       expect(result.exitCode).toBe(0)
       expect(result.stdout).toContain('Usage: vaultkeeper doctor')
     })
+
+    // Regression: issue #69 — 'config init --help' and 'config show --help'
+    // previously printed the parent 'config' help (the top-level --help check
+    // in configCommand ran before subcommand dispatch and matched any --help
+    // anywhere in args).
+    it('should print init-specific usage and exit 0 for config init --help', async () => {
+      const result = await runCli(['config', 'init', '--help'])
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Usage: vaultkeeper config init')
+      expect(result.stdout).not.toContain('Usage: vaultkeeper config <subcommand>')
+    })
+
+    it('should print show-specific usage and exit 0 for config show --help', async () => {
+      const result = await runCli(['config', 'show', '--help'])
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Usage: vaultkeeper config show')
+      expect(result.stdout).not.toContain('Usage: vaultkeeper config <subcommand>')
+    })
+
+    // Issue #69, criterion 5: exec --help includes a worked --caller example.
+    it('should include a worked --caller example in exec --help', async () => {
+      const result = await runCli(['exec', '--help'])
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('Example')
+      expect(result.stdout).toContain('--caller')
+      // The example must show a concrete path, not just the flag description.
+      expect(result.stdout).toMatch(/--caller\s+\.\/[\w.-]+/)
+    })
   })
 
+  // Issue #69, criterion 1: a documented exit-code taxonomy (0/1/2) applied
+  // uniformly. Unknown subcommand, unknown option at any level, missing
+  // required flag, and invalid flag value all exit 2; runtime failures exit 1.
   describe('exit code 2 for usage errors', () => {
     it('should exit 2 for unknown command', async () => {
       const result = await runCli(['unknown-command-xyz'])
+      expect(result.exitCode).toBe(2)
+    })
+
+    // Named regression for issue #69's core repro: a typo'd top-level flag
+    // previously fell through to the "no command given" branch and printed
+    // help with exit 0 — silently breaking scripts that check the exit code.
+    it('should exit 2 for an unknown top-level flag (regression: issue #69, vaultkeeper --bogus previously exited 0)', async () => {
+      const result = await runCli(['--bogus'])
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain("unknown option '--bogus'")
+    })
+
+    it('should exit 2 for an unknown short top-level flag', async () => {
+      const result = await runCli(['-x'])
       expect(result.exitCode).toBe(2)
     })
 
@@ -177,6 +222,76 @@ describe('bin.ts entry point', () => {
     it('should exit 2 for revoke-key with unknown flag', async () => {
       const result = await runCli(['revoke-key', '--bogus'])
       expect(result.exitCode).toBe(2)
+    })
+
+    // Regression: issue #69 — store/delete/exec/approve/dev-mode previously
+    // called parseArgs({ strict: true }) unguarded; an unrecognized flag threw
+    // synchronously and propagated uncaught to bin.ts's fatal-error handler,
+    // which exits 1 instead of the usage-error exit code 2.
+    it('should exit 2 for store with unknown flag', async () => {
+      const result = await runCli(['store', '--bogus', 'x'])
+      expect(result.exitCode).toBe(2)
+    })
+
+    it('should exit 2 for delete with unknown flag', async () => {
+      const result = await runCli(['delete', '--bogus', 'x'])
+      expect(result.exitCode).toBe(2)
+    })
+
+    it('should exit 2 for exec with unknown flag', async () => {
+      const result = await runCli(['exec', '--bogus', 'x', '--', 'echo', 'hi'])
+      expect(result.exitCode).toBe(2)
+    })
+
+    it('should exit 2 for approve with unknown flag', async () => {
+      const result = await runCli(['approve', '--bogus', 'x'])
+      expect(result.exitCode).toBe(2)
+    })
+
+    it('should exit 2 for dev-mode with unknown flag', async () => {
+      const result = await runCli(['dev-mode', 'enable', '--bogus', 'x'])
+      expect(result.exitCode).toBe(2)
+    })
+
+    // Regression: issue #69 — doctor never parsed its own args, so any
+    // unrecognized flag was silently ignored and the real checks ran,
+    // potentially exiting 0 for a typo'd flag.
+    it('should exit 2 for doctor with unknown flag', async () => {
+      const result = await runCli(['doctor', '--bogus'])
+      expect(result.exitCode).toBe(2)
+    })
+
+    it('should exit 2 for config init with unknown flag', async () => {
+      const result = await runCli(['config', 'init', '--bogus'])
+      expect(result.exitCode).toBe(2)
+    })
+
+    it('should exit 2 for config show with unknown flag', async () => {
+      const result = await runCli(['config', 'show', '--bogus'])
+      expect(result.exitCode).toBe(2)
+    })
+  })
+
+  // Issue #69, criterion 2: store rejects empty/whitespace-only --name with
+  // exit 2 and the same error style as a missing flag. Safe to test without
+  // an isolated config dir — the check runs before any backend I/O.
+  describe('store --name validation', () => {
+    it('should exit 2 for an empty --name, not silently succeed', async () => {
+      const result = await runCli(['store', '--name', '', '--skip-doctor'])
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain('--name must be non-empty')
+    })
+
+    it('should exit 2 for a whitespace-only --name', async () => {
+      const result = await runCli(['store', '--name', '   ', '--skip-doctor'])
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain('--name must be non-empty')
+    })
+
+    it('should document allowed --name characters in --help', async () => {
+      const result = await runCli(['store', '--help'])
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toMatch(/letters, digits/)
     })
   })
 })

--- a/packages/cli/test/unit/bin.test.ts
+++ b/packages/cli/test/unit/bin.test.ts
@@ -294,4 +294,66 @@ describe('bin.ts entry point', () => {
       expect(result.stdout).toMatch(/letters, digits/)
     })
   })
+
+  // Regression (PR #95 review): exec's --secret/--env/--caller each had a
+  // different, wrong exit code for an empty value — --secret exited 1 (a
+  // VaultError from deep inside the vault), --caller exited 1 (a
+  // FilesystemError from resolving '' to the current directory), and --env
+  // exited 0 (silently injected the secret into an unusable '' env key and
+  // ran the wrapped command anyway). All three must now exit 2, consistent
+  // with store/delete's --name validation.
+  describe('exec flag value validation', () => {
+    it('should exit 2 for an empty --secret, not the deep VaultError exit 1', async () => {
+      const result = await runCli([
+        'exec',
+        '--secret',
+        '',
+        '--env',
+        'FOO',
+        '--caller',
+        './x',
+        '--skip-doctor',
+        '--',
+        'echo',
+        'hi',
+      ])
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain('must not be empty or whitespace-only')
+    })
+
+    it('should exit 2 for an empty --env, not silently succeed', async () => {
+      const result = await runCli([
+        'exec',
+        '--secret',
+        'my-key',
+        '--env',
+        '',
+        '--caller',
+        './x',
+        '--skip-doctor',
+        '--',
+        'echo',
+        'hi',
+      ])
+      expect(result.exitCode).toBe(2)
+      expect(result.stdout).not.toContain('hi')
+    })
+
+    it('should exit 2 for an empty --caller, not the deep FilesystemError exit 1', async () => {
+      const result = await runCli([
+        'exec',
+        '--secret',
+        'my-key',
+        '--env',
+        'FOO',
+        '--caller',
+        '',
+        '--skip-doctor',
+        '--',
+        'echo',
+        'hi',
+      ])
+      expect(result.exitCode).toBe(2)
+    })
+  })
 })

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -60,6 +60,8 @@ function pendingVaultMock(): {
   setup: ReturnType<typeof vi.fn>
   authorize: ReturnType<typeof vi.fn>
   getSecret: ReturnType<typeof vi.fn>
+  secretExists: ReturnType<typeof vi.fn>
+  activeBackendType: string
 } {
   return {
     checkExecutableTrust: vi.fn().mockResolvedValue({
@@ -72,6 +74,11 @@ function pendingVaultMock(): {
     setup: vi.fn(),
     authorize: vi.fn(),
     getSecret: vi.fn(),
+    // issue #69: execCommand now checks secret existence before the trust
+    // gate. Defaulting to true keeps every existing trust-gate test
+    // exercising the gate itself, not this precondition.
+    secretExists: vi.fn().mockResolvedValue(true),
+    activeBackendType: 'file',
   }
 }
 
@@ -371,7 +378,15 @@ describe('execCommand', () => {
         approvedHashes: ['oldhash'],
         reason: 'changed',
       })
-      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      mockInit.mockResolvedValue({
+        checkExecutableTrust,
+        setup,
+        authorize,
+        getSecret,
+        // issue #69: execCommand checks secret existence before the trust gate.
+        secretExists: vi.fn().mockResolvedValue(true),
+        activeBackendType: 'file',
+      })
 
       const code = await execCommand(EXEC_ARGS, configDir)
 
@@ -406,7 +421,15 @@ describe('execCommand', () => {
         approvedHashes: ['oldhash'],
         reason: 'changed',
       })
-      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      mockInit.mockResolvedValue({
+        checkExecutableTrust,
+        setup,
+        authorize,
+        getSecret,
+        // issue #69: execCommand checks secret existence before the trust gate.
+        secretExists: vi.fn().mockResolvedValue(true),
+        activeBackendType: 'file',
+      })
       // A previously cached token exists — but the gate must run before it is used.
       vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')
 
@@ -436,7 +459,15 @@ describe('execCommand', () => {
         approvedHashes: ['goodhash'],
         reason: 'trusted',
       })
-      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      mockInit.mockResolvedValue({
+        checkExecutableTrust,
+        setup,
+        authorize,
+        getSecret,
+        // issue #69: execCommand checks secret existence before the trust gate.
+        secretExists: vi.fn().mockResolvedValue(true),
+        activeBackendType: 'file',
+      })
       vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')
 
       const code = await execCommand(['--cache', ...EXEC_ARGS], configDir)
@@ -466,7 +497,15 @@ describe('execCommand', () => {
         approvedHashes: [],
         reason: 'Executable not yet approved',
       })
-      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      mockInit.mockResolvedValue({
+        checkExecutableTrust,
+        setup,
+        authorize,
+        getSecret,
+        // issue #69: execCommand checks secret existence before the trust gate.
+        secretExists: vi.fn().mockResolvedValue(true),
+        activeBackendType: 'file',
+      })
 
       const code = await execCommand(['--yes', ...EXEC_ARGS], configDir)
 
@@ -495,7 +534,15 @@ describe('execCommand', () => {
         approvedHashes: [],
         reason: 'Executable not yet approved',
       })
-      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      mockInit.mockResolvedValue({
+        checkExecutableTrust,
+        setup,
+        authorize,
+        getSecret,
+        // issue #69: execCommand checks secret existence before the trust gate.
+        secretExists: vi.fn().mockResolvedValue(true),
+        activeBackendType: 'file',
+      })
 
       const code = await execCommand(EXEC_ARGS, configDir)
 
@@ -524,7 +571,15 @@ describe('execCommand', () => {
         approvedHashes: [],
         reason: 'Executable not yet approved',
       })
-      mockInit.mockResolvedValue({ checkExecutableTrust, setup, authorize, getSecret })
+      mockInit.mockResolvedValue({
+        checkExecutableTrust,
+        setup,
+        authorize,
+        getSecret,
+        // issue #69: execCommand checks secret existence before the trust gate.
+        secretExists: vi.fn().mockResolvedValue(true),
+        activeBackendType: 'file',
+      })
       // A stale cached token exists — it must NOT be read or used for a caller
       // that is only being approved this run.
       vi.mocked(readCachedToken).mockResolvedValueOnce('cached.jwe.token')

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -204,6 +204,70 @@ describe('execCommand', () => {
     })
   })
 
+  // Regression (PR #95 review): an empty/whitespace-only value for --secret,
+  // --env, or --caller previously exited inconsistently — --secret hit
+  // vault.secretExists()'s VaultError (exit 1), --caller hit a FilesystemError
+  // resolving to cwd (exit 1), and --env silently succeeded (exit 0, secret
+  // injected into an unusable '' env key). All three must now exit 2 with a
+  // usage-style message, matching store/delete's --name validation, and must
+  // never reach VaultKeeper.init() (an empty flag value is caught before any
+  // backend/vault interaction).
+  describe('empty/whitespace flag value validation', () => {
+    it('should return 2 for an empty --secret', async () => {
+      const code = await execCommand(
+        ['--secret', '', '--env', 'MY_VAR', '--caller', '/path/to/script.sh', '--', 'echo', 'hi'],
+        configDir,
+      )
+      expect(code).toBe(2)
+      expect(stderrOutput).toContain('must not be empty or whitespace-only')
+      expect(mockInit).not.toHaveBeenCalled()
+    })
+
+    it('should return 2 for a whitespace-only --secret', async () => {
+      const code = await execCommand(
+        [
+          '--secret',
+          '   ',
+          '--env',
+          'MY_VAR',
+          '--caller',
+          '/path/to/script.sh',
+          '--',
+          'echo',
+          'hi',
+        ],
+        configDir,
+      )
+      expect(code).toBe(2)
+    })
+
+    it('should return 2 for an empty --env', async () => {
+      const code = await execCommand(
+        ['--secret', 'my-key', '--env', '', '--caller', '/path/to/script.sh', '--', 'echo', 'hi'],
+        configDir,
+      )
+      expect(code).toBe(2)
+      expect(mockInit).not.toHaveBeenCalled()
+    })
+
+    it('should return 2 for an empty --caller', async () => {
+      const code = await execCommand(
+        ['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '', '--', 'echo', 'hi'],
+        configDir,
+      )
+      expect(code).toBe(2)
+      expect(mockInit).not.toHaveBeenCalled()
+    })
+
+    it('should return 2 for a whitespace-only --caller', async () => {
+      const code = await execCommand(
+        ['--secret', 'my-key', '--env', 'MY_VAR', '--caller', '   ', '--', 'echo', 'hi'],
+        configDir,
+      )
+      expect(code).toBe(2)
+    })
+  })
+
   describe('--skip-doctor flag', () => {
     // These drive the full command with a never-approved (pending) caller under
     // a simulated TTY, so the trust gate reaches promptApproval (mocked to

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -368,6 +368,7 @@ export class VaultKeeper {
     static init(options?: VaultKeeperOptions): Promise<VaultKeeper>;
     revokeKey(): Promise<void>;
     rotateKey(): Promise<void>;
+    secretExists(name: string): Promise<boolean>;
     setDevelopmentMode(executablePath: string, enabled: boolean): Promise<void>;
     setup(secretName: string, options?: SetupOptions): Promise<string>;
     sign(token: CapabilityToken, request: SignRequest): Promise<{

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -352,6 +352,26 @@ export class VaultKeeper {
   }
 
   /**
+   * Check whether a secret exists in the active backend, without retrieving
+   * its value, minting a token, or touching the TOFU trust manifest.
+   *
+   * @remarks
+   * This is a lightweight precondition check intended to run before any
+   * interactive or trust-gating logic (e.g. `exec`'s caller-approval prompt),
+   * so a nonexistent secret is reported immediately and unambiguously instead
+   * of being masked by an unrelated approval failure — see issue #69.
+   *
+   * @param name - Identifier for the secret.
+   * @returns `true` if the secret exists, `false` otherwise.
+   * @public
+   */
+  async secretExists(name: string): Promise<boolean> {
+    VaultKeeper.#validateSecretName(name)
+    const backend = this.#requireBackend()
+    return backend.exists(name)
+  }
+
+  /**
    * Read a stored secret from the backend and mint a JWE token that encapsulates it.
    *
    * @param secretName - Identifier for the secret

--- a/packages/vaultkeeper/test/unit/vault.test.ts
+++ b/packages/vaultkeeper/test/unit/vault.test.ts
@@ -511,6 +511,44 @@ describe('VaultKeeper', () => {
     })
   })
 
+  // secretExists() backs the CLI's issue #69 fix: exec validates secret
+  // existence BEFORE the interactivity/TTY gate, so it needs a way to check
+  // existence without minting a token or touching the TOFU trust manifest.
+  describe('secretExists', () => {
+    it('should return true when the secret exists', async () => {
+      const vault = await initVault({ 'my-secret': 'hunter2' })
+      await expect(vault.secretExists('my-secret')).resolves.toBe(true)
+    })
+
+    it('should return false when the secret does not exist', async () => {
+      const vault = await initVault({ 'my-secret': 'hunter2' })
+      await expect(vault.secretExists('nonexistent')).resolves.toBe(false)
+    })
+
+    it('should delegate to the active backend without retrieving the value', async () => {
+      const existsSpy = vi.fn(() => Promise.resolve(true))
+      const retrieveSpy = vi.fn(() => Promise.reject(new Error('should not be called')))
+      const backend = createMockBackend({ 'my-secret': 'hunter2' })
+      backend.exists = existsSpy
+      backend.retrieve = retrieveSpy
+      BackendRegistry.register('test', () => backend)
+
+      const vault = await VaultKeeper.init({
+        skipDoctor: true,
+        config: testConfig(),
+        configDir: '/tmp/vaultkeeper-test',
+      })
+      await vault.secretExists('my-secret')
+      expect(existsSpy).toHaveBeenCalledWith('my-secret')
+      expect(retrieveSpy).not.toHaveBeenCalled()
+    })
+
+    it('should reject an empty name, same as store/delete', async () => {
+      const vault = await initVault()
+      await expect(vault.secretExists('')).rejects.toThrow('Secret name must not be empty')
+    })
+  })
+
   describe('negative cases', () => {
     it('should reject authorize with corrupted JWE', async () => {
       const vault = await initVault()


### PR DESCRIPTION
## Summary

Refs #69

1. Applies the documented exit-code taxonomy (0 success / 1 runtime failure / 2 usage error) uniformly across every command. A top-level typo (`vaultkeeper --bogus`) previously fell into the "no command given" branch and exited 0; `store`/`delete`/`exec`/`approve`/`dev-mode` called `parseArgs({ strict: true })` unguarded, so an unrecognized flag threw uncaught and exited 1 via `bin.ts`'s fatal-error handler; `doctor` never parsed its own args at all and silently ignored any flag. All of these now exit 2, matching the missing-flag/unknown-subcommand convention already used elsewhere (`rotate-key`/`revoke-key` already did this correctly — replicated their try/catch pattern).
2. `store` (and `delete`, for consistency) reject an empty or whitespace-only `--name` with exit 2 and the same error style as a missing flag. Previously `store --name ""` reached `VaultKeeper.store()`, which threw a generic `VaultError` with exit 1 — a usage mistake reported as a runtime failure. Allowed `--name` characters (letters, digits, `.`, `_`, `-`, `/`) are documented in `--help`.
3. `exec` now validates that the secret exists **before** the caller-approval/TTY gate. This is backed by a new public, side-effect-free `VaultKeeper.secretExists(name)` — it delegates to the backend's `exists()` and never touches the TOFU trust manifest (unlike `setup()`, which records trust as a side effect), so it cannot be used to bypass caller approval. A nonexistent secret now reports `SecretNotFoundError`-style messaging regardless of TTY, instead of being masked by the generic "requires interactive approval, but stdin is not a TTY" message.
4. `config init --help` / `config show --help` now print that subcommand's help. Previously `configCommand` checked `args.includes('--help')` before subcommand dispatch, so any `--help` anywhere in the args matched and printed the parent `config` help.
5. `exec --help` gains a worked `--caller` example showing the caller/wrapped-command distinction.

## Before / after exit-code table

| Command | Before | After |
|---|---|---|
| `vaultkeeper --bogus` | `0` (prints help) | `2` |
| `vaultkeeper store --bogus x` | `1` (uncaught fatal) | `2` |
| `vaultkeeper delete --bogus x` | `1` (uncaught fatal) | `2` |
| `vaultkeeper exec --bogus x -- echo hi` | `1` (uncaught fatal) | `2` |
| `vaultkeeper approve --bogus x` | `1` (uncaught fatal) | `2` |
| `vaultkeeper dev-mode enable --bogus x` | `1` (uncaught fatal) | `2` |
| `vaultkeeper doctor --bogus` | `0` (flag silently ignored, real checks ran) | `2` |
| `vaultkeeper store --name ""` | `1` (generic `VaultError`) | `2` |
| `vaultkeeper store --name "   "` | `1` (generic `VaultError`) | `2` |
| `vaultkeeper config init --help` | `0`, prints parent `config` help | `0`, prints `config init` help |
| `vaultkeeper config show --help` | `0`, prints parent `config` help | `0`, prints `config show` help |
| `vaultkeeper exec --secret nonexistent ... </dev/null` | `1`, "requires approval, but stdin is not a TTY" | `1`, `SecretNotFoundError: Secret "nonexistent" not found in <backend> backend` |
| `vaultkeeper rotate-key --bogus` / `revoke-key --bogus` | `2` (already correct) | `2` (unchanged) |

## New public API

`VaultKeeper.secretExists(name: string): Promise<boolean>` — changeset included, API report regenerated.

## Test plan

- [x] `packages/cli/test/unit/bin.test.ts`: extended subprocess coverage — unknown top-level/per-command flags (named regression for the `--bogus` exit-0 case), `store --name` empty/whitespace validation, `config init`/`config show` subcommand-specific `--help`, `exec --help`'s `--caller` example
- [x] `packages/cli/test/unit/commands/exec.test.ts`: mocks updated for the new `secretExists`/`activeBackendType` calls; all existing trust-gate tests still pass unmodified in behavior
- [x] `packages/vaultkeeper/test/unit/vault.test.ts`: `secretExists()` unit coverage (true/false/delegates-without-retrieving/rejects-empty-name)
- [x] `packages/cli-tests/test/e2e/argument-validation.test.ts`: subprocess regression for empty/whitespace `--name` on `store`/`delete`
- [x] `packages/cli-tests/test/e2e/exec.test.ts`: subprocess regression for secret-existence-before-TTY-gate, for both a never-approved and an already-trusted caller
- [x] `pnpm check` (typecheck + lint + API report) green
- [x] `pnpm test` green across all packages (643 vaultkeeper, 230 CLI, 100 cli-tests — 25 conformance tests skipped, no Rust binary in this env)