### PR TITLE
Fix file backend default storage dir diverging from config dir

### DIFF
--- a/.changeset/file-backend-default-config-dir.md
+++ b/.changeset/file-backend-default-config-dir.md
@@ -1,0 +1,7 @@
+---
+'vaultkeeper': patch
+---
+
+Fix the `file` backend's default storage directory diverging from the resolved config directory. With no explicit `path` configured, secrets now land under `<configDir>/file/` — the same resolved config directory (honoring `--config-dir`/`VAULTKEEPER_CONFIG_DIR`, `~/.config/vaultkeeper` by default) that already holds `config.json` and key material — instead of the hardcoded `$HOME/.vaultkeeper/file`. An explicit `path` on the backend config still overrides this default unchanged.
+
+Back-compat: `retrieve`/`exists`/`delete`/`list` transparently fall back to the old `$HOME/.vaultkeeper/file` location when a secret isn't found under the new default, so secrets stored before this change remain reachable. `store` always writes to the new location going forward — nothing at the old location is migrated automatically.

--- a/README.md
+++ b/README.md
@@ -275,9 +275,11 @@ The first enabled backend in the configuration is used.
 | Windows  | `dpapi`         | PowerShell (built-in)                                            |
 | Any      | `file`          | None (AES-256-GCM encrypted file, no OS credential store needed) |
 
-The `file` backend works on all platforms and requires no system dependencies. Use it as a fallback or in environments without a native credential store (CI, Docker, etc.).
+The `file` backend works on all platforms and requires no system dependencies. Use it as a fallback or in environments without a native credential store (CI, Docker, etc.). With no explicit `path` configured, it stores secrets under `<configDir>/file/` — the same resolved config directory (`~/.config/vaultkeeper` by default, overridable via `--config-dir`/`VAULTKEEPER_CONFIG_DIR`) that holds `config.json` and key material, so everything lives in one discoverable place. Set `"path"` on the backend config to store secrets elsewhere instead.
 
 To use the native Linux credential store instead, install `secret-tool` (`sudo apt install libsecret-tools`) and set `"type": "secret-tool"` in your config.
+
+> **Upgrading from before this default changed:** the `file` backend's default storage directory moved from `$HOME/.vaultkeeper/file` to `<configDir>/file`. Existing secrets at the old location are still readable — `retrieve`/`exists`/`delete`/`list` fall back to it transparently when a secret isn't found at the new default — but `store` always writes to the new location going forward. Secrets you write after upgrading land in the new location; nothing at the old location is migrated automatically.
 
 ## Access patterns
 

--- a/docs/api/vaultkeeper.backendfactory.md
+++ b/docs/api/vaultkeeper.backendfactory.md
@@ -9,11 +9,11 @@ Factory function for creating a SecretBackend instance.
 **Signature:**
 
 ```typescript
-type BackendFactory = (config?: BackendConfig) => SecretBackend;
+type BackendFactory = (config?: BackendConfig, configDir?: string) => SecretBackend;
 ```
 **References:** [BackendConfig](./vaultkeeper.backendconfig.md)<!-- -->, [SecretBackend](./vaultkeeper.secretbackend.md)
 
 ## Remarks
 
-Factories may optionally accept a [BackendConfig](./vaultkeeper.backendconfig.md) to configure the backend from the user's vaultkeeper config file. Factories that do not need configuration can ignore the parameter.
+Factories may optionally accept a [BackendConfig](./vaultkeeper.backendconfig.md) to configure the backend from the user's vaultkeeper config file, and the resolved config directory (the same directory config and key material are read from) so file-based backends can default their storage under it. Factories that do not need either can ignore the parameters.
 

--- a/docs/api/vaultkeeper.backendregistry.create.md
+++ b/docs/api/vaultkeeper.backendregistry.create.md
@@ -9,7 +9,7 @@ Create a backend instance by type.
 **Signature:**
 
 ```typescript
-static create(type: string, config?: BackendConfig): SecretBackend;
+static create(type: string, config?: BackendConfig, configDir?: string): SecretBackend;
 ```
 
 ## Parameters
@@ -59,6 +59,22 @@ config
 </td><td>
 
 _(Optional)_ Optional backend configuration forwarded to the factory
+
+
+</td></tr>
+<tr><td>
+
+configDir
+
+
+</td><td>
+
+string
+
+
+</td><td>
+
+_(Optional)_ Optional resolved config directory forwarded to the factory, so file-based backends can default their storage under it
 
 
 </td></tr>

--- a/docs/api/vaultkeeper.backendregistry.md
+++ b/docs/api/vaultkeeper.backendregistry.md
@@ -38,7 +38,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-[create(type, config)](./vaultkeeper.backendregistry.create.md)
+[create(type, config, configDir)](./vaultkeeper.backendregistry.create.md)
 
 
 </td><td>

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -45,6 +45,10 @@ The first enabled backend in the configuration is used: `keychain` (macOS), `dpa
 `secret-tool` (Linux, via `libsecret`), or `file` (AES-256-GCM encrypted file, all platforms, no
 system dependencies). Plugin backends for 1Password and YubiKey are also available.
 
+With no explicit `path`, the `file` backend stores secrets under `<configDir>/file/` — the same
+resolved config directory (`~/.config/vaultkeeper` by default) that holds `config.json` and key
+material.
+
 ## Testing against this library
 
 Use [`@vaultkeeper/test-helpers`](https://www.npmjs.com/package/@vaultkeeper/test-helpers) for an

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -28,7 +28,7 @@ export interface BackendConfig {
 }
 
 // @public
-export type BackendFactory = (config?: BackendConfig) => SecretBackend;
+export type BackendFactory = (config?: BackendConfig, configDir?: string) => SecretBackend;
 
 // @public
 export class BackendLockedError extends VaultError {
@@ -42,7 +42,7 @@ export class BackendRegistry {
     static clearBackends(): void;
     // @internal
     static clearSetups(): void;
-    static create(type: string, config?: BackendConfig): SecretBackend;
+    static create(type: string, config?: BackendConfig, configDir?: string): SecretBackend;
     static getAvailableTypes(): Promise<string[]>;
     static getSetup(type: string): BackendSetupFactory | undefined;
     static getTypes(): string[];

--- a/packages/vaultkeeper/src/backend/file-backend.ts
+++ b/packages/vaultkeeper/src/backend/file-backend.ts
@@ -4,11 +4,22 @@
  * @remarks
  * Stores secrets encrypted with AES-256-GCM using Node.js native crypto.
  * Each secret is stored as an individual encrypted file under
- * ~/.vaultkeeper/file/. A randomly generated key stored in a protected
- * file is used for encryption.
+ * `<configDir>/file/`, where `configDir` is the same resolved config
+ * directory used for the config file and key material (see
+ * {@link getDefaultConfigDir}). A randomly generated key stored in a
+ * protected file is used for encryption.
  *
  * Encrypted file format (all parts base64-encoded, colon-separated):
  *   <iv>:<authTag>:<ciphertext>
+ *
+ * @remarks Back-compat (issue #99)
+ * Prior to this fix, the default storage directory was
+ * `$HOME/.vaultkeeper/file`, independent of the resolved config directory.
+ * When no explicit `path` is configured, reads (`retrieve`/`exists`/`delete`/
+ * `list`) transparently fall back to that legacy location if an entry is not
+ * found under the new default, so secrets stored there before this change
+ * remain reachable. Writes (`store`) always target the new location — the
+ * legacy directory is never written to going forward.
  */
 
 import * as fs from 'node:fs/promises'
@@ -16,25 +27,41 @@ import * as path from 'node:path'
 import * as os from 'node:os'
 import { SecretNotFoundError, FilesystemError } from '../errors.js'
 import { encryptGcm, decryptGcm, getOrCreateWrapKey } from '../util/at-rest.js'
+import { getDefaultConfigDir } from '../config.js'
 import type { ListableBackend } from './types.js'
 
-const STORAGE_DIR_NAME = path.join('.vaultkeeper', 'file')
+const STORAGE_DIR_NAME = 'file'
 const KEY_FILE = '.key'
+
+/**
+ * Pre-#99 default storage directory, kept as a read-only fallback.
+ *
+ * @remarks
+ * Computed lazily (not as a module-level constant) so it reflects
+ * `os.homedir()` at construction time rather than at module load time —
+ * matching the existing lazy-resolution pattern the rest of this module
+ * relies on for testability.
+ */
+function legacyStorageDir(): string {
+  return path.join(os.homedir(), '.vaultkeeper', 'file')
+}
 
 /**
  * Resolve the storage directory for a FileBackend instance.
  *
  * When `configuredPath` is provided (from `BackendConfig.path`), secrets are
- * stored directly under that directory. Otherwise the default
- * `$HOME/.vaultkeeper/file` location is used.
+ * stored directly under that directory. Otherwise the default is
+ * `<configDir>/file`, where `configDir` is the resolved config directory
+ * (the value passed to the backend factory, or `getDefaultConfigDir()` when
+ * constructing a `FileBackend` directly without one).
  */
-function resolveStorageDir(configuredPath?: string): string {
+function resolveStorageDir(configuredPath?: string, configDir?: string): string {
   // Config validation (see validateConfig) rejects empty/whitespace-only
   // paths, so any defined value here is guaranteed non-blank.
   if (configuredPath !== undefined) {
     return configuredPath
   }
-  return path.join(os.homedir(), STORAGE_DIR_NAME)
+  return path.join(configDir ?? getDefaultConfigDir(), STORAGE_DIR_NAME)
 }
 
 function getEntryPath(storageDir: string, id: string): string {
@@ -75,13 +102,23 @@ export class FileBackend implements ListableBackend {
   readonly displayName = 'Encrypted File Store'
 
   readonly #storageDir: string
+  /**
+   * Pre-#99 default storage directory, consulted as a read-only fallback
+   * when `storageDir` was not explicitly configured. `undefined` when an
+   * explicit `storageDir` was given — an explicit path never falls back.
+   */
+  readonly #legacyStorageDir: string | undefined
 
   /**
    * @param storageDir - Directory in which encrypted secrets are stored.
-   *   Sourced from `BackendConfig.path`. Defaults to `$HOME/.vaultkeeper/file`.
+   *   Sourced from `BackendConfig.path`. Defaults to `<configDir>/file`.
+   * @param configDir - Resolved config directory, used to compute the
+   *   default `storageDir` when one is not explicitly provided. Ignored when
+   *   `storageDir` is given. Defaults to `getDefaultConfigDir()`.
    */
-  constructor(storageDir?: string) {
-    this.#storageDir = resolveStorageDir(storageDir)
+  constructor(storageDir?: string, configDir?: string) {
+    this.#storageDir = resolveStorageDir(storageDir, configDir)
+    this.#legacyStorageDir = storageDir === undefined ? legacyStorageDir() : undefined
   }
 
   async isAvailable(): Promise<boolean> {
@@ -103,8 +140,12 @@ export class FileBackend implements ListableBackend {
     await fs.writeFile(entryPath, encrypted, { mode: 0o600 })
   }
 
-  async retrieve(id: string): Promise<string> {
-    const storageDir = this.#storageDir
+  /**
+   * Attempt to read and decrypt the entry for `id` from `storageDir`.
+   * Returns `undefined` (rather than throwing) when the entry does not
+   * exist in `storageDir`, so callers can probe a fallback location.
+   */
+  async #tryRetrieveFrom(storageDir: string, id: string): Promise<string | undefined> {
     const entryPath = getEntryPath(storageDir, id)
 
     let encoded: string
@@ -112,7 +153,7 @@ export class FileBackend implements ListableBackend {
       encoded = await fs.readFile(entryPath, 'utf8')
     } catch (err) {
       if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
-        throw new SecretNotFoundError(`Secret not found in file store: ${id}`)
+        return undefined
       }
       throw err
     }
@@ -127,26 +168,61 @@ export class FileBackend implements ListableBackend {
     }
   }
 
+  async retrieve(id: string): Promise<string> {
+    const fromPrimary = await this.#tryRetrieveFrom(this.#storageDir, id)
+    if (fromPrimary !== undefined) {
+      return fromPrimary
+    }
+
+    if (this.#legacyStorageDir !== undefined) {
+      const fromLegacy = await this.#tryRetrieveFrom(this.#legacyStorageDir, id)
+      if (fromLegacy !== undefined) {
+        return fromLegacy
+      }
+    }
+
+    throw new SecretNotFoundError(`Secret not found in file store: ${id}`)
+  }
+
   async delete(id: string): Promise<void> {
-    const storageDir = this.#storageDir
-    const entryPath = getEntryPath(storageDir, id)
+    const entryPath = getEntryPath(this.#storageDir, id)
 
     try {
       await fs.unlink(entryPath)
+      return
     } catch (err) {
-      if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
-        throw new SecretNotFoundError(`Secret not found in file store: ${id}`)
+      if (!(err instanceof Error && 'code' in err && err.code === 'ENOENT')) {
+        throw err
       }
-      throw err
     }
+
+    if (this.#legacyStorageDir !== undefined) {
+      try {
+        await fs.unlink(getEntryPath(this.#legacyStorageDir, id))
+        return
+      } catch (err) {
+        if (!(err instanceof Error && 'code' in err && err.code === 'ENOENT')) {
+          throw err
+        }
+      }
+    }
+
+    throw new SecretNotFoundError(`Secret not found in file store: ${id}`)
   }
 
   async exists(id: string): Promise<boolean> {
-    const storageDir = this.#storageDir
-    const entryPath = getEntryPath(storageDir, id)
+    if (await FileBackend.#entryExists(this.#storageDir, id)) {
+      return true
+    }
+    if (this.#legacyStorageDir !== undefined) {
+      return FileBackend.#entryExists(this.#legacyStorageDir, id)
+    }
+    return false
+  }
 
+  static async #entryExists(storageDir: string, id: string): Promise<boolean> {
     try {
-      await fs.access(entryPath)
+      await fs.access(getEntryPath(storageDir, id))
       return true
     } catch {
       return false
@@ -154,7 +230,18 @@ export class FileBackend implements ListableBackend {
   }
 
   async list(): Promise<string[]> {
-    const storageDir = this.#storageDir
+    const ids = new Set<string>()
+    for (const storageDir of [this.#storageDir, this.#legacyStorageDir].filter(
+      (dir): dir is string => dir !== undefined,
+    )) {
+      for (const id of await FileBackend.#listEntries(storageDir)) {
+        ids.add(id)
+      }
+    }
+    return Array.from(ids)
+  }
+
+  static async #listEntries(storageDir: string): Promise<string[]> {
     let entries: string[]
     try {
       entries = await fs.readdir(storageDir)

--- a/packages/vaultkeeper/src/backend/register-builtins.ts
+++ b/packages/vaultkeeper/src/backend/register-builtins.ts
@@ -28,7 +28,10 @@ import { YubikeyBackend } from './yubikey-backend.js'
  * @internal
  */
 export function registerBuiltinBackends(): void {
-  BackendRegistry.register('file', (config?: BackendConfig) => new FileBackend(config?.path))
+  BackendRegistry.register(
+    'file',
+    (config?: BackendConfig, configDir?: string) => new FileBackend(config?.path, configDir),
+  )
   BackendRegistry.register('keychain', () => new KeychainBackend())
   BackendRegistry.register('dpapi', (config?: BackendConfig) => new DpapiBackend(config?.path))
   BackendRegistry.register('secret-tool', () => new SecretToolBackend())

--- a/packages/vaultkeeper/src/backend/registry.ts
+++ b/packages/vaultkeeper/src/backend/registry.ts
@@ -38,10 +38,16 @@ export class BackendRegistry {
    * Create a backend instance by type.
    * @param type - Backend type identifier
    * @param config - Optional backend configuration forwarded to the factory
+   * @param configDir - Optional resolved config directory forwarded to the
+   *   factory, so file-based backends can default their storage under it
    * @returns A SecretBackend instance
    * @throws {@link BackendUnavailableError} if the backend type is not registered
    */
-  static create(type: string, config?: import('../types.js').BackendConfig): SecretBackend {
+  static create(
+    type: string,
+    config?: import('../types.js').BackendConfig,
+    configDir?: string,
+  ): SecretBackend {
     const factory = this.backends.get(type)
     if (factory === undefined) {
       throw new BackendUnavailableError(
@@ -51,7 +57,7 @@ export class BackendRegistry {
         Array.from(this.backends.keys()),
       )
     }
-    return factory(config)
+    return factory(config, configDir)
   }
 
   /**

--- a/packages/vaultkeeper/src/backend/types.ts
+++ b/packages/vaultkeeper/src/backend/types.ts
@@ -7,13 +7,18 @@
  *
  * @remarks
  * Factories may optionally accept a {@link BackendConfig} to configure the
- * backend from the user's vaultkeeper config file. Factories that do not need
- * configuration can ignore the parameter.
+ * backend from the user's vaultkeeper config file, and the resolved config
+ * directory (the same directory config and key material are read from) so
+ * file-based backends can default their storage under it. Factories that do
+ * not need either can ignore the parameters.
  *
  * @public
  */
 // Inline import() avoids a circular dependency: ../types.js imports from this barrel.
-export type BackendFactory = (config?: import('../types.js').BackendConfig) => SecretBackend
+export type BackendFactory = (
+  config?: import('../types.js').BackendConfig,
+  configDir?: string,
+) => SecretBackend
 
 /**
  * Abstraction interface for all secret storage backends.

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -835,7 +835,7 @@ export class VaultKeeper {
       throw new BackendUnavailableError('No enabled backends configured', 'none-enabled', [])
     }
 
-    return BackendRegistry.create(firstEnabled.type, firstEnabled)
+    return BackendRegistry.create(firstEnabled.type, firstEnabled, this.#configDir)
   }
 
   #requireBackend(): SecretBackend {

--- a/packages/vaultkeeper/test/integration/backend/file-backend-path.test.ts
+++ b/packages/vaultkeeper/test/integration/backend/file-backend-path.test.ts
@@ -107,7 +107,7 @@ describe('BackendConfig.path plumbing (file backend)', () => {
     expect(await fs.readdir(customDir)).not.toContain(entryFile('api-key'))
   })
 
-  it('uses the default home location when no path is configured', async () => {
+  it('uses the resolved config dir when no path is configured (issue #99)', async () => {
     const config: VaultConfig = {
       version: 1,
       backends: [{ type: 'file', enabled: true }],
@@ -118,8 +118,76 @@ describe('BackendConfig.path plumbing (file backend)', () => {
 
     await vault.store('api-key', 'sk-live-abc123')
 
-    const defaultDir = path.join(fakeHome, '.vaultkeeper', 'file')
-    const entries = await fs.readdir(defaultDir)
+    // Default storage now lives under the resolved config dir (fakeHome/file),
+    // not the legacy $HOME/.vaultkeeper/file location.
+    const configDirDefault = path.join(fakeHome, 'file')
+    const entries = await fs.readdir(configDirDefault)
     expect(entries).toContain(entryFile('api-key'))
+
+    const legacyDir = path.join(fakeHome, '.vaultkeeper', 'file')
+    await expect(fs.readdir(legacyDir)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('reads a secret from the legacy $HOME/.vaultkeeper/file location when absent from the new default (issue #99 back-compat)', async () => {
+    // Simulate a secret written under the pre-#99 default before this fix
+    // existed, using a fresh FileBackend pointed directly at the legacy dir.
+    const legacyDir = path.join(fakeHome, '.vaultkeeper', 'file')
+    const legacyBackend = BackendRegistry.create('file', {
+      type: 'file',
+      enabled: true,
+      path: legacyDir,
+    })
+    await legacyBackend.store('legacy-key', 'legacy-secret-value')
+
+    const config: VaultConfig = {
+      version: 1,
+      backends: [{ type: 'file', enabled: true }],
+      keyRotation: { gracePeriodDays: 7 },
+      defaults: { ttlMinutes: 30, trustTier: 3 },
+    }
+    const vault = await VaultKeeper.init({ skipDoctor: true, config, configDir: fakeHome })
+
+    const jwe = await vault.setup('legacy-key', { executablePath: 'dev' })
+    const { token } = await vault.authorize(jwe)
+    let secret: string | undefined
+    vault.getSecret(token).read((buf) => {
+      secret = buf.toString('utf8')
+    })
+    expect(secret).toBe('legacy-secret-value')
+
+    // New default location was never written to by the legacy-only read.
+    const configDirDefault = path.join(fakeHome, 'file')
+    await expect(fs.readdir(configDirDefault)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  // Acceptance criterion 4: no-path store lands under the resolved config
+  // dir, and a second VaultKeeper against the same config dir reads it back.
+  it('lets a second VaultKeeper against the same config dir read back a no-path store (criterion 4)', async () => {
+    const config: VaultConfig = {
+      version: 1,
+      backends: [{ type: 'file', enabled: true }],
+      keyRotation: { gracePeriodDays: 7 },
+      defaults: { ttlMinutes: 30, trustTier: 3 },
+      developmentMode: { executables: ['dev'] },
+    }
+    const configDir = await fs.mkdtemp(path.join(osModule.tmpdir(), 'vk-cfgdir-'))
+    try {
+      const vault1 = await VaultKeeper.init({ skipDoctor: true, config, configDir })
+      await vault1.store('api-key', 'sk-live-abc123')
+
+      const storageDir = path.join(configDir, 'file')
+      expect(await fs.readdir(storageDir)).toContain(entryFile('api-key'))
+
+      const vault2 = await VaultKeeper.init({ skipDoctor: true, config, configDir })
+      const jwe = await vault2.setup('api-key', { executablePath: 'dev' })
+      const { token } = await vault2.authorize(jwe)
+      let secret: string | undefined
+      vault2.getSecret(token).read((buf) => {
+        secret = buf.toString('utf8')
+      })
+      expect(secret).toBe('sk-live-abc123')
+    } finally {
+      await fs.rm(configDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/vaultkeeper/test/unit/backend/file-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/file-backend.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import * as path from 'node:path'
+import * as os from 'node:os'
 
 vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn(),
@@ -12,9 +13,13 @@ vi.mock('node:fs/promises', () => ({
 
 import * as fs from 'node:fs/promises'
 import { FileBackend } from '../../../src/backend/file-backend.js'
+import { getDefaultConfigDir } from '../../../src/config.js'
 import { SecretNotFoundError } from '../../../src/errors.js'
 
 const mockFs = vi.mocked(fs)
+
+/** The new (issue #99) default storage dir: `<configDir>/file`. */
+const defaultStorageDir = path.join(getDefaultConfigDir(), 'file')
 
 describe('FileBackend', () => {
   let backend: FileBackend
@@ -53,8 +58,10 @@ describe('FileBackend', () => {
 
       await backend.store('my-secret', 'secret-value')
 
+      // Issue #99: default storage lives under the resolved config dir
+      // (getDefaultConfigDir()/file), not the legacy $HOME/.vaultkeeper/file.
       expect(mockFs.mkdir).toHaveBeenCalledWith(
-        expect.stringContaining('.vaultkeeper'),
+        defaultStorageDir,
         expect.objectContaining({ recursive: true }),
       )
       expect(mockFs.writeFile).toHaveBeenCalledTimes(2)
@@ -97,11 +104,73 @@ describe('FileBackend', () => {
       )
       const encryptedWriteCall = mockFs.writeFile.mock.calls[0]
       expect(encryptedWriteCall?.[0]).toEqual(expect.stringContaining(customDir))
-      // Default $HOME/.vaultkeeper location must never be touched.
-      expect(mockFs.mkdir).not.toHaveBeenCalledWith(
-        expect.stringContaining('.vaultkeeper'),
-        expect.anything(),
+      // Default config-dir-relative location must never be touched.
+      expect(mockFs.mkdir).not.toHaveBeenCalledWith(defaultStorageDir, expect.anything())
+    })
+  })
+
+  describe('legacy $HOME/.vaultkeeper/file fallback (issue #99 back-compat)', () => {
+    let legacyBackend: FileBackend
+    const legacyStorageDir = path.join(os.homedir(), '.vaultkeeper', 'file')
+
+    beforeEach(() => {
+      // No explicit storageDir/configDir → legacy fallback is active.
+      legacyBackend = new FileBackend()
+      vi.clearAllMocks()
+    })
+
+    it('retrieve falls back to the legacy location when absent from the new default', async () => {
+      const crypto = await import('node:crypto')
+      const key = crypto.randomBytes(32)
+      const iv = crypto.randomBytes(12)
+      const cipher = crypto.createCipheriv('aes-256-gcm', key, iv, { authTagLength: 16 })
+      const encrypted = Buffer.concat([cipher.update('legacy-value', 'utf8'), cipher.final()])
+      const authTag = cipher.getAuthTag()
+      const encoded = [
+        iv.toString('base64'),
+        authTag.toString('base64'),
+        encrypted.toString('base64'),
+      ].join(':')
+
+      const noFileError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      mockFs.readFile.mockImplementation((target) => {
+        const filePath = typeof target === 'string' ? target : ''
+        if (filePath.startsWith(defaultStorageDir)) {
+          return Promise.reject(noFileError)
+        }
+        if (filePath.endsWith('.enc')) {
+          return Promise.resolve(encoded)
+        }
+        return Promise.resolve(key)
+      })
+
+      const result = await legacyBackend.retrieve('legacy-secret')
+      expect(result).toBe('legacy-value')
+      expect(mockFs.readFile).toHaveBeenCalledWith(
+        expect.stringContaining(legacyStorageDir),
+        'utf8',
       )
+    })
+
+    it('retrieve throws SecretNotFoundError when the secret exists in neither location', async () => {
+      const noFileError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      mockFs.readFile.mockRejectedValue(noFileError)
+
+      await expect(legacyBackend.retrieve('missing')).rejects.toBeInstanceOf(SecretNotFoundError)
+    })
+
+    it('does not consult the legacy location when an explicit path is configured', async () => {
+      const explicitBackend = new FileBackend(path.join(path.sep, 'explicit', 'dir'))
+      const noFileError = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      mockFs.readFile.mockRejectedValue(noFileError)
+
+      await expect(explicitBackend.retrieve('missing')).rejects.toBeInstanceOf(SecretNotFoundError)
+      // Only the explicit dir was consulted — never the legacy dir.
+      for (const call of mockFs.readFile.mock.calls) {
+        const target = call[0]
+        const filePath = typeof target === 'string' ? target : ''
+        expect(filePath).not.toContain(legacyStorageDir)
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

- The `file` backend's default storage directory (used when `BackendConfig.path` is not set) diverged from `getDefaultConfigDir()`: it wrote to the hardcoded `$HOME/.vaultkeeper/file` instead of the resolved config directory (`--config-dir`/`VAULTKEEPER_CONFIG_DIR`/`~/.config/vaultkeeper`). A secret stored via one docs-endorsed path could be invisible to a `VaultKeeper` initialized against the documented default config dir.
- Default now resolves to `<configDir>/file`, aligned with where key material (#93) is already stored, by threading the resolved config dir through `BackendRegistry.create(type, config, configDir)` -> the backend factory -> `FileBackend`. An explicit `path` still overrides this default unchanged (#60 behavior preserved).
- `BackendFactory`'s public type gained an optional second `configDir` parameter (backward compatible — existing factories that ignore it still satisfy the type).

## Back-compat decision (criterion 3)

Chose **dual-read, prefer new**: `retrieve`/`exists`/`delete`/`list` transparently fall back to the legacy `$HOME/.vaultkeeper/file` location when a secret isn't found under the new default, so secrets stored before this fix remain reachable. `store` always writes to the new location going forward — nothing is migrated automatically, and this is called out in both READMEs. The legacy fallback is skipped entirely when an explicit `path` is configured (an explicit path never had ambiguity to begin with).

## Test plan

- [x] New integration tests in `packages/vaultkeeper/test/integration/backend/file-backend-path.test.ts`: default lands under the resolved config dir (not the legacy location); a second `VaultKeeper` against the same config dir reads it back (criterion 4); legacy-location secrets remain readable via fallback.
- [x] New/updated unit tests in `packages/vaultkeeper/test/unit/backend/file-backend.test.ts`: default storage dir assertion updated to `<configDir>/file`; legacy fallback coverage for `retrieve` (found, not found, explicit path bypasses fallback).
- [x] `pnpm check` (typecheck + lint + api-report) — clean.
- [x] `pnpm check:api-docs` — clean (regenerated `docs/api/` for the `BackendFactory`/`BackendRegistry.create` signature change).
- [x] Full `vaultkeeper`, `@vaultkeeper/cli`, and `@vaultkeeper/cli-tests` (e2e + packaging) suites green.
- [x] Changeset added (`patch` on `vaultkeeper`).

Refs #99