### PR TITLE
Verify exec --cache and WASM authorize() fixes, clarify WASM setup() contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,9 @@ const apiKey = result.secret.read((value) => value)
 // store()/retrieve() are a separate, independent file-backend API — useful
 // when you want the WASM SDK to persist a secret for later retrieval, but
 // note that setup() above will not read what you stored here.
-await vault.store('MY_API_KEY', 'my-secret-value')
-console.log(await vault.retrieve('MY_API_KEY'))
+await vault.store('MY_API_KEY', apiKey)
+const retrieved = await vault.retrieve('MY_API_KEY')
+console.log(retrieved === apiKey) // true — same value, via the independent store()/retrieve() path
 
 // Rotate or revoke keys
 vault.rotateKey()

--- a/README.md
+++ b/README.md
@@ -213,21 +213,27 @@ The WASM SDK exposes lower-level APIs than the TypeScript library's delegated pa
 
 **The WASM SDK always uses the file backend.** Unlike the native and Node.js CLIs and the TypeScript library, it does not read the `backends` config and does not use the platform-default credential store (Keychain, DPAPI, `secret-tool`) — secrets are always stored in the AES-256-GCM encrypted file backend regardless of platform.
 
+**`setup()` does not read from the backend.** This is the one method where the WASM SDK's contract deliberately diverges from the TypeScript library's: `vault.setup(secretName, secretValue, options?)` mints a JWE directly from the `secretValue` argument you pass in — it never calls `store()`/`retrieve()` or looks at anything already persisted under `secretName`. The TypeScript library's `vault.setup(secretName, options?)` has no `secretValue` parameter at all; it always reads the current value from the configured backend. `store()` and `setup()` are independent operations here — calling `store()` first has no effect on what `setup()` encapsulates.
+
 ```ts
 import { createVaultKeeper } from '@vaultkeeper/wasm'
 
 const vault = await createVaultKeeper()
 
-// Store a secret
-await vault.store('MY_API_KEY', 'my-secret-value')
-
-// Mint a JWE token
+// Mint a JWE token directly from a value you already have — setup() does not
+// read from the backend (see above), so no prior store() call is needed.
 const jwe = vault.setup('MY_API_KEY', 'my-secret-value')
 
 // Authorize: decrypt and validate. The result's `claims` never contain the
 // raw secret — read it exactly once through the one-time accessor.
 const result = vault.authorize(jwe)
 const apiKey = result.secret.read((value) => value)
+
+// store()/retrieve() are a separate, independent file-backend API — useful
+// when you want the WASM SDK to persist a secret for later retrieval, but
+// note that setup() above will not read what you stored here.
+await vault.store('MY_API_KEY', 'my-secret-value')
+const stored = await vault.retrieve('MY_API_KEY')
 
 // Rotate or revoke keys
 vault.rotateKey()

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ The WASM SDK exposes lower-level APIs than the TypeScript library's delegated pa
 
 **The WASM SDK always uses the file backend.** Unlike the native and Node.js CLIs and the TypeScript library, it does not read the `backends` config and does not use the platform-default credential store (Keychain, DPAPI, `secret-tool`) — secrets are always stored in the AES-256-GCM encrypted file backend regardless of platform.
 
-**`setup()` does not read from the backend.** This is the one method where the WASM SDK's contract deliberately diverges from the TypeScript library's: `vault.setup(secretName, secretValue, options?)` mints a JWE directly from the `secretValue` argument you pass in — it never calls `store()`/`retrieve()` or looks at anything already persisted under `secretName`. The TypeScript library's `vault.setup(secretName, options?)` has no `secretValue` parameter at all; it always reads the current value from the configured backend. `store()` and `setup()` are independent operations here — calling `store()` first has no effect on what `setup()` encapsulates.
+**`setup()` does not read from the backend.** `vault.setup(secretName, secretValue, options?)` mints a JWE directly from the `secretValue` argument you pass in — it never calls `store()`/`retrieve()` or looks at anything already persisted under `secretName`. This diverges from the TypeScript library's `vault.setup(secretName, options?)`, which has no `secretValue` parameter at all and always reads the current value from the configured backend. `store()` and `setup()` are independent operations here — calling `store()` first has no effect on what `setup()` encapsulates.
 
 ```ts
 import { createVaultKeeper } from '@vaultkeeper/wasm'
@@ -233,7 +233,7 @@ const apiKey = result.secret.read((value) => value)
 // when you want the WASM SDK to persist a secret for later retrieval, but
 // note that setup() above will not read what you stored here.
 await vault.store('MY_API_KEY', 'my-secret-value')
-const stored = await vault.retrieve('MY_API_KEY')
+console.log(await vault.retrieve('MY_API_KEY'))
 
 // Rotate or revoke keys
 vault.rotateKey()

--- a/docs/api/wasm.vaultkeeper.md
+++ b/docs/api/wasm.vaultkeeper.md
@@ -174,6 +174,8 @@ Rotate the encryption key.
 
 Create a JWE token encapsulating a secret.
 
+Unlike the TypeScript `vaultkeeper` library's `setup(secretName, options?)`<!-- -->, this method does not read from the backend — it mints the token directly from `secretValue`<!-- -->. It never calls [VaultKeeper.store()](./wasm.vaultkeeper.store.md) / [VaultKeeper.retrieve()](./wasm.vaultkeeper.retrieve.md) or looks at anything already persisted under `secretName`<!-- -->, so a prior `store()` call has no effect on what `setup()` encapsulates. This is an intentional divergence between the two SDKs' `setup()` contracts, not a bug.
+
 
 </td></tr>
 <tr><td>

--- a/docs/api/wasm.vaultkeeper.setup.md
+++ b/docs/api/wasm.vaultkeeper.setup.md
@@ -6,6 +6,8 @@
 
 Create a JWE token encapsulating a secret.
 
+Unlike the TypeScript `vaultkeeper` library's `setup(secretName, options?)`<!-- -->, this method does not read from the backend — it mints the token directly from `secretValue`<!-- -->. It never calls [VaultKeeper.store()](./wasm.vaultkeeper.store.md) / [VaultKeeper.retrieve()](./wasm.vaultkeeper.retrieve.md) or looks at anything already persisted under `secretName`<!-- -->, so a prior `store()` call has no effect on what `setup()` encapsulates. This is an intentional divergence between the two SDKs' `setup()` contracts, not a bug.
+
 **Signature:**
 
 ```typescript

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -20,9 +20,16 @@
  * material) and accurate error surfacing on the cached-token path: a revoked
  * key must be reported as `KeyRevokedError`, not a generic "expired" message.
  *
+ * Issue #104 re-verifies that the #59 cross-process cache-reuse fix still
+ * holds against the current CLI: "reuses a cached token across processes
+ * without re-authenticating" below runs two separate CLI subprocesses
+ * sharing a config dir and asserts the second invocation neither re-prompts
+ * nor prints an "expired"/re-authentication notice.
+ *
  * @see https://github.com/mike-north/vaultkeeper/issues/57
  * @see https://github.com/mike-north/vaultkeeper/issues/58
  * @see https://github.com/mike-north/vaultkeeper/issues/59
+ * @see https://github.com/mike-north/vaultkeeper/issues/104
  */
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -20,11 +20,11 @@
  * material) and accurate error surfacing on the cached-token path: a revoked
  * key must be reported as `KeyRevokedError`, not a generic "expired" message.
  *
- * Issue #104 re-verifies that the #59 cross-process cache-reuse fix still
- * holds against the current CLI: "reuses a cached token across processes
- * without re-authenticating" below runs two separate CLI subprocesses
- * sharing a config dir and asserts the second invocation neither re-prompts
- * nor prints an "expired"/re-authentication notice.
+ * Issue #104 re-verifies the cross-process cache-reuse behavior from #59
+ * still holds against the current CLI: "reuses a cached token across
+ * processes without re-authenticating" below runs two separate CLI
+ * subprocesses sharing a config dir and asserts the second invocation
+ * neither re-prompts nor prints an "expired"/re-authentication notice.
  *
  * @see https://github.com/mike-north/vaultkeeper/issues/57
  * @see https://github.com/mike-north/vaultkeeper/issues/58

--- a/packages/vaultkeeper-wasm/README.md
+++ b/packages/vaultkeeper-wasm/README.md
@@ -8,6 +8,13 @@ The public API is not a drop-in replacement for the TypeScript library — some 
 differ (e.g. `setup(secretName, secretValue, ...)` here, vs. the TS library's
 `setup(secretName, options?)`).
 
+**`setup()` does not read from the backend.** This package's `setup(secretName, secretValue, options?)`
+mints a JWE directly from the `secretValue` argument — it never calls `store()`/`retrieve()` or reads
+whatever is already persisted under `secretName`. The TS library's `setup(secretName, options?)` has
+no `secretValue` parameter at all and always reads the current value from the configured backend.
+`store()` and `setup()` are independent operations here; calling `store()` first has no effect on
+what `setup()` encapsulates.
+
 ## Installation
 
 ```sh
@@ -23,10 +30,8 @@ import { createVaultKeeper } from '@vaultkeeper/wasm'
 
 const vault = await createVaultKeeper()
 
-// Store a secret
-await vault.store('MY_API_KEY', 'my-secret-value')
-
-// Mint a JWE token
+// Mint a JWE token directly from a value you already have — setup() does not
+// read from the backend (see above), so no prior store() call is needed.
 const jwe = vault.setup('MY_API_KEY', 'my-secret-value')
 
 // Authorize: decrypt and validate. The result's `claims` never contain the

--- a/packages/vaultkeeper-wasm/src/index.ts
+++ b/packages/vaultkeeper-wasm/src/index.ts
@@ -154,7 +154,17 @@ export class VaultKeeper {
     return callAsync(() => this.#inner.doctor());
   }
 
-  /** Create a JWE token encapsulating a secret. */
+  /**
+   * Create a JWE token encapsulating a secret.
+   *
+   * Unlike the TypeScript `vaultkeeper` library's `setup(secretName, options?)`,
+   * this method does not read from the backend — it mints the token directly
+   * from `secretValue`. It never calls {@link VaultKeeper.store} /
+   * {@link VaultKeeper.retrieve} or looks at anything already persisted under
+   * `secretName`, so a prior `store()` call has no effect on what `setup()`
+   * encapsulates. This is an intentional divergence between the two SDKs'
+   * `setup()` contracts, not a bug.
+   */
   setup(secretName: string, secretValue: string, options?: SetupOptions): string {
     return callSync(() => this.#inner.setup(secretName, secretValue, options ?? {}));
   }

--- a/packages/vaultkeeper-wasm/src/test/sdk.test.ts
+++ b/packages/vaultkeeper-wasm/src/test/sdk.test.ts
@@ -505,3 +505,34 @@ describe('@vaultkeeper/wasm security parity (issue #66)', () => {
     });
   });
 });
+
+// Issue #104: pin the documented setup(secretName, secretValue) contract —
+// it mints the token from the `secretValue` argument and never reads
+// whatever is already persisted under `secretName` via store()/retrieve().
+// This is a deliberate divergence from the TS `vaultkeeper` library's
+// setup(secretName, options?), which always reads from the backend. If this
+// test starts failing, either the divergence was silently closed (update the
+// README/JSDoc accordingly) or setup() regressed to reading stored state.
+describe('@vaultkeeper/wasm setup() contract (issue #104)', () => {
+  it('setup() mints from its secretValue argument, ignoring any stored value under the same name', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir);
+      await vault.store('contract-key', 'stored-value');
+
+      const token = vault.setup('contract-key', 'argument-value');
+      const result = vault.authorize(token);
+
+      assert.equal(
+        result.secret.read((value) => value),
+        'argument-value',
+        'setup() must encapsulate the secretValue argument, not the stored value',
+      );
+
+      // The stored value is untouched and independently retrievable — store()
+      // and setup() are independent operations.
+      const stored = await vault.retrieve('contract-key');
+      assert.equal(stored, 'stored-value');
+      vault.dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refs #104

- Re-verified `exec --cache`'s cross-process token reuse (#93's headline fix) using the existing real-subprocess integration test in `packages/cli-tests/test/e2e/exec.test.ts` ("reuses a cached token across processes without re-authenticating") — added an `@see` reference to #104 in the file's doc comment for traceability. Confirmed green: the second CLI invocation reuses the cached token without re-prompting and without the "expired"/re-authentication notice.
- Re-verified the WASM SDK `authorize()` return shape contains no raw secret material (#66/#85) using the existing `packages/vaultkeeper-wasm/src/test/sdk.test.ts` security-parity suite. Confirmed green against the shipped artifact.
- Investigated the WASM `setup(secretName, secretValue)` vs. the TS `vaultkeeper` library's `setup(secretName)` divergence. **Decision: document, don't align.** The literal-`secretValue`-argument contract for `setup()` originates in the Rust core (`crates/vaultkeeper-core/src/vault.rs`), not just the WASM wrapper — the WASM binding is a faithful pass-through of the core's own API. Changing it to read from the backend instead would mean either a breaking Rust core API change or bolting on backend-read behavior in the JS wrapper alone (diverging WASM's `setup()` from what the underlying core actually does), both out of scope per the issue's non-goal against re-architecting. Instead:
  - Documented the divergence explicitly in the WASM package README, the root README's WASM SDK quick start, and `setup()`'s JSDoc.
  - Dropped the misleading `store()` → `setup()` sequence from both quick starts (it implied setup() reads back what was just stored — it doesn't).
  - Added a regression test (`sdk.test.ts`, "issue #104" describe block) that stores one value, calls `setup()` with a different value, and asserts the minted token encapsulates the argument, not the stored value — pins the documented contract so a future change either updates the docs or is caught as a regression.

No gaps were found in #93 or #66/#85 — both hold under the current code, proven by the tests above (already existing, now re-confirmed) plus the new #104-specific contract test.

## Test plan

- [x] `pnpm build` (clean, after `pnpm clean` + `nx reset`)
- [x] `pnpm check` (typecheck + lint + api-report) — green
- [x] `pnpm check:api-docs` — green (`docs/api/` regenerated and verified up to date)
- [x] `pnpm test` — all suites green, including `packages/cli-tests/test/e2e/exec.test.ts` (cache-reuse test) and `@vaultkeeper/wasm` `node:test` suite (security-parity + new setup() contract test)
- [x] No Rust source changed — Cargo build/clippy/wasm-pack rebuild not required (cargo unavailable in this environment, but no `crates/` files were touched)