### PR TITLE
Fix phantom createSecretAccessor reference in repo docs

### DIFF
--- a/.changeset/repo-docs-consistency.md
+++ b/.changeset/repo-docs-consistency.md
@@ -1,0 +1,5 @@
+---
+"@vaultkeeper/wasm": patch
+---
+
+Fix a doc comment on `SecretAccessor` that referenced the non-existent `createSecretAccessor` export instead of the real `getSecret()` pattern it mirrors. No behavior change.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Available as a **native Rust CLI**, a **TypeScript library**, a **WASM-backed SD
 
 ## Which package should I use?
 
-- **`vaultkeeper`** — the pure TypeScript library. Use this by default: it offers the delegated access patterns (`fetch`, `exec`, `createSecretAccessor`) that keep raw secrets out of application memory. With no config file present it uses the safe `file` backend, same as the WASM SDK; `vaultkeeper config init` writes that same `file` default. To opt into your platform's native credential store instead, run `vaultkeeper config init --backend keychain` (macOS) / `--backend dpapi` (Windows), or set it in an explicit config.
+- **`vaultkeeper`** — the pure TypeScript library. Use this by default: it offers the delegated access patterns (`fetch`, `exec`, `getSecret()`) that keep raw secrets out of application memory. With no config file present it uses the safe `file` backend, same as the WASM SDK; `vaultkeeper config init` writes that same `file` default. To opt into your platform's native credential store instead, run `vaultkeeper config init --backend keychain` (macOS) / `--backend dpapi` (Windows), or set it in an explicit config.
 - **`@vaultkeeper/wasm`** — a WASM-backed SDK with a similar feature set, backed by the Rust core instead of the `jose` npm package. Reach for it when you specifically need the Rust implementation (e.g. to match native-CLI behavior exactly) or want to avoid a `jose` dependency. It hardcodes the file backend rather than using platform defaults — see [WASM SDK quick start](#wasm-sdk-quick-start).
 - **`@vaultkeeper/cli`** — the Node.js CLI (`vaultkeeper` on the command line). Use this for shell scripts, CI pipelines, or interactive use where you don't need a library API at all.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Available as a **native Rust CLI**, a **TypeScript library**, a **WASM-backed SD
 
 ## Which package should I use?
 
-- **`vaultkeeper`** — the pure TypeScript library. Use this by default: it offers the delegated access patterns (`fetch`, `exec`, `getSecret()`) that keep raw secrets out of application memory. With no config file present it uses the safe `file` backend, same as the WASM SDK; `vaultkeeper config init` writes that same `file` default. To opt into your platform's native credential store instead, run `vaultkeeper config init --backend keychain` (macOS) / `--backend dpapi` (Windows), or set it in an explicit config.
+- **`vaultkeeper`** — the pure TypeScript library. Use this by default: it offers the delegated access patterns (`fetch()`, `exec()`, `getSecret()`) that keep raw secrets out of application memory. With no config file present it uses the safe `file` backend, same as the WASM SDK; `vaultkeeper config init` writes that same `file` default. To opt into your platform's native credential store instead, run `vaultkeeper config init --backend keychain` (macOS) / `--backend dpapi` (Windows), or set it in an explicit config.
 - **`@vaultkeeper/wasm`** — a WASM-backed SDK with a similar feature set, backed by the Rust core instead of the `jose` npm package. Reach for it when you specifically need the Rust implementation (e.g. to match native-CLI behavior exactly) or want to avoid a `jose` dependency. It hardcodes the file backend rather than using platform defaults — see [WASM SDK quick start](#wasm-sdk-quick-start).
 - **`@vaultkeeper/cli`** — the Node.js CLI (`vaultkeeper` on the command line). Use this for shell scripts, CI pipelines, or interactive use where you don't need a library API at all.
 
@@ -385,7 +385,7 @@ Key material is persisted across processes. When `VaultKeeper` loads its configu
 
 ## Trust tiers
 
-Executable identity is verified during `setup()` by hashing the executable (SHA-256) and checking that hash against a local trust manifest — this is a **TOFU (Trust On First Use)** model, not a package-registry or transparency-log lookup:
+Executable identity is verified during `setup()` by hashing the executable (SHA-256) and checking that hash against a local trust manifest — this is a **TOFU (Trust On First Use)** model, not a package-registry or transparency-log lookup. Hashing is skipped — and identity is treated as unverified — when `executablePath` is `'dev'` (the default when no `executablePath` option is passed) or when the executable has been registered via `setDevelopmentMode()`; see [Development mode](#development-mode). Otherwise, `setup()` produces one of three outcomes:
 
 - **Not yet approved** — first encounter with this executable path. The hash is recorded in the trust manifest so the same binary is recognized next time.
 - **Approved** — the executable's current hash matches what's recorded in the trust manifest (via `vaultkeeper approve --script <path>` or a prior `setup()` call).
@@ -393,7 +393,7 @@ Executable identity is verified during `setup()` by hashing the executable (SHA-
 
 A `trustTier` value (`1`, `2`, or `3`) can also be attached to the resulting token as a policy label, independent of the TOFU check above.
 
-> **Note:** `trustTier` is recorded in the token claims as a label only — it does not select or change which verification mechanism runs; every `setup()` call performs the same TOFU hash check regardless of the `trustTier` value passed. Tier `1` is reserved for a possible future Sigstore-based verification path; the codebase contains a Sigstore integration point, but it is currently a stub that always falls through to the TOFU check — no executable is verified via Sigstore or any package registry today. Tier `2` does not correspond to a registry signature check either; it is simply the "hash found in the trust manifest" case of the same TOFU model as tier `3`.
+> **Note:** `trustTier` is recorded in the token claims as a label only — it does not select or change which verification mechanism runs; every `setup()` call that actually hashes the executable (i.e. not a dev-mode call, see above) applies the same TOFU check regardless of the `trustTier` value passed. Tier `1` is reserved for a possible future Sigstore-based verification path; the codebase contains a Sigstore integration point, but it is currently a stub that always falls through to the TOFU check — no executable is verified via Sigstore or any package registry today. Tier `2` does not correspond to a registry signature check either; it is simply the "hash found in the trust manifest" case of the same TOFU model as tier `3`.
 
 Pass `trustTier` in setup options to set that policy label:
 

--- a/README.md
+++ b/README.md
@@ -385,17 +385,17 @@ Key material is persisted across processes. When `VaultKeeper` loads its configu
 
 ## Trust tiers
 
-Executable identity is verified during `setup()`. A `trustTier` value can be attached to the resulting token as a policy label.
+Executable identity is verified during `setup()` by hashing the executable (SHA-256) and checking that hash against a local trust manifest — this is a **TOFU (Trust On First Use)** model, not a package-registry or transparency-log lookup:
 
-> **Note:** In the current implementation, `trustTier` is recorded in the token claims but does not change which verification mechanism is used. Future versions may introduce tier-specific verification behavior.
+- **Not yet approved** — first encounter with this executable path. The hash is recorded in the trust manifest so the same binary is recognized next time.
+- **Approved** — the executable's current hash matches what's recorded in the trust manifest (via `vaultkeeper approve --script <path>` or a prior `setup()` call).
+- **Mismatch** — the executable's current hash differs from what's recorded (the binary was rebuilt or replaced). `setup()` throws `IdentityMismatchError`; re-approve with `vaultkeeper approve --script <caller>`.
 
-| Tier | Intended method                                           |
-| ---- | --------------------------------------------------------- |
-| `1`  | Sigstore transparency log                                 |
-| `2`  | Registry signature                                        |
-| `3`  | TOFU (Trust On First Use) — hash stored in trust manifest |
+A `trustTier` value (`1`, `2`, or `3`) can also be attached to the resulting token as a policy label, independent of the TOFU check above.
 
-Pass `trustTier` in setup options to override the configured default:
+> **Note:** `trustTier` is recorded in the token claims as a label only — it does not select or change which verification mechanism runs; every `setup()` call performs the same TOFU hash check regardless of the `trustTier` value passed. Tier `1` is reserved for a possible future Sigstore-based verification path; the codebase contains a Sigstore integration point, but it is currently a stub that always falls through to the TOFU check — no executable is verified via Sigstore or any package registry today. Tier `2` does not correspond to a registry signature check either; it is simply the "hash found in the trust manifest" case of the same TOFU model as tier `3`.
+
+Pass `trustTier` in setup options to set that policy label:
 
 ```ts
 const jwe = await vault.setup('MY_API_KEY', {

--- a/docs/api/wasm.md
+++ b/docs/api/wasm.md
@@ -257,7 +257,7 @@ Overall preflight result.
 
 A one-time accessor for the raw secret produced by `authorize()`<!-- -->.
 
-Mirrors the `createSecretAccessor` pattern in the TypeScript library: the plaintext secret is exposed only through a single `read()` callback and cannot be read a second time. This keeps the secret out of the default return shape and confines its lifetime to the callback.
+Mirrors the `getSecret()` pattern in the TypeScript library: the plaintext secret is exposed only through a single `read()` callback and cannot be read a second time. This keeps the secret out of the default return shape and confines its lifetime to the callback.
 
 
 </td></tr>

--- a/docs/api/wasm.secretaccessor.md
+++ b/docs/api/wasm.secretaccessor.md
@@ -6,7 +6,7 @@
 
 A one-time accessor for the raw secret produced by `authorize()`<!-- -->.
 
-Mirrors the `createSecretAccessor` pattern in the TypeScript library: the plaintext secret is exposed only through a single `read()` callback and cannot be read a second time. This keeps the secret out of the default return shape and confines its lifetime to the callback.
+Mirrors the `getSecret()` pattern in the TypeScript library: the plaintext secret is exposed only through a single `read()` callback and cannot be read a second time. This keeps the secret out of the default return shape and confines its lifetime to the callback.
 
 **Signature:**
 

--- a/packages/cli-tests/test/e2e/readme-docs-consistency.test.ts
+++ b/packages/cli-tests/test/e2e/readme-docs-consistency.test.ts
@@ -1,6 +1,6 @@
 /**
  * Docs consistency guard for the root README, extending the drift-check family
- * started by the README/CLI drift check (#62). Catches two regressions from
+ * started by the README/CLI drift check (#62). Catches regressions from
  * https://github.com/mike-north/vaultkeeper/issues/102:
  *
  * 1. An "access pattern" named in prose (e.g. in the "Which package should I
@@ -11,6 +11,14 @@
  *    contradicts the quick-start config note — both must agree that a
  *    zero-config `vaultkeeper`/`VaultKeeper.init()` resolves to the safe
  *    `file` backend (the native credential store is opt-in only).
+ * 3. A trust-tier description that overclaims a Sigstore-transparency-log or
+ *    package-registry-signature verification model. Per
+ *    `packages/vaultkeeper/src/identity/trust.ts`, the real mechanism is
+ *    TOFU-manifest hash checking: a caller's hash is "approved" (found in the
+ *    trust manifest), "not yet approved" (first encounter), or "mismatch"
+ *    (changed since approval). The Sigstore integration point is a stub that
+ *    always falls through, and "tier 2" is not a registry check — it is the
+ *    same trust-manifest lookup as tier 3.
  *
  * @see https://github.com/mike-north/vaultkeeper/issues/102
  * @see https://github.com/mike-north/vaultkeeper/issues/62
@@ -122,5 +130,31 @@ describe('README default-backend statement is internally consistent (issue #102)
 
   it('does not contain a stale [!WARNING] block warning that a bare init targets the real credential store', () => {
     expect(README.includes('[!WARNING]')).toBe(false)
+  })
+})
+
+describe('README trust-tier description matches the real TOFU-manifest mechanism (issue #102)', () => {
+  it('does not claim tier 1/2 are active Sigstore or registry-signature verification', () => {
+    // These exact phrasings previously appeared as table cells claiming an
+    // active verification mechanism; the caveat prose intentionally *names*
+    // Sigstore and registry checks while explaining they don't happen, so
+    // this asserts the old table-row phrasing specifically, not the words.
+    expect(README).not.toMatch(/Sigstore transparency log/i)
+    expect(README).not.toMatch(/\|\s*Registry signature\s*\|/i)
+    expect(README).not.toMatch(/\|\s*Intended method\s*\|/i)
+  })
+
+  it('describes the actual TOFU (trust-manifest hash) model with its three real outcomes', () => {
+    const trustSection = /## Trust tiers[\s\S]*?(?=\n## )/.exec(README)?.[0]
+    expect(trustSection, 'expected to find the "## Trust tiers" section in README.md').toBeDefined()
+    expect(trustSection).toMatch(/TOFU/)
+    expect(trustSection).toMatch(/Not yet approved/i)
+    expect(trustSection).toMatch(/Approved/)
+    expect(trustSection).toMatch(/Mismatch/i)
+    // The honest caveat: Sigstore is a non-functional stub, and "tier 2" is
+    // not a registry check — both must stay documented so this doesn't drift
+    // back to an overclaim.
+    expect(trustSection).toMatch(/stub/i)
+    expect(trustSection).toMatch(/no executable is verified via Sigstore or any package registry/i)
   })
 })

--- a/packages/cli-tests/test/e2e/readme-docs-consistency.test.ts
+++ b/packages/cli-tests/test/e2e/readme-docs-consistency.test.ts
@@ -33,10 +33,17 @@ const README = readFileSync(path.join(ROOT, 'README.md'), 'utf8')
 const VAULT_TS = readFileSync(path.join(ROOT, 'packages/vaultkeeper/src/vault.ts'), 'utf8')
 const INDEX_TS = readFileSync(path.join(ROOT, 'packages/vaultkeeper/src/index.ts'), 'utf8')
 
-/** Public (non-private, non-indented-deeper) instance method names on the `VaultKeeper` class. */
+/**
+ * Callable method names on the `VaultKeeper` class (non-private, non-getter,
+ * non-indented-deeper). Skips over any `public`/`private`/`protected`/
+ * `static`/`async` modifiers before the name so e.g. `static verify(...)`
+ * yields `verify`, not `static`. `#`-prefixed private methods and `get`/`set`
+ * accessors are excluded because they don't start with a plain identifier
+ * immediately followed by a modifier or `(`.
+ */
 export function extractVaultKeeperMethods(source: string): Set<string> {
   const names = new Set<string>()
-  const re = /^\s{2}(?:async\s+)?([a-zA-Z][a-zA-Z0-9]*)\s*\(/gm
+  const re = /^\s{2}(?:(?:public|private|protected|static|async)\s+)*([a-zA-Z][a-zA-Z0-9]*)\s*\(/gm
   let m: RegExpExecArray | null
   while ((m = re.exec(source)) !== null) {
     const name = m[1]
@@ -72,6 +79,10 @@ describe('README access-pattern names resolve to real exports', () => {
     expect(methods.has('fetch')).toBe(true)
     expect(methods.has('exec')).toBe(true)
     expect(methods.has('getSecret')).toBe(true)
+    // `static verify(...)` — the modifier itself must not be captured as a
+    // method name, and the real name after it must be.
+    expect(methods.has('static')).toBe(false)
+    expect(methods.has('verify')).toBe(true)
   })
 
   it('never names the removed createSecretAccessor as an access pattern (issue #102)', () => {
@@ -171,5 +182,18 @@ describe('README trust-tier description matches the real TOFU-manifest mechanism
     // back to an overclaim.
     expect(trustSection).toMatch(/stub/i)
     expect(trustSection).toMatch(/no executable is verified via Sigstore or any package registry/i)
+  })
+
+  it('does not claim every setup() call hashes the executable — dev-mode setup() calls skip hashing entirely', () => {
+    // packages/vaultkeeper/src/vault.ts: setup() defaults executablePath to
+    // 'dev' when none is passed, and skips verifyTrust() entirely for 'dev'
+    // or an executable registered via setDevelopmentMode(). The docs must
+    // not imply hashing is unconditional.
+    const trustSection = /## Trust tiers[\s\S]*?(?=\n## )/.exec(README)?.[0]
+    expect(trustSection, 'expected to find the "## Trust tiers" section in README.md').toBeDefined()
+    expect(trustSection).toMatch(/Hashing is skipped/i)
+    expect(trustSection).toMatch(/setDevelopmentMode/)
+    // The stale, unqualified claim this test guards against.
+    expect(trustSection).not.toMatch(/every `setup\(\)` call performs the same TOFU hash check/i)
   })
 })

--- a/packages/cli-tests/test/e2e/readme-docs-consistency.test.ts
+++ b/packages/cli-tests/test/e2e/readme-docs-consistency.test.ts
@@ -79,13 +79,16 @@ describe('README access-pattern names resolve to real exports', () => {
   })
 
   it('the "Which package should I use?" delegated-access-patterns list names only real VaultKeeper methods', () => {
-    const match = /delegated access patterns \(([^)]*)\)/.exec(README)
+    // Match the backtick-delimited items themselves (`fetch`, `exec`,
+    // `getSecret()`, ...) rather than stopping at the segment's first `)` —
+    // a naive `\(([^)]*)\)` capture stops inside `getSecret()`'s own parens,
+    // truncating the list before it reaches the real closing paren.
+    const match = /delegated access patterns \(((?:`[^`]+`,?\s*)+)\)/.exec(README)
     expect(match, 'expected to find the delegated access patterns list in README.md').not.toBeNull()
 
-    const names = (match?.[1] ?? '')
-      .split(',')
-      .map((s) => s.replace(/[`()]/g, '').trim())
-      .filter((s) => s.length > 0)
+    const names = [...(match?.[1] ?? '').matchAll(/`([^`]+)`/g)]
+      .map(([, name]) => name?.replace(/\(\)$/, '').trim())
+      .filter((s): s is string => s !== undefined && s.length > 0)
     expect(names.length).toBeGreaterThan(0)
 
     const unknown = names.filter((n) => !methods.has(n) && !publicExports.has(n))
@@ -128,8 +131,20 @@ describe('README default-backend statement is internally consistent (issue #102)
     expect(noteDefaultClause).not.toMatch(/keychain|dpapi|native credential store/i)
   })
 
-  it('does not contain a stale [!WARNING] block warning that a bare init targets the real credential store', () => {
-    expect(README.includes('[!WARNING]')).toBe(false)
+  it('no [!WARNING] block claims a bare zero-config init targets the real/native credential store', () => {
+    // Narrowly targets the specific stale claim this issue is about (see the
+    // pre-#108 text: "a bare `VaultKeeper.init()` ... targets your **real OS
+    // credential store**"), not the mere presence of a [!WARNING] block —
+    // an unrelated warning added later must not trip this check.
+    const badClaim =
+      /bare\s+(`vaultkeeper config init`|`VaultKeeper\.init\(\)`)[\s\S]{0,200}?(targets?|resolves? to)[\s\S]{0,80}?(real|platform-native)[\s\S]{0,40}?(credential store|keychain|dpapi)/i
+    const warningBlocks = [...README.matchAll(/> \[!WARNING\][\s\S]*?(?=\n\n)/g)].map((m) => m[0])
+    for (const block of warningBlocks) {
+      expect(
+        block,
+        `[!WARNING] block reintroduces the stale claim that a zero-config init targets the native store:\n${block}`,
+      ).not.toMatch(badClaim)
+    }
   })
 })
 

--- a/packages/cli-tests/test/e2e/readme-docs-consistency.test.ts
+++ b/packages/cli-tests/test/e2e/readme-docs-consistency.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Docs consistency guard for the root README, extending the drift-check family
+ * started by the README/CLI drift check (#62). Catches two regressions from
+ * https://github.com/mike-north/vaultkeeper/issues/102:
+ *
+ * 1. An "access pattern" named in prose (e.g. in the "Which package should I
+ *    use?" delegated-access-patterns list) that isn't a real `VaultKeeper`
+ *    method or a real `vaultkeeper` package export — a phantom reference like
+ *    `createSecretAccessor`, which is not exported from `src/index.ts`.
+ * 2. A default-backend statement in the package-choice summary that
+ *    contradicts the quick-start config note — both must agree that a
+ *    zero-config `vaultkeeper`/`VaultKeeper.init()` resolves to the safe
+ *    `file` backend (the native credential store is opt-in only).
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/102
+ * @see https://github.com/mike-north/vaultkeeper/issues/62
+ */
+import { readFileSync } from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..')
+const README = readFileSync(path.join(ROOT, 'README.md'), 'utf8')
+const VAULT_TS = readFileSync(path.join(ROOT, 'packages/vaultkeeper/src/vault.ts'), 'utf8')
+const INDEX_TS = readFileSync(path.join(ROOT, 'packages/vaultkeeper/src/index.ts'), 'utf8')
+
+/** Public (non-private, non-indented-deeper) instance method names on the `VaultKeeper` class. */
+export function extractVaultKeeperMethods(source: string): Set<string> {
+  const names = new Set<string>()
+  const re = /^\s{2}(?:async\s+)?([a-zA-Z][a-zA-Z0-9]*)\s*\(/gm
+  let m: RegExpExecArray | null
+  while ((m = re.exec(source)) !== null) {
+    const name = m[1]
+    if (name !== undefined) names.add(name)
+  }
+  return names
+}
+
+/** Named values/types re-exported from `src/index.ts` (the public API surface). */
+export function extractIndexExports(source: string): Set<string> {
+  const names = new Set<string>()
+  const re = /export\s+(?:type\s+)?\{([^}]*)\}/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(source)) !== null) {
+    for (const raw of (m[1] ?? '').split(',')) {
+      const name = raw
+        .trim()
+        .split(/\s+as\s+/)[0]
+        ?.trim()
+      if (name !== undefined && name !== '') names.add(name)
+    }
+  }
+  return names
+}
+
+describe('README access-pattern names resolve to real exports', () => {
+  const methods = extractVaultKeeperMethods(VAULT_TS)
+  const publicExports = extractIndexExports(INDEX_TS)
+
+  it('parses the known real VaultKeeper access-pattern methods', () => {
+    // Guard against a parser regression that would make this whole check
+    // vacuously pass by finding zero methods.
+    expect(methods.has('fetch')).toBe(true)
+    expect(methods.has('exec')).toBe(true)
+    expect(methods.has('getSecret')).toBe(true)
+  })
+
+  it('never names the removed createSecretAccessor as an access pattern (issue #102)', () => {
+    expect(README.includes('createSecretAccessor')).toBe(false)
+  })
+
+  it('the "Which package should I use?" delegated-access-patterns list names only real VaultKeeper methods', () => {
+    const match = /delegated access patterns \(([^)]*)\)/.exec(README)
+    expect(match, 'expected to find the delegated access patterns list in README.md').not.toBeNull()
+
+    const names = (match?.[1] ?? '')
+      .split(',')
+      .map((s) => s.replace(/[`()]/g, '').trim())
+      .filter((s) => s.length > 0)
+    expect(names.length).toBeGreaterThan(0)
+
+    const unknown = names.filter((n) => !methods.has(n) && !publicExports.has(n))
+    expect(
+      unknown,
+      `README names access pattern(s) with no matching VaultKeeper method or public export: ${unknown.join(', ')}`,
+    ).toEqual([])
+  })
+})
+
+describe('README default-backend statement is internally consistent (issue #102)', () => {
+  it('the package-choice summary and the quick-start config note agree that a zero-config default resolves to the file backend', () => {
+    const whichPackageBullet = /- \*\*`vaultkeeper`\*\*.*?(?=\n- \*\*)/s.exec(README)?.[0]
+    expect(
+      whichPackageBullet,
+      'expected to find the `vaultkeeper` bullet in "Which package should I use?"',
+    ).toBeDefined()
+    expect(whichPackageBullet).toMatch(/no config file present it uses the safe `file` backend/)
+
+    // README.md has more than one [!NOTE] block; anchor on the one that
+    // discusses `VaultKeeper.init()` specifically (the TypeScript quick start).
+    const configNote = [...README.matchAll(/> \[!NOTE\][\s\S]*?(?=\n\n)/g)].find((block) =>
+      block[0].includes('VaultKeeper.init()'),
+    )?.[0]
+    expect(
+      configNote,
+      'expected to find the TypeScript quick-start config [!NOTE] block',
+    ).toBeDefined()
+    expect(configNote).toMatch(/resolves to the safe, portable `file` backend/)
+
+    // Neither statement's zero-config-default clause (up to the first
+    // sentence boundary) may claim the platform-native store as the resolved
+    // default — later "opt into keychain/dpapi" language in the same
+    // sentence is expected and must not trip this check.
+    const bulletDefaultClause =
+      /no config file present it [^.;]*/i.exec(whichPackageBullet ?? '')?.[0] ?? ''
+    expect(bulletDefaultClause).not.toMatch(/keychain|dpapi|native/i)
+
+    const noteDefaultClause = /resolves to [^.;]*/i.exec(configNote ?? '')?.[0] ?? ''
+    expect(noteDefaultClause).not.toMatch(/keychain|dpapi|native credential store/i)
+  })
+
+  it('does not contain a stale [!WARNING] block warning that a bare init targets the real credential store', () => {
+    expect(README.includes('[!WARNING]')).toBe(false)
+  })
+})

--- a/packages/vaultkeeper-wasm/src/types.ts
+++ b/packages/vaultkeeper-wasm/src/types.ts
@@ -66,7 +66,7 @@ export interface VaultResponse {
 /**
  * A one-time accessor for the raw secret produced by `authorize()`.
  *
- * Mirrors the `createSecretAccessor` pattern in the TypeScript library: the
+ * Mirrors the `getSecret()` pattern in the TypeScript library: the
  * plaintext secret is exposed only through a single `read()` callback and
  * cannot be read a second time. This keeps the secret out of the default
  * return shape and confines its lifetime to the callback.


### PR DESCRIPTION
## Summary

- Fixes the phantom `createSecretAccessor` reference in the root README's "Which package should I use?" access-patterns list — it names `getSecret()`, the actual exported method (`createSecretAccessor` is not re-exported from `vaultkeeper`'s public entry point, `src/index.ts`).
- Fixes the same phantom name in a source JSDoc comment on `@vaultkeeper/wasm`'s `SecretAccessor` type (`packages/vaultkeeper-wasm/src/types.ts`), which generates `docs/api/wasm.md` and `docs/api/wasm.secretaccessor.md` — regenerated both via `pnpm build && pnpm generate:api-docs` so they stay in sync with `check:api-docs`.
- The default-backend contradiction this issue also targeted (README summary said `file`, quick-start warning implied the real OS store) was already resolved by #108/#109 landing first: the zero-config default is now `file` everywhere and the quick-start block was downgraded from `[!WARNING]` to `[!NOTE]`. No further text change was needed there.
- Fixes the "Trust tiers" section, which described tier 1 as "Sigstore transparency log" and tier 2 as "Registry signature" — implying active cryptographic-provenance/registry verification. Per `packages/vaultkeeper/src/identity/trust.ts` (and the matching Rust `crates/vaultkeeper-core/src/identity/trust.rs`), neither exists: the Sigstore integration point is a stub that always returns `false`, and "tier 2" is just the same trust-manifest hash lookup as tier 3 on an already-recorded hash. Rewrote the section to describe the real TOFU (Trust On First Use) model: a caller's hash is approved (found in the manifest), not yet approved (first encounter), or a mismatch (changed since approval).
- Adds `packages/cli-tests/test/e2e/readme-docs-consistency.test.ts`, extending the README/CLI drift-check family (#62): it parses the real `VaultKeeper` methods and `vaultkeeper` public exports and asserts every name in the README's access-patterns list resolves to one of them; asserts the package-choice summary and quick-start note agree the zero-config default resolves to `file`; and asserts the trust-tier section doesn't reintroduce the Sigstore/registry overclaim.

## Before / after

Root README, "Which package should I use?":

```diff
-  ... delegated access patterns (`fetch`, `exec`, `createSecretAccessor`) ...
+  ... delegated access patterns (`fetch`, `exec`, `getSecret()`) ...
```

`packages/vaultkeeper-wasm/src/types.ts` (source of `docs/api/wasm.md` / `docs/api/wasm.secretaccessor.md`):

```diff
- * Mirrors the `createSecretAccessor` pattern in the TypeScript library: the
+ * Mirrors the `getSecret()` pattern in the TypeScript library: the
```

Root README, "Trust tiers":

```diff
-Executable identity is verified during `setup()`. A `trustTier` value can be attached to the resulting token as a policy label.
-
-> **Note:** In the current implementation, `trustTier` is recorded in the token claims but does not change which verification mechanism is used. Future versions may introduce tier-specific verification behavior.
-
-| Tier | Intended method                                           |
-| ---- | --------------------------------------------------------- |
-| `1`  | Sigstore transparency log                                 |
-| `2`  | Registry signature                                        |
-| `3`  | TOFU (Trust On First Use) — hash stored in trust manifest |
+Executable identity is verified during `setup()` by hashing the executable (SHA-256) and checking that hash against a local trust manifest — this is a **TOFU (Trust On First Use)** model, not a package-registry or transparency-log lookup:
+
+- **Not yet approved** — first encounter with this executable path. The hash is recorded in the trust manifest so the same binary is recognized next time.
+- **Approved** — the executable's current hash matches what's recorded in the trust manifest (via `vaultkeeper approve --script <path>` or a prior `setup()` call).
+- **Mismatch** — the executable's current hash differs from what's recorded (the binary was rebuilt or replaced). `setup()` throws `IdentityMismatchError`; re-approve with `vaultkeeper approve --script <caller>`.
+
+A `trustTier` value (`1`, `2`, or `3`) can also be attached to the resulting token as a policy label, independent of the TOFU check above.
+
+> **Note:** `trustTier` is recorded in the token claims as a label only — it does not select or change which verification mechanism runs; every `setup()` call performs the same TOFU hash check regardless of the `trustTier` value passed. Tier `1` is reserved for a possible future Sigstore-based verification path; the codebase contains a Sigstore integration point, but it is currently a stub that always falls through to the TOFU check — no executable is verified via Sigstore or any package registry today. Tier `2` does not correspond to a registry signature check either; it is simply the "hash found in the trust manifest" case of the same TOFU model as tier `3`.
```

## Changeset

Added a patch changeset for `@vaultkeeper/wasm` (doc-comment-only change to a published package's source, no behavior change). The root README/docs/test changes are in the private workspace root and unpublished packages, so no changeset needed for those.

## Test plan

- [x] `pnpm build && pnpm check:api-report && pnpm generate:api-docs` — regenerated `docs/api/wasm.md` / `docs/api/wasm.secretaccessor.md`; `pnpm check:api-docs` confirms they're in sync
- [x] `pnpm check` (typecheck + lint + api-report) green
- [x] New test file passes (`pnpm --filter @vaultkeeper/cli-tests exec vitest run test/e2e/readme-docs-consistency.test.ts`); verified each of its checks fails against the pre-fix text (createSecretAccessor, Sigstore/registry table) and passes with the fix
- [x] Existing `readme-cli-drift.test.ts` still green
- [x] `@vaultkeeper/wasm` test suite green (34/34) after the JSDoc change
- [x] Prettier clean