### PR TITLE
Make packaged READMEs self-contained

### DIFF
--- a/.changeset/packaged-readme-selfcontainment.md
+++ b/.changeset/packaged-readme-selfcontainment.md
@@ -1,0 +1,10 @@
+---
+'vaultkeeper': patch
+'@vaultkeeper/cli': patch
+---
+
+Make the packaged READMEs self-contained: `vaultkeeper` and `@vaultkeeper/cli` now include a
+minimal, safe-by-default (`file` backend) example `VaultConfig`/config JSON, plus inline
+explanations of key rotation grace periods and trust tiers — the concepts the CLI's own `config
+show` and `exec` output surface — so the golden path no longer depends on fetching the unshipped
+repository README.

--- a/.changeset/packaged-readme-selfcontainment.md
+++ b/.changeset/packaged-readme-selfcontainment.md
@@ -5,6 +5,6 @@
 
 Make the packaged READMEs self-contained: `vaultkeeper` and `@vaultkeeper/cli` now include a
 minimal, safe-by-default (`file` backend) example `VaultConfig`/config JSON, plus inline
-explanations of key rotation grace periods and trust tiers — the concepts the CLI's own `config
-show` and `exec` output surface — so the golden path no longer depends on fetching the unshipped
-repository README.
+explanations of key rotation grace periods, the `trustTier` policy label, and the
+trust-on-first-use (TOFU) check that `exec` reports on every run — so the golden path no longer
+depends on fetching the unshipped repository README.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,6 +56,36 @@ vaultkeeper delete --name MY_API_KEY
 Run `vaultkeeper <command> --help` for full flag reference on any subcommand — the CLI's own
 `--help` output is the source of truth for its flags.
 
+## Example config
+
+`vaultkeeper config init` (no `--backend`) writes this config — the safe-by-default `file` backend,
+not your OS credential store:
+
+```json
+{
+  "version": 1,
+  "backends": [{ "type": "file", "enabled": true }],
+  "keyRotation": { "gracePeriodDays": 7 },
+  "defaults": { "ttlMinutes": 60, "trustTier": 3 }
+}
+```
+
+`vaultkeeper config show` prints this same shape (the file if one exists, otherwise the platform
+defaults). `keyRotation.gracePeriodDays` and `defaults.trustTier` are the two fields `config show`
+and `exec` surface directly — see below for what they mean.
+
+## Key rotation and trust tiers
+
+`vaultkeeper rotate-key` replaces the active encryption key but keeps the previous one valid for
+decryption for `keyRotation.gracePeriodDays` days, so secrets minted before a rotation don't break
+immediately; after the grace period, they become permanently unreadable.
+
+`vaultkeeper exec` mints a token tagged with the config's `defaults.trustTier` (`1`, `2`, or `3`)
+as a policy label describing how the caller executable's identity was verified: `1` = Sigstore
+transparency log, `2` = registry signature, `3` = TOFU (Trust On First Use, hash stored in the
+local trust manifest — the default). `vaultkeeper approve --script <path>` pre-registers a TOFU
+hash so tier-3 executables aren't prompted on first use.
+
 ## Exit codes
 
 Every command exits with one of three codes, so scripts and CI pipelines can branch on the class
@@ -75,8 +105,10 @@ of failure without parsing stderr:
 
 ## Full documentation
 
-See the [repository README](https://github.com/mike-north/vaultkeeper#readme) for the TypeScript
-library API, access patterns, key rotation, trust tiers, and configuration reference.
+The [`vaultkeeper`](https://www.npmjs.com/package/vaultkeeper) library package's README and shipped
+`.d.ts` cover the TypeScript API and access patterns for embedding vaultkeeper programmatically. For
+narrative coverage of development mode and the full error hierarchy, see the
+[repository README](https://github.com/mike-north/vaultkeeper#readme).
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -71,20 +71,24 @@ not your OS credential store:
 ```
 
 `vaultkeeper config show` prints this same shape (the file if one exists, otherwise the platform
-defaults). `keyRotation.gracePeriodDays` and `defaults.trustTier` are the two fields `config show`
-and `exec` surface directly — see below for what they mean.
+defaults) — that's where `keyRotation.gracePeriodDays` and `defaults.trustTier` are visible
+directly. `vaultkeeper exec` surfaces a related but distinct concept on every run: the caller's
+trust-on-first-use (TOFU) status (see below), not these config fields.
 
-## Key rotation and trust tiers
+## Key rotation and trust
 
 `vaultkeeper rotate-key` replaces the active encryption key but keeps the previous one valid for
 decryption for `keyRotation.gracePeriodDays` days, so secrets minted before a rotation don't break
-immediately; after the grace period, they become permanently unreadable.
+immediately; once the grace period elapses, they become permanently unreadable.
 
-`vaultkeeper exec` mints a token tagged with the config's `defaults.trustTier` (`1`, `2`, or `3`)
-as a policy label describing how the caller executable's identity was verified: `1` = Sigstore
-transparency log, `2` = registry signature, `3` = TOFU (Trust On First Use, hash stored in the
-local trust manifest — the default). `vaultkeeper approve --script <path>` pre-registers a TOFU
-hash so tier-3 executables aren't prompted on first use.
+`vaultkeeper exec` checks the caller executable (`--caller <path>`) against a local
+trust-on-first-use (TOFU) manifest before granting access, and reports the outcome to stderr:
+`Trust: verified (hash matches trust manifest)` for an already-approved caller, or a prompt/error
+if the caller is unrecognized or its hash has changed since it was approved (requiring
+re-approval). `vaultkeeper approve --script <path>` pre-registers a caller's hash so it's already
+trusted on its first `exec` run. This TOFU trust check is separate from the `trustTier` label
+(`1`, `2`, or `3`) that `defaults.trustTier` attaches to each minted token as policy metadata —
+the label doesn't itself reflect the TOFU check's outcome.
 
 ## Exit codes
 

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -53,7 +53,51 @@ const { response } = await vault.fetch(token, {
 ```
 
 Other access patterns — delegated `exec()` (secret injected via env var) and controlled direct
-access via `getSecret()` (auto-zeroing buffer) — are documented in the repo README linked below.
+access via `getSecret()` (auto-zeroing buffer) — share the same `{{secret}}` placeholder substitution
+shown above; see the `SecretAccessor` and `ExecRequest` types in the package's shipped `.d.ts` for
+their full signatures.
+
+## Example config
+
+`VaultKeeper.init()` works with no config file (it resolves to the safe `file` backend). To pin
+the configuration explicitly — e.g. to set a non-default TTL or trust tier — write a config file
+matching this shape. This example is safe-by-default: it uses the portable `file` backend, not
+your OS credential store.
+
+```json
+{
+  "version": 1,
+  "backends": [{ "type": "file", "enabled": true }],
+  "keyRotation": { "gracePeriodDays": 7 },
+  "defaults": { "ttlMinutes": 60, "trustTier": 3 }
+}
+```
+
+- `backends` — ordered list of backend configs; the first one with `"enabled": true` is used. To
+  opt into an OS-native store instead, add an entry with `"type": "keychain"` (macOS), `"dpapi"`
+  (Windows), or `"secret-tool"` (Linux) — `file` must still be listed to keep it a valid fallback.
+- `keyRotation.gracePeriodDays` — how many days the previous encryption key stays valid for
+  decrypting existing tokens after `rotateKey()` runs; see [Key rotation](#key-rotation) below.
+- `defaults.ttlMinutes` / `defaults.trustTier` — applied to `setup()` when its options don't
+  override them; see [Trust tiers](#trust-tiers) below.
+
+The full field reference is documented on the `VaultConfig` interface in the package's shipped
+`.d.ts` (`vaultkeeper/dist/*.d.ts`).
+
+## Key rotation
+
+`rotateKey()` replaces the active encryption key but keeps the previous one valid for decryption
+for `keyRotation.gracePeriodDays` days, so tokens minted before a rotation don't break immediately.
+After the grace period elapses, JWEs encrypted under the old key become permanently unreadable
+(`KeyRotatedError`).
+
+## Trust tiers
+
+`trustTier` (`1`, `2`, or `3`) is a policy label attached to a token at `setup()` time, describing
+how strongly the executable's identity was verified: `1` = Sigstore transparency log, `2` =
+registry signature, `3` = TOFU (Trust On First Use, hash stored in the local trust manifest).
+`defaults.trustTier` in the config sets the value used when `setup()` doesn't pass its own
+`trustTier` option.
 
 ## Backends
 
@@ -74,8 +118,9 @@ in-memory backend with zero OS dependencies in your own test suite.
 
 ## Full documentation
 
-Access patterns, key rotation, trust tiers, development mode, configuration reference, and the
-full error hierarchy are documented in the
+The package's shipped `.d.ts` files carry the complete API reference (every type, method, and
+option, with JSDoc). For narrative coverage of development mode and the full error hierarchy
+beyond what's inlined above, see the
 [repository README](https://github.com/mike-north/vaultkeeper#readme).
 
 ## License

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -73,9 +73,10 @@ your OS credential store.
 }
 ```
 
-- `backends` — ordered list of backend configs; the first one with `"enabled": true` is used. To
-  opt into an OS-native store instead, add an entry with `"type": "keychain"` (macOS), `"dpapi"`
-  (Windows), or `"secret-tool"` (Linux) — `file` must still be listed to keep it a valid fallback.
+- `backends` — ordered list of backend configs; whichever entry is **first** with `"enabled": true`
+  becomes the single active backend — there's no automatic fallback to a later entry. To switch to
+  an OS-native store, put an entry with `"type": "keychain"` (macOS), `"dpapi"` (Windows), or
+  `"secret-tool"` (Linux) ahead of (or in place of) the `file` entry.
 - `keyRotation.gracePeriodDays` — how many days the previous encryption key stays valid for
   decrypting existing tokens after `rotateKey()` runs; see [Key rotation](#key-rotation) below.
 - `defaults.ttlMinutes` / `defaults.trustTier` — applied to `setup()` when its options don't
@@ -88,16 +89,18 @@ The full field reference is documented on the `VaultConfig` interface in the pac
 
 `rotateKey()` replaces the active encryption key but keeps the previous one valid for decryption
 for `keyRotation.gracePeriodDays` days, so tokens minted before a rotation don't break immediately.
-After the grace period elapses, JWEs encrypted under the old key become permanently unreadable
-(`KeyRotatedError`).
+Once the grace period elapses, the retired key is dropped and JWEs encrypted under it can no
+longer be decrypted.
 
 ## Trust tiers
 
-`trustTier` (`1`, `2`, or `3`) is a policy label attached to a token at `setup()` time, describing
-how strongly the executable's identity was verified: `1` = Sigstore transparency log, `2` =
-registry signature, `3` = TOFU (Trust On First Use, hash stored in the local trust manifest).
-`defaults.trustTier` in the config sets the value used when `setup()` doesn't pass its own
-`trustTier` option.
+Executable identity is verified during `setup()` against a local trust-on-first-use (TOFU)
+manifest: a caller executable's hash is either already approved (trusted), unrecognized (first
+encounter, recorded automatically), or changed since it was approved (a conflict, which rejects
+the call until re-approved via `approveExecutable()`). Separately, `trustTier` (`1`, `2`, or `3`)
+is a policy **label** attached to the resulting token — it does not itself reflect the outcome of
+that verification. It defaults to `defaults.trustTier` from the config and can be overridden per
+call via `setup()`'s `trustTier` option.
 
 ## Backends
 

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -52,10 +52,12 @@ const { response } = await vault.fetch(token, {
 })
 ```
 
-Other access patterns — delegated `exec()` (secret injected via env var) and controlled direct
-access via `getSecret()` (auto-zeroing buffer) — share the same `{{secret}}` placeholder substitution
-shown above; see the `SecretAccessor` and `ExecRequest` types in the package's shipped `.d.ts` for
-their full signatures.
+Other access patterns: delegated `exec()` (secret injected via env var) uses the same `{{secret}}`
+placeholder substitution as `fetch()` above. Controlled direct access via `getSecret()` is
+different — it returns a `SecretAccessor` whose secret is only reachable through a single-use
+`read(callback)` call backed by an auto-zeroing buffer; no placeholder substitution is involved.
+See the `SecretAccessor` and `ExecRequest` types in the package's shipped `.d.ts` for their full
+signatures.
 
 ## Example config
 


### PR DESCRIPTION
## Summary

- Adds a minimal, safe-by-default (`file` backend) example `VaultConfig` JSON to the `vaultkeeper` package README quick start, showing the required fields (`version`, `backends[].type`/`enabled`, `keyRotation.gracePeriodDays`, `defaults.ttlMinutes`/`trustTier`). Also adds the matching config example to the `@vaultkeeper/cli` README (the exact shape `config init`/`config show` produce).
- Inlines a short explanation of key rotation grace periods and trust tiers — concepts the CLI's own `config show` and `exec` output surface — directly in both package READMEs, instead of relying solely on the unshipped repository README.
- Points remaining "see full docs" links at content that's actually shipped in the package (the `.d.ts` files) where possible, and narrows the repository-README link to only what isn't inlined (development mode, full error hierarchy).

Refs #101

## Test plan

- [x] `pnpm build`
- [x] `pnpm check` (typecheck + lint + api-report) — green
- [x] `pnpm exec vitest run test/e2e/readme-cli-drift.test.ts test/packaging` in `packages/cli-tests` — green (README-CLI drift check #62 and packaging test #63 both still pass; these only touch the root README/package.json contents, unaffected by this change)
- [x] Verified all config fields shown against the `VaultConfig` interface in `packages/vaultkeeper/src/types.ts` and the CLI's `buildConfig()` in `packages/cli/src/commands/config.ts`