### PR TITLE
Docs polish: exit codes, --config-dir, ESM note, useLimit default, RotationInProgressError next-step

### DIFF
--- a/.changeset/cli-library-docs-polish.md
+++ b/.changeset/cli-library-docs-polish.md
@@ -1,0 +1,13 @@
+---
+'vaultkeeper': patch
+'@vaultkeeper/cli': patch
+---
+
+Document the CLI's exit-code contract (0 success / 1 runtime error / 2 usage error, with an example
+of each) and the `--config-dir` flag / `VAULTKEEPER_CONFIG_DIR` env var in the CLI README. Note in
+the library README that consumers need `"type": "module"` (vaultkeeper is ESM-only) and that
+`useLimit` defaults to unlimited (`null`) when omitted from `setup()` options.
+
+`RotationInProgressError`'s message now includes a next step — run `vaultkeeper revoke-key` (or
+call `revokeKey()`) to invalidate the previous key immediately, or wait for the grace period to
+elapse — matching the actionable-remediation style of the other domain errors.

--- a/README.md
+++ b/README.md
@@ -554,10 +554,13 @@ Config is loaded from `~/.config/vaultkeeper/config.json` by default. Override w
 
 ## Setup options
 
+All fields are optional; omitting `useLimit` defaults it to `null` (unlimited uses) rather than
+single-use.
+
 ```ts
 const jwe = await vault.setup('SECRET_NAME', {
   ttlMinutes: 30, // token TTL (default: from config)
-  useLimit: 1, // null for unlimited
+  useLimit: 1, // null for unlimited (the default when omitted)
   executablePath: '/path/to/caller', // or 'dev' to skip identity check
   trustTier: 3,
   backendType: 'keychain',

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -17,6 +17,17 @@ npm install -g @vaultkeeper/cli
 
 ## Quick start
 
+All state (config, keys, the default `file` backend's secrets) lives under a config directory
+that defaults to `~/.config/vaultkeeper`. Override it with the global `--config-dir <path>` flag
+or the `VAULTKEEPER_CONFIG_DIR` environment variable — useful for CI runs and sandboxed/isolated
+test environments that shouldn't touch a developer's real config:
+
+```sh
+vaultkeeper --config-dir /tmp/ci-vault doctor
+# or
+VAULTKEEPER_CONFIG_DIR=/tmp/ci-vault vaultkeeper doctor
+```
+
 ```sh
 # Run preflight checks
 vaultkeeper doctor
@@ -44,6 +55,17 @@ vaultkeeper delete --name MY_API_KEY
 
 Run `vaultkeeper <command> --help` for full flag reference on any subcommand — the CLI's own
 `--help` output is the source of truth for its flags.
+
+## Exit codes
+
+Every command exits with one of three codes, so scripts and CI pipelines can branch on the class
+of failure without parsing stderr:
+
+| Code | Meaning       | Example                                                               |
+| ---- | ------------- | --------------------------------------------------------------------- |
+| `0`  | Success       | `vaultkeeper doctor` when all required dependencies are present       |
+| `1`  | Runtime error | `vaultkeeper delete --name DOES_NOT_EXIST` — the secret doesn't exist |
+| `2`  | Usage error   | `vaultkeeper --bogus` or `vaultkeeper some-unknown-command`           |
 
 ## Available commands
 

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -16,6 +16,10 @@ pnpm add vaultkeeper
 
 ## Quick start
 
+vaultkeeper is ESM-only. The consuming project needs `"type": "module"` in its `package.json`
+(or an ESM-capable loader/bundler) for the `import` below to work — a default `npm init -y`
+project is CommonJS and will need that field added first.
+
 ```ts
 import { VaultKeeper } from 'vaultkeeper'
 
@@ -29,7 +33,9 @@ const vault = await VaultKeeper.init()
 // 2. Store a secret in the configured backend
 await vault.store('MY_API_KEY', 'my-secret-value')
 
-// 3. Mint a JWE token for the stored secret
+// 3. Mint a JWE token for the stored secret. Optional setup options
+//    (ttlMinutes, useLimit, trustTier, ...) may be passed as a second
+//    argument; useLimit defaults to unlimited (null) when omitted.
 const jwe = await vault.setup('MY_API_KEY')
 
 // 4. Authorize: decrypt and validate the token

--- a/packages/vaultkeeper/src/errors.ts
+++ b/packages/vaultkeeper/src/errors.ts
@@ -439,10 +439,12 @@ export class FilesystemError extends VaultError {
  */
 export class RotationInProgressError extends VaultError {
   constructor(message: string) {
+    const trimmed = message.trim()
+    const separator = /[.!?]$/.test(trimmed) ? '' : '.'
     super(
-      `${message}. Either wait for the current grace period to elapse before rotating again, ` +
-        "or run 'vaultkeeper revoke-key' (or call revokeKey()) to invalidate the previous key " +
-        'immediately and clear the grace period.',
+      `${trimmed}${separator} Either wait for the current grace period to elapse before ` +
+        "rotating again, or run 'vaultkeeper revoke-key' (or call revokeKey()) to invalidate " +
+        'the previous key immediately and clear the grace period.',
     )
     this.name = 'RotationInProgressError'
   }

--- a/packages/vaultkeeper/src/errors.ts
+++ b/packages/vaultkeeper/src/errors.ts
@@ -440,12 +440,12 @@ export class FilesystemError extends VaultError {
 export class RotationInProgressError extends VaultError {
   constructor(message: string) {
     const trimmed = message.trim()
-    const separator = /[.!?]$/.test(trimmed) ? '' : '.'
-    super(
-      `${trimmed}${separator} Either wait for the current grace period to elapse before ` +
-        "rotating again, or run 'vaultkeeper revoke-key' (or call revokeKey()) to invalidate " +
-        'the previous key immediately and clear the grace period.',
-    )
+    const nextSteps =
+      'Either wait for the current grace period to elapse before rotating again, ' +
+      "or run 'vaultkeeper revoke-key' (or call revokeKey()) to invalidate the previous key " +
+      'immediately and clear the grace period.'
+    const prefix = trimmed.length === 0 ? '' : `${trimmed}${/[.!?]$/.test(trimmed) ? '' : '.'} `
+    super(`${prefix}${nextSteps}`)
     this.name = 'RotationInProgressError'
   }
 }

--- a/packages/vaultkeeper/src/errors.ts
+++ b/packages/vaultkeeper/src/errors.ts
@@ -439,7 +439,11 @@ export class FilesystemError extends VaultError {
  */
 export class RotationInProgressError extends VaultError {
   constructor(message: string) {
-    super(message)
+    super(
+      `${message}. Either wait for the current grace period to elapse before rotating again, ` +
+        "or run 'vaultkeeper revoke-key' (or call revokeKey()) to invalidate the previous key " +
+        'immediately and clear the grace period.',
+    )
     this.name = 'RotationInProgressError'
   }
 }

--- a/packages/vaultkeeper/test/unit/keys/manager.test.ts
+++ b/packages/vaultkeeper/test/unit/keys/manager.test.ts
@@ -248,6 +248,23 @@ describe('KeyManager.rotateKey — concurrent rotation guard', () => {
     )
   })
 
+  // Regression: an empty or whitespace-only message (possible from the WASM
+  // error mapper) previously left a bare leading period — ". Either wait ..."
+  // — before the next-step guidance. It should be omitted entirely instead.
+  it('omits the leading period for an empty or whitespace-only message', () => {
+    const emptyMessage = new RotationInProgressError('')
+    const whitespaceMessage = new RotationInProgressError('   ')
+
+    for (const err of [emptyMessage, whitespaceMessage]) {
+      expect(err.message.startsWith('. ')).toBe(false)
+      expect(err.message).toBe(
+        'Either wait for the current grace period to elapse before rotating again, ' +
+          "or run 'vaultkeeper revoke-key' (or call revokeKey()) to invalidate the previous key " +
+          'immediately and clear the grace period.',
+      )
+    }
+  })
+
   it('allows a new rotation after the grace period expires', async () => {
     const mgr = await makeInitializedManager()
     mgr.rotateKey(1_000)

--- a/packages/vaultkeeper/test/unit/keys/manager.test.ts
+++ b/packages/vaultkeeper/test/unit/keys/manager.test.ts
@@ -208,6 +208,24 @@ describe('KeyManager.rotateKey — concurrent rotation guard', () => {
     }).toThrowError(RotationInProgressError)
   })
 
+  // Regression: RotationInProgressError previously surfaced only the bare
+  // "A key rotation is already in progress" message with no next step,
+  // unlike the CLI's other domain errors, which name actionable remediation.
+  it('includes actionable next-step guidance (revoke-key / grace period) in the message', async () => {
+    const mgr = await makeInitializedManager()
+    mgr.rotateKey(5_000)
+
+    try {
+      mgr.rotateKey(5_000)
+      expect.unreachable('rotateKey should have thrown RotationInProgressError')
+    } catch (err) {
+      expect(err).toBeInstanceOf(RotationInProgressError)
+      const message = err instanceof Error ? err.message : String(err)
+      expect(message).toContain('revoke-key')
+      expect(message).toContain('grace period')
+    }
+  })
+
   it('allows a new rotation after the grace period expires', async () => {
     const mgr = await makeInitializedManager()
     mgr.rotateKey(1_000)

--- a/packages/vaultkeeper/test/unit/keys/manager.test.ts
+++ b/packages/vaultkeeper/test/unit/keys/manager.test.ts
@@ -226,6 +226,28 @@ describe('KeyManager.rotateKey — concurrent rotation guard', () => {
     }
   })
 
+  it('appends a separating period to a message with no trailing punctuation', () => {
+    const err = new RotationInProgressError('A key rotation is already in progress')
+    expect(err.message).toBe(
+      'A key rotation is already in progress. Either wait for the current grace period to ' +
+        "elapse before rotating again, or run 'vaultkeeper revoke-key' (or call revokeKey()) " +
+        'to invalidate the previous key immediately and clear the grace period.',
+    )
+  })
+
+  // Regression: appending ". Either ..." unconditionally to a message that
+  // already ends in sentence punctuation (e.g. from the WASM error mapper)
+  // produced double punctuation ("already in progress.. Either ...").
+  it('does not double up punctuation when the message already ends in a period', () => {
+    const err = new RotationInProgressError('A key rotation is already in progress.')
+    expect(err.message).not.toContain('..')
+    expect(err.message).toBe(
+      'A key rotation is already in progress. Either wait for the current grace period to ' +
+        "elapse before rotating again, or run 'vaultkeeper revoke-key' (or call revokeKey()) " +
+        'to invalidate the previous key immediately and clear the grace period.',
+    )
+  })
+
   it('allows a new rotation after the grace period expires', async () => {
     const mgr = await makeInitializedManager()
     mgr.rotateKey(1_000)


### PR DESCRIPTION
## Summary

Refs #103

- Documents the CLI exit-code contract (0 success / 1 runtime error / 2 usage error) in `packages/cli/README.md`, with one real example of each (verified against the built CLI).
- Documents `--config-dir` / `VAULTKEEPER_CONFIG_DIR` in the CLI README's quick start.
- Notes in the library README (`packages/vaultkeeper/README.md`) that the consumer needs `"type": "module"` (vaultkeeper is ESM-only).
- States in prose (both `packages/vaultkeeper/README.md`'s quick start and the root README's "Setup options" section) that `setup()`'s `useLimit` defaults to unlimited (`null`) when omitted — verified against `vault.ts`'s `options?.useLimit ?? null`.
- Gives `RotationInProgressError`'s message a next step: run `vaultkeeper revoke-key` (or call `revokeKey()`) to invalidate the previous key immediately, or wait for the grace period to elapse — matching the other domain errors' actionable-remediation style. Verified `revokeKey()` actually clears the grace period.

## Test plan

- [x] New regression test in `packages/vaultkeeper/test/unit/keys/manager.test.ts` asserts the `RotationInProgressError` message contains `revoke-key` and `grace period`.
- [x] `pnpm check` (typecheck + lint + api-report) passes.
- [x] `pnpm test` passes across the workspace (652 vaultkeeper tests, full cli-tests suite).
- [x] README-CLI drift check (`packages/cli-tests/test/e2e/readme-cli-drift.test.ts`) passes.
- [x] Manually ran the built CLI to confirm exit codes: `--help` → 0, `--bogus`/unknown command → 2, `delete --name <missing>` → 1.