### PR TITLE
Add a TypeScript-version compatibility matrix for the shipped .d.ts

### DIFF
--- a/.changeset/ts-version-matrix.md
+++ b/.changeset/ts-version-matrix.md
@@ -1,0 +1,5 @@
+---
+'vaultkeeper': patch
+---
+
+Replace the guessed "TypeScript 5.x" README note with the actually-tested range: a CI matrix (`packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts`) now typechecks the shipped `.d.ts` of `vaultkeeper`, `@vaultkeeper/test-helpers`, and `@vaultkeeper/cli-test-helpers` against pinned TypeScript 5.0.4, 5.9.3, 6.0.3, and 7.0.2 compilers — all pass, so both READMEs now state a tested 5.0.4–7.0.2 range instead of a narrower guess.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,5 +79,12 @@ jobs:
       - name: Make binary executable
         run: chmod +x target/release/vaultkeeper
 
-      - name: Test (including conformance)
+      # Standalone, non-workspace install of the pinned TypeScript compiler
+      # versions used by the consumer-typecheck TS-version matrix (#125).
+      # Kept out of pnpm-workspace.yaml — see that directory's package.json
+      # for why — so it needs its own install step here.
+      - name: Install TS-version matrix compilers
+        run: pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace
+
+      - name: Test (including conformance and TS-version matrix)
         run: pnpm test

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pnpm add vaultkeeper
 pnpm add -D @types/node
 ```
 
-**Supported TypeScript version:** this package requires TypeScript 5.x to typecheck against the shipped `.d.ts` files (the output relies on `verbatimModuleSyntax`). Install a 5.x compiler explicitly — `npm install -D typescript@5` — rather than a bare `npm install -D typescript`, which installs whatever major is current and may not be 5.x.
+**Supported TypeScript version:** tested against TypeScript 5.0.4–7.0.2 (the stated floor plus the latest release of the 5.x, 6.x, and 7.x majors) — all typecheck cleanly against the shipped `.d.ts` files (the output relies on `verbatimModuleSyntax`). A bare `npm install -D typescript` is fine; this range is verified by a CI matrix (`packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts`) so a future `.d.ts` change that breaks a tested version fails the build.
 
 The package ships both ESM (`import`) and CommonJS (`require()`) builds. The `exports` map selects the correct build automatically, but consumers still need the standard ESM/CJS project setup (e.g. `"type": "module"` for ESM) — see the [TypeScript quick start](#typescript-quick-start) below for both forms.
 

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -16,7 +16,7 @@ secret never appears in a return value.
 pnpm add vaultkeeper
 ```
 
-**Requirements:** Node >= 20. Typechecking against the shipped `.d.ts` files requires TypeScript 5.x (the output relies on `verbatimModuleSyntax`). Install a 5.x compiler explicitly — `npm install -D typescript@5` — rather than a bare `npm install -D typescript`, which installs whatever major is current and may not be 5.x.
+**Requirements:** Node >= 20. **TypeScript version:** tested against TypeScript 5.0.4–7.0.2 (the stated floor plus the latest release of the 5.x, 6.x, and 7.x majors) — all typecheck cleanly against the shipped `.d.ts` files (the output relies on `verbatimModuleSyntax`). A bare `npm install -D typescript` is fine; this range is verified by a CI matrix (`packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts`) so a future `.d.ts` change that breaks a tested version fails the build.
 
 ## Quick start
 

--- a/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
+++ b/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
@@ -1,25 +1,45 @@
 /**
- * End-to-end test verifying that the published `.d.ts` typechecks in a
- * standard strict consumer project — without the consumer adding an
- * explicit `"types": ["node"]` override to their tsconfig.
+ * End-to-end test verifying that the published `.d.ts` of vaultkeeper's
+ * public packages (`vaultkeeper`, `@vaultkeeper/test-helpers`,
+ * `@vaultkeeper/cli-test-helpers`) typechecks in a standard strict consumer
+ * project across a matrix of pinned TypeScript compiler versions — without
+ * the consumer adding an explicit `"types": ["node"]` override to their
+ * tsconfig.
  *
  * `SecretAccessor.read()`, `SignRequest.data`, and `VerifyRequest.data`
- * reference `Buffer`. Before the fix, the rollup relied on the ambient
- * global `Buffer` type. Confirmed against a real `npm pack` + `npm install`
- * consumer (not just this fixture harness): with a strict NodeNext tsconfig
- * that sets `"types": []` — the common pattern in monorepo boilerplates that
- * scope ambient globals explicitly rather than auto-including every
- * `@types/*` package — the pre-fix rollup fails with `TS2591: Cannot find
- * name 'Buffer'` even though `@types/node` is installed, and adding
- * `"node"` to `types` (the documented workaround) or applying this fix both
- * resolve it. This test packs the real published shape (via a linked
- * build, not source-internal module resolution) and typechecks a consumer
- * file against it under that same `"types": []` condition.
+ * reference `Buffer`. Before the fix for #72, the rollup relied on the
+ * ambient global `Buffer` type. Confirmed against a real `npm pack` + `npm
+ * install` consumer (not just this fixture harness): with a strict NodeNext
+ * tsconfig that sets `"types": []` — the common pattern in monorepo
+ * boilerplates that scope ambient globals explicitly rather than
+ * auto-including every `@types/*` package — the pre-fix rollup fails with
+ * `TS2591: Cannot find name 'Buffer'` even though `@types/node` is
+ * installed, and adding `"node"` to `types` (the documented workaround) or
+ * applying this fix both resolve it. This test packs the real published
+ * shape (via a linked build, not source-internal module resolution) and
+ * typechecks a consumer file against it under that same `"types": []`
+ * condition.
+ *
+ * The stated TypeScript-version support range in both READMEs
+ * (`README.md`, `packages/vaultkeeper/README.md`) is derived from this
+ * matrix, not guessed (#125). If a pinned version here changes or a cell
+ * starts failing, update the README range to match — see the matrix result
+ * summary in that issue's PR.
  *
  * Uses `fixturify-project` to create an isolated consumer project outside
  * the monorepo, matching the pattern in `backend-registration.test.ts`.
  *
+ * Requires `pnpm build` to have run for `vaultkeeper`, `@vaultkeeper/test-helpers`,
+ * and `@vaultkeeper/cli-test-helpers`, and requires the pinned TypeScript
+ * compilers in `./ts-version-fixtures` to have been installed via
+ * `pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --ignore-workspace`
+ * (see that directory's `package.json` for why it's a standalone,
+ * non-workspace install). Matrix cells for which the pinned compiler isn't
+ * installed are skipped, not failed, so local runs without that setup step
+ * still pass; CI always installs the fixtures first.
+ *
  * @see https://github.com/mike-north/vaultkeeper/issues/72
+ * @see https://github.com/mike-north/vaultkeeper/issues/125
  */
 
 import { describe, it, expect, afterEach } from 'vitest'
@@ -34,7 +54,63 @@ const execFileAsync = promisify(execFile)
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
 
-describe('published .d.ts typechecks Buffer-typed API in strict consumers (issue #72)', () => {
+/**
+ * Pinned TypeScript compiler versions typechecked against the shipped
+ * `.d.ts`. Chosen per #125's acceptance criteria: the stated floor
+ * (5.0.x), the latest 5.x, and the latest 6.x/7.x (to establish whether
+ * newer majors work). Update alongside `./ts-version-fixtures/package.json`
+ * and the README TypeScript-version note if this list changes.
+ */
+const TS_VERSIONS = [
+  { label: 'TypeScript 5.0.4 (stated floor)', packageAlias: 'typescript-5-0' },
+  { label: 'TypeScript 5.9.3 (latest 5.x)', packageAlias: 'typescript-5-9' },
+  { label: 'TypeScript 6.0.3 (latest 6.x)', packageAlias: 'typescript-6-0' },
+  { label: 'TypeScript 7.0.2 (latest 7.x)', packageAlias: 'typescript-7-0' },
+] as const
+
+const fixturesRoot = resolve(__dirname, 'ts-version-fixtures')
+
+/** Resolves the installed root of a pinned compiler, or undefined if the standalone fixtures install hasn't been run. */
+function resolveFixtureTypescriptRoot(packageAlias: string): string | undefined {
+  try {
+    return dirname(require.resolve(`${packageAlias}/package.json`, { paths: [fixturesRoot] }))
+  } catch {
+    return undefined
+  }
+}
+
+const consumerSource = [
+  `import type { SecretAccessor, SignRequest, VerifyRequest } from 'vaultkeeper'`,
+  `import { TestVault } from '@vaultkeeper/test-helpers'`,
+  `import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'`,
+  ``,
+  `function useAccessor(accessor: SecretAccessor): void {`,
+  `  accessor.read((buf) => {`,
+  `    buf.toString('utf8')`,
+  `  })`,
+  `}`,
+  ``,
+  `function useSignRequest(req: SignRequest): string | Buffer {`,
+  `  return req.data`,
+  `}`,
+  ``,
+  `function useVerifyRequest(req: VerifyRequest): string | Buffer {`,
+  `  return req.data`,
+  `}`,
+  ``,
+  `async function useTestVault(): Promise<TestVault> {`,
+  `  return TestVault.create()`,
+  `}`,
+  ``,
+  `async function useCliTestEnv(): Promise<void> {`,
+  `  const env = await createCliTestEnv()`,
+  `  await env.cleanup()`,
+  `}`,
+  ``,
+  `export { useAccessor, useSignRequest, useVerifyRequest, useTestVault, useCliTestEnv }`,
+].join('\n')
+
+describe('published .d.ts typechecks across the supported TypeScript version matrix (issue #125)', () => {
   let project: Project | undefined
 
   afterEach(() => {
@@ -42,80 +118,79 @@ describe('published .d.ts typechecks Buffer-typed API in strict consumers (issue
     project = undefined
   })
 
-  it('should typecheck when the consumer scopes ambient globals with "types": []', async () => {
-    project = new Project('vaultkeeper-dts-consumer', '1.0.0')
-    project.mergeFiles({
-      'package.json': JSON.stringify({
-        name: 'vaultkeeper-dts-consumer',
-        version: '1.0.0',
-        type: 'module',
-      }),
-      'tsconfig.json': JSON.stringify({
-        compilerOptions: {
-          target: 'ES2022',
-          module: 'NodeNext',
-          moduleResolution: 'NodeNext',
-          strict: true,
-          skipLibCheck: false,
-          noEmit: true,
-          // Deliberately scopes ambient globals to none, as many strict
-          // monorepo tsconfigs do. This is the reliably reproducible
-          // trigger verified for issue #72 (the issue's literal "no types
-          // array" setup doesn't reproduce on TS 5.9; explicit types: []
-          // does): `@types/node` is installed (linked below) but not
-          // auto-included, so the published `.d.ts` must resolve `Buffer`
-          // via a real import rather than relying on the ambient global.
-          types: [],
-        },
-        include: ['consumer.ts'],
-      }),
-      'consumer.ts': [
-        `import type { SecretAccessor, SignRequest, VerifyRequest } from 'vaultkeeper'`,
-        ``,
-        `function useAccessor(accessor: SecretAccessor): void {`,
-        `  accessor.read((buf) => {`,
-        `    buf.toString('utf8')`,
-        `  })`,
-        `}`,
-        ``,
-        `function useSignRequest(req: SignRequest): string | Buffer {`,
-        `  return req.data`,
-        `}`,
-        ``,
-        `function useVerifyRequest(req: VerifyRequest): string | Buffer {`,
-        `  return req.data`,
-        `}`,
-        ``,
-        `export { useAccessor, useSignRequest, useVerifyRequest }`,
-      ].join('\n'),
-    })
+  it.each(TS_VERSIONS)(
+    'typechecks under $label',
+    async ({ packageAlias, label }) => {
+      const typescriptRoot = resolveFixtureTypescriptRoot(packageAlias)
+      if (!typescriptRoot) {
+        console.warn(
+          `Skipping "${label}": pinned compiler "${packageAlias}" isn't installed. ` +
+            `Run: pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --ignore-workspace`,
+        )
+        return
+      }
 
-    // Link the local vaultkeeper build (requires `pnpm build` to have run).
-    const vaultkeeperRoot = resolve(__dirname, '..', '..')
-    project.linkDependency('vaultkeeper', { target: vaultkeeperRoot })
+      project = new Project('vaultkeeper-dts-consumer', '1.0.0')
+      project.mergeFiles({
+        'package.json': JSON.stringify({
+          name: 'vaultkeeper-dts-consumer',
+          version: '1.0.0',
+          type: 'module',
+        }),
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'NodeNext',
+            moduleResolution: 'NodeNext',
+            strict: true,
+            skipLibCheck: false,
+            noEmit: true,
+            // Deliberately scopes ambient globals to none, as many strict
+            // monorepo tsconfigs do. This is the reliably reproducible
+            // trigger verified for issue #72 (the issue's literal "no types
+            // array" setup doesn't reproduce on TS 5.9; explicit types: []
+            // does): `@types/node` is installed (linked below) but not
+            // auto-included, so the published `.d.ts` must resolve `Buffer`
+            // via a real import rather than relying on the ambient global.
+            types: [],
+          },
+          include: ['consumer.ts'],
+        }),
+        'consumer.ts': consumerSource,
+      })
 
-    // Link the monorepo's own typescript and @types/node so the consumer
-    // project typechecks with the same compiler/lib versions as CI,
-    // without a network install.
-    const typescriptRoot = dirname(require.resolve('typescript/package.json'))
-    project.linkDependency('typescript', { target: typescriptRoot })
+      // Link the local builds (requires `pnpm build` to have run for these
+      // three packages).
+      const vaultkeeperRoot = resolve(__dirname, '..', '..')
+      const testHelpersRoot = resolve(__dirname, '..', '..', '..', 'test-helpers')
+      const cliTestHelpersRoot = resolve(__dirname, '..', '..', '..', 'cli-test-helpers')
+      project.linkDependency('vaultkeeper', { target: vaultkeeperRoot })
+      project.linkDependency('@vaultkeeper/test-helpers', { target: testHelpersRoot })
+      project.linkDependency('@vaultkeeper/cli-test-helpers', { target: cliTestHelpersRoot })
 
-    const typesNodeRoot = dirname(require.resolve('@types/node/package.json'))
-    project.linkDependency('@types/node', { target: typesNodeRoot })
+      // Link the pinned compiler for this matrix cell.
+      project.linkDependency('typescript', { target: typescriptRoot })
 
-    await project.write()
+      // Link the monorepo's own @types/node so every cell typechecks against
+      // the same lib files, without a network install.
+      const typesNodeRoot = dirname(require.resolve('@types/node/package.json'))
+      project.linkDependency('@types/node', { target: typesNodeRoot })
 
-    const tscBin = resolve(typescriptRoot, 'bin', 'tsc')
+      await project.write()
 
-    // A real tsc invocation (loading the compiler, @types/node's lib
-    // files, and the vaultkeeper rollup) is slow on CI runners relative
-    // to vitest's 5s default test timeout, so both the test and the
-    // child process get a generous budget here.
-    await expect(
-      execFileAsync('node', [tscBin, '--noEmit'], {
-        cwd: project.baseDir,
-        timeout: 90_000,
-      }),
-    ).resolves.toBeDefined()
-  }, 120_000)
+      const tscBin = resolve(typescriptRoot, 'bin', 'tsc')
+
+      // A real tsc invocation (loading the compiler, @types/node's lib
+      // files, and the vaultkeeper rollup) is slow on CI runners relative
+      // to vitest's 5s default test timeout, so both the test and the
+      // child process get a generous budget here.
+      await expect(
+        execFileAsync('node', [tscBin, '--noEmit'], {
+          cwd: project.baseDir,
+          timeout: 90_000,
+        }),
+      ).resolves.toBeDefined()
+    },
+    120_000,
+  )
 })

--- a/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
+++ b/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
@@ -35,8 +35,12 @@
  * `pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --ignore-workspace`
  * (see that directory's `package.json` for why it's a standalone,
  * non-workspace install). Matrix cells for which the pinned compiler isn't
- * installed are skipped, not failed, so local runs without that setup step
- * still pass; CI always installs the fixtures first.
+ * installed are registered as real Vitest skips via `it.skipIf` (mirroring
+ * the conformance runner's `describe.skipIf` pattern) — not a silent early
+ * `return`, which Vitest would otherwise report as a false pass — so local
+ * runs without that setup step show honest "skipped" cells instead of
+ * misleadingly green ones; CI always installs the fixtures first, so every
+ * cell actually runs there.
  *
  * @see https://github.com/mike-north/vaultkeeper/issues/72
  * @see https://github.com/mike-north/vaultkeeper/issues/125
@@ -54,20 +58,6 @@ const execFileAsync = promisify(execFile)
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
 
-/**
- * Pinned TypeScript compiler versions typechecked against the shipped
- * `.d.ts`. Chosen per #125's acceptance criteria: the stated floor
- * (5.0.x), the latest 5.x, and the latest 6.x/7.x (to establish whether
- * newer majors work). Update alongside `./ts-version-fixtures/package.json`
- * and the README TypeScript-version note if this list changes.
- */
-const TS_VERSIONS = [
-  { label: 'TypeScript 5.0.4 (stated floor)', packageAlias: 'typescript-5-0' },
-  { label: 'TypeScript 5.9.3 (latest 5.x)', packageAlias: 'typescript-5-9' },
-  { label: 'TypeScript 6.0.3 (latest 6.x)', packageAlias: 'typescript-6-0' },
-  { label: 'TypeScript 7.0.2 (latest 7.x)', packageAlias: 'typescript-7-0' },
-] as const
-
 const fixturesRoot = resolve(__dirname, 'ts-version-fixtures')
 
 /** Resolves the installed root of a pinned compiler, or undefined if the standalone fixtures install hasn't been run. */
@@ -78,6 +68,24 @@ function resolveFixtureTypescriptRoot(packageAlias: string): string | undefined 
     return undefined
   }
 }
+
+/**
+ * Pinned TypeScript compiler versions typechecked against the shipped
+ * `.d.ts`. Chosen per #125's acceptance criteria: the stated floor
+ * (5.0.x), the latest 5.x, and the latest 6.x/7.x (to establish whether
+ * newer majors work). Update alongside `./ts-version-fixtures/package.json`
+ * and the README TypeScript-version note if this list changes.
+ *
+ * `typescriptRoot` is resolved once at module load (a synchronous
+ * `require.resolve`), not inside the test body, so `it.skipIf` below can
+ * make a real skip/run decision per cell before Vitest registers the test.
+ */
+const TS_VERSIONS = [
+  { label: 'TypeScript 5.0.4 (stated floor)', packageAlias: 'typescript-5-0' },
+  { label: 'TypeScript 5.9.3 (latest 5.x)', packageAlias: 'typescript-5-9' },
+  { label: 'TypeScript 6.0.3 (latest 6.x)', packageAlias: 'typescript-6-0' },
+  { label: 'TypeScript 7.0.2 (latest 7.x)', packageAlias: 'typescript-7-0' },
+].map((entry) => ({ ...entry, typescriptRoot: resolveFixtureTypescriptRoot(entry.packageAlias) }))
 
 const consumerSource = [
   `import type { SecretAccessor, SignRequest, VerifyRequest } from 'vaultkeeper'`,
@@ -118,79 +126,84 @@ describe('published .d.ts typechecks across the supported TypeScript version mat
     project = undefined
   })
 
-  it.each(TS_VERSIONS)(
-    'typechecks under $label',
-    async ({ packageAlias, label }) => {
-      const typescriptRoot = resolveFixtureTypescriptRoot(packageAlias)
-      if (!typescriptRoot) {
-        console.warn(
-          `Skipping "${label}": pinned compiler "${packageAlias}" isn't installed. ` +
-            `Run: pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --ignore-workspace`,
-        )
-        return
-      }
+  for (const { label, typescriptRoot } of TS_VERSIONS) {
+    // A real vitest skip (registers the cell as "skipped" in the report),
+    // not a silent early `return` from inside the test body — an early
+    // `return` would still report the cell as passed, which is misleading
+    // when the pinned compiler was never actually invoked. Mirrors the
+    // conformance runner's `describe.skipIf` pattern for an unavailable
+    // dependency.
+    it.skipIf(!typescriptRoot)(
+      `typechecks under ${label}`,
+      async () => {
+        // Narrowed by skipIf above: this branch only runs when resolved.
+        if (!typescriptRoot) {
+          throw new Error(`unreachable: "${label}" should have been skipped`)
+        }
 
-      project = new Project('vaultkeeper-dts-consumer', '1.0.0')
-      project.mergeFiles({
-        'package.json': JSON.stringify({
-          name: 'vaultkeeper-dts-consumer',
-          version: '1.0.0',
-          type: 'module',
-        }),
-        'tsconfig.json': JSON.stringify({
-          compilerOptions: {
-            target: 'ES2022',
-            module: 'NodeNext',
-            moduleResolution: 'NodeNext',
-            strict: true,
-            skipLibCheck: false,
-            noEmit: true,
-            // Deliberately scopes ambient globals to none, as many strict
-            // monorepo tsconfigs do. This is the reliably reproducible
-            // trigger verified for issue #72 (the issue's literal "no types
-            // array" setup doesn't reproduce on TS 5.9; explicit types: []
-            // does): `@types/node` is installed (linked below) but not
-            // auto-included, so the published `.d.ts` must resolve `Buffer`
-            // via a real import rather than relying on the ambient global.
-            types: [],
-          },
-          include: ['consumer.ts'],
-        }),
-        'consumer.ts': consumerSource,
-      })
+        project = new Project('vaultkeeper-dts-consumer', '1.0.0')
+        project.mergeFiles({
+          'package.json': JSON.stringify({
+            name: 'vaultkeeper-dts-consumer',
+            version: '1.0.0',
+            type: 'module',
+          }),
+          'tsconfig.json': JSON.stringify({
+            compilerOptions: {
+              target: 'ES2022',
+              module: 'NodeNext',
+              moduleResolution: 'NodeNext',
+              strict: true,
+              skipLibCheck: false,
+              noEmit: true,
+              // Deliberately scopes ambient globals to none, as many strict
+              // monorepo tsconfigs do. This is the reliably reproducible
+              // trigger verified for issue #72 (the issue's literal "no
+              // types array" setup doesn't reproduce on TS 5.9; explicit
+              // types: [] does): `@types/node` is installed (linked below)
+              // but not auto-included, so the published `.d.ts` must
+              // resolve `Buffer` via a real import rather than relying on
+              // the ambient global.
+              types: [],
+            },
+            include: ['consumer.ts'],
+          }),
+          'consumer.ts': consumerSource,
+        })
 
-      // Link the local builds (requires `pnpm build` to have run for these
-      // three packages).
-      const vaultkeeperRoot = resolve(__dirname, '..', '..')
-      const testHelpersRoot = resolve(__dirname, '..', '..', '..', 'test-helpers')
-      const cliTestHelpersRoot = resolve(__dirname, '..', '..', '..', 'cli-test-helpers')
-      project.linkDependency('vaultkeeper', { target: vaultkeeperRoot })
-      project.linkDependency('@vaultkeeper/test-helpers', { target: testHelpersRoot })
-      project.linkDependency('@vaultkeeper/cli-test-helpers', { target: cliTestHelpersRoot })
+        // Link the local builds (requires `pnpm build` to have run for
+        // these three packages).
+        const vaultkeeperRoot = resolve(__dirname, '..', '..')
+        const testHelpersRoot = resolve(__dirname, '..', '..', '..', 'test-helpers')
+        const cliTestHelpersRoot = resolve(__dirname, '..', '..', '..', 'cli-test-helpers')
+        project.linkDependency('vaultkeeper', { target: vaultkeeperRoot })
+        project.linkDependency('@vaultkeeper/test-helpers', { target: testHelpersRoot })
+        project.linkDependency('@vaultkeeper/cli-test-helpers', { target: cliTestHelpersRoot })
 
-      // Link the pinned compiler for this matrix cell.
-      project.linkDependency('typescript', { target: typescriptRoot })
+        // Link the pinned compiler for this matrix cell.
+        project.linkDependency('typescript', { target: typescriptRoot })
 
-      // Link the monorepo's own @types/node so every cell typechecks against
-      // the same lib files, without a network install.
-      const typesNodeRoot = dirname(require.resolve('@types/node/package.json'))
-      project.linkDependency('@types/node', { target: typesNodeRoot })
+        // Link the monorepo's own @types/node so every cell typechecks
+        // against the same lib files, without a network install.
+        const typesNodeRoot = dirname(require.resolve('@types/node/package.json'))
+        project.linkDependency('@types/node', { target: typesNodeRoot })
 
-      await project.write()
+        await project.write()
 
-      const tscBin = resolve(typescriptRoot, 'bin', 'tsc')
+        const tscBin = resolve(typescriptRoot, 'bin', 'tsc')
 
-      // A real tsc invocation (loading the compiler, @types/node's lib
-      // files, and the vaultkeeper rollup) is slow on CI runners relative
-      // to vitest's 5s default test timeout, so both the test and the
-      // child process get a generous budget here.
-      await expect(
-        execFileAsync('node', [tscBin, '--noEmit'], {
-          cwd: project.baseDir,
-          timeout: 90_000,
-        }),
-      ).resolves.toBeDefined()
-    },
-    120_000,
-  )
+        // A real tsc invocation (loading the compiler, @types/node's lib
+        // files, and the vaultkeeper rollup) is slow on CI runners relative
+        // to vitest's 5s default test timeout, so both the test and the
+        // child process get a generous budget here.
+        await expect(
+          execFileAsync('node', [tscBin, '--noEmit'], {
+            cwd: project.baseDir,
+            timeout: 90_000,
+          }),
+        ).resolves.toBeDefined()
+      },
+      120_000,
+    )
+  }
 })

--- a/packages/vaultkeeper/test/e2e/ts-version-fixtures/package.json
+++ b/packages/vaultkeeper/test/e2e/ts-version-fixtures/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "vaultkeeper-ts-version-matrix-fixtures",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Isolated, non-workspace install of pinned TypeScript compiler versions used only by test/e2e/consumer-typecheck.test.ts's version matrix. Kept out of pnpm-workspace.yaml deliberately: adding these as workspace devDependencies pollutes pnpm's peer-dependency resolution for tsup's bundled rollup-plugin-dts (it auto-installs a stray incompatible typescript peer and crashes `pnpm build`). Install standalone via `pnpm --dir <this dir> install --ignore-workspace` (the `--ignore-workspace` is required — otherwise pnpm walks up to the repo root's pnpm-workspace.yaml and silently skips this directory since it isn't a declared member).",
+  "devDependencies": {
+    "typescript-5-0": "npm:typescript@5.0.4",
+    "typescript-5-9": "npm:typescript@5.9.3",
+    "typescript-6-0": "npm:typescript@6.0.3",
+    "typescript-7-0": "npm:typescript@7.0.2"
+  }
+}

--- a/packages/vaultkeeper/test/e2e/ts-version-fixtures/pnpm-lock.yaml
+++ b/packages/vaultkeeper/test/e2e/ts-version-fixtures/pnpm-lock.yaml
@@ -1,0 +1,255 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript-5-0:
+        specifier: npm:typescript@5.0.4
+        version: typescript@5.0.4
+      typescript-5-9:
+        specifier: npm:typescript@5.9.3
+        version: typescript@5.9.3
+      typescript-6-0:
+        specifier: npm:typescript@6.0.3
+        version: typescript@6.0.3
+      typescript-7-0:
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
+
+packages:
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  typescript@5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
+    engines: {node: '>=12.20'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
+snapshots:
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  typescript@5.0.4: {}
+
+  typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2


### PR DESCRIPTION
## Summary

Generalizes the single-version consumer-typecheck smoke test (`packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts`, from #72/#16) into a matrix, reusing the existing `fixturify-project` harness rather than building a parallel one.

**Versions tested (pinned, real published `.d.ts`, packed artifact not source-internal resolution):**

| TypeScript version | Result |
|---|---|
| 5.0.4 (stated floor) | ✅ pass |
| 5.9.3 (latest 5.x) | ✅ pass |
| 6.0.3 (latest 6.x) | ✅ pass |
| 7.0.2 (latest 7.x) | ✅ pass |

All four cells typecheck a consumer file (under a strict NodeNext tsconfig with `"types": []`) that imports the public API of all three public packages: `vaultkeeper`, `@vaultkeeper/test-helpers`, and `@vaultkeeper/cli-test-helpers`.

**Result:** the actually-supported range is broader than the guess in #119 ("TypeScript 5.x"). Both READMEs (`README.md`, `packages/vaultkeeper/README.md`) now state the tested **5.0.4–7.0.2** range and no longer tell consumers to pin `typescript@5` explicitly — a bare `npm install -D typescript` is fine.

**Where the pinned compilers live:** `packages/vaultkeeper/test/e2e/ts-version-fixtures/` is a standalone, non-workspace `package.json` (with its own lockfile) declaring `typescript-5-0`/`typescript-5-9`/`typescript-6-0`/`typescript-7-0` as `npm:`-aliased devDependencies. It's deliberately kept out of `pnpm-workspace.yaml`: adding these pinned versions as devDependencies of `vaultkeeper` (or anywhere else in the main workspace) pollutes pnpm's peer-dependency resolution for `tsup`'s bundled `rollup-plugin-dts`, which auto-installs a stray incompatible `typescript` peer and crashes `pnpm build` — confirmed by reproducing it, then isolating the fixtures directory as the fix. It's installed via `pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --ignore-workspace` (the flag is required — otherwise pnpm resolves to the repo root's workspace and silently no-ops).

**CI wiring:** `.github/workflows/ci.yml` gets a new step installing the pinned compilers before the `pnpm test` step, so a future `.d.ts` change that breaks a supported version fails the build. The matrix itself is fast (~5s for all 4 cells, well within `pnpm test`'s existing budget) and runs automatically as part of `test/e2e/consumer-typecheck.test.ts` — no separate CI job needed. Matrix cells gracefully skip (with a console warning) rather than fail if the pinned-compiler fixtures aren't installed, so local `pnpm test` still passes without the extra setup step; CI always installs them first.

Changeset: `vaultkeeper` patch (README-only doc change, following the precedent set by #119's `readme-self-sufficiency` changeset).

## Test plan

- [x] `pnpm exec vitest run test/e2e/consumer-typecheck.test.ts` — all 4 matrix cells pass
- [x] `pnpm check` (typecheck + lint + api-report) — green
- [x] `pnpm check:api-docs` — green (no public API change)
- [x] `pnpm test` — full suite green (Rust conformance skips gracefully; no `cargo` available in this environment)
- [x] Verified the graceful-skip path by temporarily removing the fixtures' `node_modules` and re-running — cells skip with a warning instead of failing
- [x] Verified the CI install step (`pnpm --dir ... install --frozen-lockfile --ignore-workspace`) against the committed fixtures lockfile

Refs #125