### PR TITLE
Add config init --force to recover from a corrupt config

### DIFF
--- a/.changeset/config-init-force-recovery.md
+++ b/.changeset/config-init-force-recovery.md
@@ -1,0 +1,9 @@
+---
+'vaultkeeper': patch
+'@vaultkeeper/cli': patch
+---
+
+Add a supported recovery path for a corrupt or unreadable `config.json`.
+
+- `vaultkeeper config init --force` now overwrites an existing config file, including one that's present-but-unparseable. `config init` without `--force` keeps its current non-destructive refusal, and now points at `config init --force` in its refusal message. `--force` composes with `--backend` (e.g. `config init --force --backend file`).
+- `ConfigParseError` (and the other `loadConfig` errors sharing its remediation hint) now names `vaultkeeper config init --force` instead of `vaultkeeper config init` — the previous hint sent users to a command that provably failed in the exact state that produced the error.

--- a/docs/api/vaultkeeper.loadconfig.md
+++ b/docs/api/vaultkeeper.loadconfig.md
@@ -6,7 +6,7 @@
 
 Load the vaultkeeper config from disk, falling back to platform defaults only when the config file is missing (`ENOENT`<!-- -->).
 
-Any other read failure (e.g. `EACCES`<!-- -->, `EISDIR`<!-- -->) is a genuinely broken or unreadable config and is rethrown as a [FilesystemError](./vaultkeeper.filesystemerror.md) rather than silently defaulted — silently defaulting on a permissions error would hide the problem from `doctor` and `config show` (issue \#68). A present file that fails to parse as JSON throws [ConfigParseError](./vaultkeeper.configparseerror.md)<!-- -->; a present file that parses but fails schema validation throws [ConfigValidationError](./vaultkeeper.configvalidationerror.md)<!-- -->. All three error messages include the config file path and a remediation hint naming `vaultkeeper config init`<!-- -->.
+Any other read failure (e.g. `EACCES`<!-- -->, `EISDIR`<!-- -->) is a genuinely broken or unreadable config and is rethrown as a [FilesystemError](./vaultkeeper.filesystemerror.md) rather than silently defaulted — silently defaulting on a permissions error would hide the problem from `doctor` and `config show` (issue \#68). A present file that fails to parse as JSON throws [ConfigParseError](./vaultkeeper.configparseerror.md)<!-- -->; a present file that parses but fails schema validation throws [ConfigValidationError](./vaultkeeper.configvalidationerror.md)<!-- -->. All three error messages include the config file path and a remediation hint naming `vaultkeeper config init --force`<!-- -->, the supported recovery path for an existing-but-broken config (issue \#97).
 
 **Signature:**
 

--- a/docs/api/vaultkeeper.md
+++ b/docs/api/vaultkeeper.md
@@ -370,7 +370,7 @@ Type guard for backends that support listing.
 
 Load the vaultkeeper config from disk, falling back to platform defaults only when the config file is missing (`ENOENT`<!-- -->).
 
-Any other read failure (e.g. `EACCES`<!-- -->, `EISDIR`<!-- -->) is a genuinely broken or unreadable config and is rethrown as a [FilesystemError](./vaultkeeper.filesystemerror.md) rather than silently defaulted — silently defaulting on a permissions error would hide the problem from `doctor` and `config show` (issue \#68). A present file that fails to parse as JSON throws [ConfigParseError](./vaultkeeper.configparseerror.md)<!-- -->; a present file that parses but fails schema validation throws [ConfigValidationError](./vaultkeeper.configvalidationerror.md)<!-- -->. All three error messages include the config file path and a remediation hint naming `vaultkeeper config init`<!-- -->.
+Any other read failure (e.g. `EACCES`<!-- -->, `EISDIR`<!-- -->) is a genuinely broken or unreadable config and is rethrown as a [FilesystemError](./vaultkeeper.filesystemerror.md) rather than silently defaulted — silently defaulting on a permissions error would hide the problem from `doctor` and `config show` (issue \#68). A present file that fails to parse as JSON throws [ConfigParseError](./vaultkeeper.configparseerror.md)<!-- -->; a present file that parses but fails schema validation throws [ConfigValidationError](./vaultkeeper.configvalidationerror.md)<!-- -->. All three error messages include the config file path and a remediation hint naming `vaultkeeper config init --force`<!-- -->, the supported recovery path for an existing-but-broken config (issue \#97).
 
 
 </td></tr>

--- a/packages/cli-tests/test/e2e/config.test.ts
+++ b/packages/cli-tests/test/e2e/config.test.ts
@@ -280,5 +280,24 @@ describe('config command', () => {
       const recover = await env.run(['config', 'init', '--force'])
       expect(recover.exitCode).toBe(0)
     })
+
+    // Criterion 3, ConfigValidationError variant: structurally valid JSON
+    // that fails schema validation shares the same remediation hint as
+    // ConfigParseError, so it must also name the working recovery command.
+    it('should have ConfigValidationError name the working recovery command (regression: issue #97)', async () => {
+      env = await createCliTestEnv()
+      await fs.writeFile(
+        path.join(env.configDir, 'config.json'),
+        JSON.stringify({ version: 99 }),
+        'utf8',
+      )
+      const result = await env.run(['config', 'show'])
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('vaultkeeper config init --force')
+
+      // And that named command must actually succeed from this exact state.
+      const recover = await env.run(['config', 'init', '--force'])
+      expect(recover.exitCode).toBe(0)
+    })
   })
 })

--- a/packages/cli-tests/test/e2e/config.test.ts
+++ b/packages/cli-tests/test/e2e/config.test.ts
@@ -202,4 +202,83 @@ describe('config command', () => {
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('Usage: vaultkeeper config')
   })
+
+  // Issue #97: a corrupt config.json previously had no CLI recovery path —
+  // `config init` refused to overwrite it, so the error's own remediation
+  // ("run config init") was a dead end. `config init --force` is the
+  // supported recovery command; this exercises the full corrupt -> recover
+  // -> show flow end-to-end.
+  describe('config init --force recovery (issue #97)', () => {
+    it('should refuse to overwrite an existing config without --force (regression: issue #97 dead-end remediation)', async () => {
+      env = await createCliTestEnv()
+      const result = await env.run(['config', 'init'])
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('already exists')
+      // The refusal itself must point at the working recovery command.
+      expect(result.stderr).toContain('vaultkeeper config init --force')
+    })
+
+    it('should recover from a corrupt config.json via config init --force, then config show succeeds (issue #97 repro)', async () => {
+      env = await createCliTestEnv()
+      await fs.writeFile(path.join(env.configDir, 'config.json'), '{ not valid json', 'utf8')
+
+      // Confirm the corruption is detected first (issue #68 behavior).
+      const broken = await env.run(['config', 'show'])
+      expect(broken.exitCode).not.toBe(0)
+
+      // The documented recovery command succeeds over the corrupt file.
+      const recover = await env.run(['config', 'init', '--force'])
+      expect(recover.exitCode).toBe(0)
+      expect(recover.stdout).toContain('Config created at')
+
+      // And config show now succeeds against the recovered config.
+      const recovered = await env.run(['config', 'show'])
+      expect(recovered.exitCode).toBe(0)
+      const parsed: unknown = JSON.parse(recovered.stdout)
+      expect(parsed).toHaveProperty('version', 1)
+    })
+
+    it('should overwrite a valid existing config with config init --force', async () => {
+      env = await createCliTestEnv()
+      const before = await readConfig(env.configDir)
+      expect(before).toHaveProperty('backends[0].type', 'file')
+
+      const result = await env.run([
+        'config',
+        'init',
+        '--force',
+        '--backend',
+        platformDefaultBackend,
+      ])
+      expect(result.exitCode).toBe(0)
+      const after = await readConfig(env.configDir)
+      expect(after).toHaveProperty('backends[0].type', platformDefaultBackend)
+    })
+
+    // Criterion 4: --backend interaction is preserved under --force.
+    it('should honor --backend when combined with --force (config init --force --backend file)', async () => {
+      env = await createCliTestEnv()
+      await fs.writeFile(path.join(env.configDir, 'config.json'), '{ still not valid json', 'utf8')
+
+      const result = await env.run(['config', 'init', '--force', '--backend', 'file'])
+      expect(result.exitCode).toBe(0)
+      const parsed = await readConfig(env.configDir)
+      expect(parsed).toHaveProperty('backends[0].type', 'file')
+      expect(result.stdout).toContain('Backend: file')
+    })
+
+    // Criterion 3: ConfigParseError's remediation text names a command that
+    // actually works in the state that produced the error.
+    it('should have ConfigParseError name the working recovery command (regression: issue #97)', async () => {
+      env = await createCliTestEnv()
+      await fs.writeFile(path.join(env.configDir, 'config.json'), '{ bad json', 'utf8')
+      const result = await env.run(['config', 'show'])
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('vaultkeeper config init --force')
+
+      // And that named command must actually succeed from this exact state.
+      const recover = await env.run(['config', 'init', '--force'])
+      expect(recover.exitCode).toBe(0)
+    })
+  })
 })

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -176,17 +176,16 @@ async function configInit(rest: string[], configDir: string): Promise<number> {
     // Create config directory with restrictive permissions.
     await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
 
-    if (!force) {
-      try {
-        await fs.access(configPath)
-        process.stderr.write(
-          `Config already exists at ${configPath}\n` +
-            "Run 'vaultkeeper config init --force' to overwrite it.\n",
-        )
-        return 1
-      } catch {
-        // File doesn't exist — create it.
-      }
+    // Only a genuinely missing file (ENOENT, via configFileExists) is safe to
+    // proceed over; any other access failure (e.g. EACCES) is a real problem
+    // and must not be swallowed into "doesn't exist, create it" — that could
+    // silently attempt to overwrite a file in an unusual permission state.
+    if (!force && (await configFileExists(configDir))) {
+      process.stderr.write(
+        `Config already exists at ${configPath}\n` +
+          "Run 'vaultkeeper config init --force' to overwrite it.\n",
+      )
+      return 1
     }
 
     await fs.writeFile(configPath, buildConfig(backendType) + '\n', {

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -91,7 +91,8 @@ function printConfigHelp(): void {
       '  show   Print the current config file\n\n' +
       'Options for init:\n' +
       '  --backend <type>   Backend to configure as the active store\n' +
-      `                     (valid: ${BackendRegistry.getTypes().join(', ')})\n\n` +
+      `                     (valid: ${BackendRegistry.getTypes().join(', ')})\n` +
+      '  --force            Overwrite an existing (or corrupt) config file\n\n' +
       'Options:\n' +
       CONFIG_DIR_HELP_OPTION +
       '  -h, --help   Show this help message\n\n' +
@@ -103,11 +104,13 @@ function printConfigHelp(): void {
 
 function printConfigInitHelp(): void {
   process.stdout.write(
-    'Usage: vaultkeeper config init [--backend <type>]\n\n' +
+    'Usage: vaultkeeper config init [--backend <type>] [--force]\n\n' +
       'Create a default config file.\n\n' +
       'Options:\n' +
       '  --backend <type>   Backend to configure as the active store\n' +
       `                     (valid: ${BackendRegistry.getTypes().join(', ')})\n` +
+      '  --force            Overwrite an existing (or corrupt/unparseable)\n' +
+      '                     config file instead of refusing\n' +
       CONFIG_DIR_HELP_OPTION +
       '  -h, --help         Show this help message\n\n' +
       'Environment variables:\n' +
@@ -136,7 +139,7 @@ async function configInit(rest: string[], configDir: string): Promise<number> {
     return 0
   }
 
-  const unknownFlag = findUnknownFlag(rest, new Set(['backend']))
+  const unknownFlag = findUnknownFlag(rest, new Set(['backend', 'force']))
   if (unknownFlag !== undefined) {
     process.stderr.write(`Error: unknown option '${unknownFlag}' for 'config init'\n`)
     return 2
@@ -144,10 +147,11 @@ async function configInit(rest: string[], configDir: string): Promise<number> {
 
   const { values } = parseArgs({
     args: rest,
-    options: { backend: { type: 'string' } },
+    options: { backend: { type: 'string' }, force: { type: 'boolean' } },
     allowPositionals: true,
     strict: false,
   })
+  const force = values.force === true
 
   let requestedBackend: string | undefined
   if (values.backend !== undefined) {
@@ -172,12 +176,17 @@ async function configInit(rest: string[], configDir: string): Promise<number> {
     // Create config directory with restrictive permissions.
     await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
 
-    try {
-      await fs.access(configPath)
-      process.stderr.write(`Config already exists at ${configPath}\n`)
-      return 1
-    } catch {
-      // File doesn't exist — create it.
+    if (!force) {
+      try {
+        await fs.access(configPath)
+        process.stderr.write(
+          `Config already exists at ${configPath}\n` +
+            "Run 'vaultkeeper config init --force' to overwrite it.\n",
+        )
+        return 1
+      } catch {
+        // File doesn't exist — create it.
+      }
     }
 
     await fs.writeFile(configPath, buildConfig(backendType) + '\n', {

--- a/packages/cli/test/unit/commands/config-init-access-error.test.ts
+++ b/packages/cli/test/unit/commands/config-init-access-error.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+// This suite needs a mocked node:fs/promises so it can force fs.access to
+// fail with a non-ENOENT code (EACCES) without depending on real filesystem
+// permission behavior, which is unreliable across platforms/CI users (e.g.
+// root bypasses permission bits). All other config.test.ts suites use the
+// real filesystem via temp dirs; this one is isolated in its own file so the
+// mock doesn't leak into those.
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  return {
+    ...actual,
+    access: vi.fn(),
+    writeFile: vi.fn(actual.writeFile),
+  }
+})
+
+const { access, writeFile, mkdtemp, rm } = await import('node:fs/promises')
+const { configCommand } = await import('../../../src/commands/config.js')
+
+/** Build a Node.js-shaped filesystem error with a `code` (e.g. 'EACCES'). */
+function fsError(code: string, message: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(message), { code })
+}
+
+describe('config init: non-ENOENT access errors (regression: PR #105 review)', () => {
+  let tempDir: string
+  let configDir: string
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'vaultkeeper-config-init-access-test-'))
+    configDir = path.join(tempDir, '.config', 'vaultkeeper')
+  })
+
+  afterEach(async () => {
+    vi.mocked(access).mockReset()
+    vi.mocked(writeFile).mockClear()
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  // Before this fix, configInit's existence check treated ANY fs.access
+  // failure (not just ENOENT) as "file doesn't exist", so an EACCES on the
+  // config path would be silently swallowed and init would proceed to
+  // writeFile — a less-direct failure mode that could attempt to overwrite
+  // a file in an unusual permission state. It must now rethrow non-ENOENT
+  // errors and never reach writeFile.
+  it('rethrows an EACCES access error instead of proceeding to writeFile', async () => {
+    vi.mocked(access).mockRejectedValue(fsError('EACCES', 'permission denied'))
+
+    const code = await configCommand(['init'], configDir)
+
+    expect(code).toBe(1)
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled()
+  })
+
+  it('does not swallow an EPERM access error either', async () => {
+    vi.mocked(access).mockRejectedValue(fsError('EPERM', 'operation not permitted'))
+
+    const code = await configCommand(['init'], configDir)
+
+    expect(code).toBe(1)
+    expect(vi.mocked(writeFile)).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/test/unit/commands/config.test.ts
+++ b/packages/cli/test/unit/commands/config.test.ts
@@ -90,6 +90,10 @@ describe('configCommand', () => {
     it('should overwrite an existing config with --force and return 0', async () => {
       const { configCommand } = await import('../../../src/commands/config.js')
       await configCommand(['init'], configDir)
+      // Reset the captured buffer so this assertion validates only the
+      // forced init's own output, not output accumulated from the first
+      // (unforced) init above.
+      stdoutOutput = ''
       const code = await configCommand(['init', '--force'], configDir)
       expect(code).toBe(0)
       expect(stdoutOutput).toContain('Config created at')

--- a/packages/cli/test/unit/commands/config.test.ts
+++ b/packages/cli/test/unit/commands/config.test.ts
@@ -70,6 +70,58 @@ describe('configCommand', () => {
       await configCommand(['init'], configDir)
       expect(stderrOutput).toContain('Config already exists at')
     })
+
+    // Issue #97: without --force, config init must keep its current
+    // non-destructive refusal even though --force now exists as an option.
+    it('should still refuse without --force even after a prior successful init (regression: issue #97)', async () => {
+      const { configCommand } = await import('../../../src/commands/config.js')
+      await configCommand(['init'], configDir)
+      const configPath = path.join(configDir, 'config.json')
+      const before = await fs.readFile(configPath, 'utf8')
+
+      const code = await configCommand(['init'], configDir)
+
+      expect(code).toBe(1)
+      const after = await fs.readFile(configPath, 'utf8')
+      expect(after).toBe(before)
+    })
+
+    // Issue #97: config init --force overwrites an existing valid config.
+    it('should overwrite an existing config with --force and return 0', async () => {
+      const { configCommand } = await import('../../../src/commands/config.js')
+      await configCommand(['init'], configDir)
+      const code = await configCommand(['init', '--force'], configDir)
+      expect(code).toBe(0)
+      expect(stdoutOutput).toContain('Config created at')
+    })
+
+    // Issue #97 repro: config init --force recovers from a corrupt config.json.
+    it('should overwrite a corrupt/unparseable config.json with --force and return 0 (issue #97 repro)', async () => {
+      const { configCommand } = await import('../../../src/commands/config.js')
+      await fs.mkdir(configDir, { recursive: true })
+      const configPath = path.join(configDir, 'config.json')
+      await fs.writeFile(configPath, '{ not valid json', 'utf8')
+
+      const code = await configCommand(['init', '--force'], configDir)
+
+      expect(code).toBe(0)
+      const content = await fs.readFile(configPath, 'utf8')
+      const parsed: unknown = JSON.parse(content)
+      expect(parsed).toMatchObject({ version: 1 })
+    })
+
+    // Issue #97 acceptance criterion 4: --backend interaction preserved
+    // under --force.
+    it('should honor --backend when combined with --force', async () => {
+      const { configCommand } = await import('../../../src/commands/config.js')
+      await configCommand(['init'], configDir)
+      const code = await configCommand(['init', '--force', '--backend', 'file'], configDir)
+      expect(code).toBe(0)
+      const configPath = path.join(configDir, 'config.json')
+      const content = await fs.readFile(configPath, 'utf8')
+      const parsed: unknown = JSON.parse(content)
+      expect(parsed).toMatchObject({ backends: [{ type: 'file', enabled: true }] })
+    })
   })
 
   describe('show subcommand', () => {

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -13,7 +13,8 @@ import { ConfigValidationError, ConfigParseError, FilesystemError } from './erro
  * always has a concrete next step, regardless of whether the failure was a
  * read error, a JSON syntax error, or a schema validation error (issue #68).
  */
-const CONFIG_REMEDIATION_HINT = "Run 'vaultkeeper config init' to create a valid config."
+const CONFIG_REMEDIATION_HINT =
+  "Fix the file, or run 'vaultkeeper config init --force' to overwrite it with a valid config."
 
 /** `true` if `err` is a Node.js filesystem error with the given `code`. */
 function hasErrorCode(err: unknown, code: string): boolean {
@@ -303,7 +304,8 @@ export function validateConfig(config: unknown): VaultConfig {
  * that fails to parse as JSON throws {@link ConfigParseError}; a present file
  * that parses but fails schema validation throws {@link ConfigValidationError}.
  * All three error messages include the config file path and a remediation
- * hint naming `vaultkeeper config init`.
+ * hint naming `vaultkeeper config init --force`, the supported recovery path
+ * for an existing-but-broken config (issue #97).
  *
  * @param configDir - Directory containing config.json. Defaults to
  * `getDefaultConfigDir()`, which itself honors `VAULTKEEPER_CONFIG_DIR`


### PR DESCRIPTION
## Summary

- A corrupted `config.json` was correctly detected by `config show`/`doctor` (typed `ConfigParseError` with line:column), but its own remediation text — "run `vaultkeeper config init`" — was a dead end: `config init` refuses to overwrite an existing (even unparseable) file. The only recovery was to `rm`/hand-edit the file outside the tool.
- `vaultkeeper config init --force` now overwrites an existing or corrupt config file. `config init` without `--force` keeps its current non-destructive refusal (still exits 1), and its refusal message now names `config init --force` as the recovery path. `--force` composes with `--backend` (`config init --force --backend file`).
- `ConfigParseError` (and the other `loadConfig` errors sharing its remediation hint — `ConfigValidationError`, `FilesystemError`) now point at `vaultkeeper config init --force` instead of the dead-end `vaultkeeper config init`.
- Regenerated `docs/api/` for the updated `loadConfig` JSDoc.
- Added a patch changeset for `vaultkeeper` and `@vaultkeeper/cli`.

Refs #97

## Test plan

- [x] `pnpm build`
- [x] `pnpm check` (typecheck + lint + API report validation) — green
- [x] `pnpm --filter vaultkeeper test` — 643 passed
- [x] `pnpm --filter @vaultkeeper/cli test` — 242 passed
- [x] `pnpm --filter @vaultkeeper/cli-tests test` — 105 passed, 25 skipped (conformance, no Rust binary in this env)
- [x] `pnpm check:api-docs` — up to date
- [x] New regression tests: corrupt config → `config init --force` → `config show` succeeds; `ConfigParseError` names the working command; `config init` without `--force` still refuses over an existing config; `--force` + `--backend` interaction preserved