### PR TITLE
Fix CLI config errors to give a CLI-native remediation, not install @vaultkeeper/cli

### DIFF
--- a/.changeset/cli-native-config-remediation.md
+++ b/.changeset/cli-native-config-remediation.md
@@ -1,0 +1,5 @@
+---
+'@vaultkeeper/cli': patch
+---
+
+Fixed the CLI printing the library's "install @vaultkeeper/cli" remediation when it hit an invalid config (`ConfigParseError`/`ConfigValidationError`) — a user already running this CLI was told to install a CLI they already had. The CLI now prints its own remediation naming the file path and the actual recovery command: "The config at `<path>` is invalid — run `vaultkeeper config init --force` to overwrite it." The library's own message (used by JS-API consumers) is unchanged.

--- a/packages/cli-tests/test/e2e/config.test.ts
+++ b/packages/cli-tests/test/e2e/config.test.ts
@@ -176,6 +176,15 @@ describe('config command', () => {
   // Repro from issue #68: a syntactically invalid config.json must never be
   // dumped verbatim with exit 0 — it must fail with the parse error, the
   // file path, a parse location, and a remediation hint.
+  //
+  // Issue #114: the remediation hint must be CLI-native ("run `vaultkeeper
+  // config init --force`"), not the library's "install @vaultkeeper/cli"
+  // text — a user running this CLI already has it installed. The library's
+  // own field-level validation reason (e.g. "version must be 1") is no
+  // longer echoed verbatim, since it travels only inside the library's
+  // message alongside that wrong remediation (issue #100); the CLI instead
+  // builds its own message from the error's structured, remediation-free
+  // fields (path, and — for a parse error — its line/column location).
   it('should exit non-zero with path, parse location, and remediation hint for corrupt config.json (issue #68 repro)', async () => {
     env = await createCliTestEnv()
     await fs.writeFile(path.join(env.configDir, 'config.json'), '{ bad json', 'utf8')
@@ -184,7 +193,8 @@ describe('config command', () => {
     expect(result.stdout).toBe('')
     expect(result.stderr).toContain(path.join(env.configDir, 'config.json'))
     expect(result.stderr).toMatch(/line \d+, column \d+/)
-    expect(result.stderr).toContain('vaultkeeper config init')
+    expect(result.stderr).toContain('vaultkeeper config init --force')
+    expect(result.stderr).not.toContain('install @vaultkeeper/cli')
   })
 
   it('should exit non-zero with path and remediation hint for a structurally invalid config.json', async () => {
@@ -197,8 +207,8 @@ describe('config command', () => {
     const result = await env.run(['config', 'show'])
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).toContain(path.join(env.configDir, 'config.json'))
-    expect(result.stderr).toContain('version must be 1')
-    expect(result.stderr).toContain('vaultkeeper config init')
+    expect(result.stderr).toContain('vaultkeeper config init --force')
+    expect(result.stderr).not.toContain('install @vaultkeeper/cli')
   })
 
   it('should exit 2 for config with no subcommand', async () => {

--- a/packages/cli-tests/test/e2e/store-delete.test.ts
+++ b/packages/cli-tests/test/e2e/store-delete.test.ts
@@ -81,7 +81,13 @@ describe('store and delete lifecycle', () => {
   // "Failed to parse config file at <path>" and no location or remediation.
   // The error must now include the file path, a parse location, and a
   // remediation hint naming `vaultkeeper config init`.
-  it('store should exit non-zero with path, parse location, and remediation hint for corrupt config.json (issue #68 repro)', async () => {
+  //
+  // Issue #114 (acceptance criterion 4): a user running `vaultkeeper store`
+  // is already running the CLI, so the remediation must be CLI-native
+  // ("run `vaultkeeper config init --force`") — never the library's
+  // "install @vaultkeeper/cli" text, which is the wrong advice for someone
+  // who already has it installed.
+  it('store should exit non-zero with a CLI-native remediation (path, parse location, config init --force) for corrupt config.json (issues #68, #114)', async () => {
     env = await createCliTestEnv()
     await fs.writeFile(path.join(env.configDir, 'config.json'), '{ bad json', 'utf8')
     const result = await env.runWithStdin(
@@ -91,7 +97,8 @@ describe('store and delete lifecycle', () => {
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).toContain(path.join(env.configDir, 'config.json'))
     expect(result.stderr).toMatch(/line \d+, column \d+/)
-    expect(result.stderr).toContain('vaultkeeper config init')
+    expect(result.stderr).toContain('vaultkeeper config init --force')
+    expect(result.stderr).not.toContain('install @vaultkeeper/cli')
   })
 
   // No-config story (issue #68): store falls back to the default backend and

--- a/packages/cli/src/commands/approve.ts
+++ b/packages/cli/src/commands/approve.ts
@@ -65,7 +65,7 @@ export async function approveCommand(args: string[], configDir: string): Promise
     process.stdout.write(`Approved ${scriptPath} (hash: ${status.hash})\n`)
     return 0
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     // Exit code 1: runtime error (e.g. missing script, unwritable manifest)
     return 1
   }

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -222,7 +222,7 @@ async function configInit(rest: string[], configDir: string): Promise<number> {
     }
     return 0
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }
@@ -282,7 +282,7 @@ async function configShow(rest: string[], configDir: string): Promise<number> {
     }
     return 0
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -87,7 +87,7 @@ export async function deleteCommand(args: string[], configDir: string): Promise<
     process.stdout.write(`Secret "${values.name}" deleted.\n`)
     return 0
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }

--- a/packages/cli/src/commands/dev-mode.ts
+++ b/packages/cli/src/commands/dev-mode.ts
@@ -72,7 +72,7 @@ export async function devModeCommand(args: string[], configDir: string): Promise
     process.stdout.write(`Development mode ${enabled ? 'enabled' : 'disabled'} for ${scriptPath}\n`)
     return 0
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -82,7 +82,7 @@ export async function doctorCommand(args: string[], configDir: string): Promise<
     }
     return 1
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -430,7 +430,7 @@ export async function execCommand(args: string[], configDir: string): Promise<nu
       })
     })
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }

--- a/packages/cli/src/commands/revoke-key.ts
+++ b/packages/cli/src/commands/revoke-key.ts
@@ -49,7 +49,7 @@ export async function revokeKeyCommand(args: string[], configDir: string): Promi
     process.stdout.write('Key revoked successfully.\n')
     return 0
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }

--- a/packages/cli/src/commands/rotate-key.ts
+++ b/packages/cli/src/commands/rotate-key.ts
@@ -49,7 +49,7 @@ export async function rotateKeyCommand(args: string[], configDir: string): Promi
     process.stdout.write('Key rotated successfully.\n')
     return 0
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }

--- a/packages/cli/src/commands/store.ts
+++ b/packages/cli/src/commands/store.ts
@@ -113,7 +113,7 @@ export async function storeCommand(args: string[], configDir: string): Promise<n
     process.stdout.write(`Secret "${values.name}" stored successfully.\n`)
     return 0
   } catch (err) {
-    process.stderr.write(`${formatError(err)}\n`)
+    process.stderr.write(`${formatError(err, configDir)}\n`)
     return 1
   }
 }

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -4,6 +4,9 @@
  * @internal
  */
 
+import * as path from 'node:path'
+import { ConfigParseError, ConfigValidationError } from 'vaultkeeper'
+
 /** Check if stdout is a TTY at call time (not module load time). */
 function isTTY(): boolean {
   return process.stdout.isTTY
@@ -19,8 +22,43 @@ export function dim(text: string): string {
   return isTTY() ? `\x1b[2m${text}\x1b[22m` : text
 }
 
+/**
+ * Build a CLI-native remediation message for a config parse/validation
+ * error, from the errors' structured fields rather than their `.message`.
+ *
+ * The library's own message points a reader at installing `@vaultkeeper/cli`
+ * — correct advice for a library consumer that doesn't have a CLI installed
+ * (issue #100), but wrong for a user who is already running this CLI
+ * (issue #114). Only structured fields that are safe to depend on are used
+ * (the file path, and — for a parse error — its line/column location); the
+ * library-internal validation reason text lives only in `.message`
+ * alongside the wrong remediation, so it is deliberately not reused here.
+ * `configDir` is a fallback for `ConfigValidationError.configFilePath`,
+ * which is `undefined` when the error came from validating an in-memory
+ * value rather than a loaded file — a case the CLI itself never hits, since
+ * it only ever validates via `loadConfig`/`VaultKeeper.init`.
+ */
+function formatConfigError(
+  err: ConfigParseError | ConfigValidationError,
+  configDir: string,
+): string {
+  const configPath =
+    err instanceof ConfigParseError
+      ? err.path
+      : (err.configFilePath ?? path.join(configDir, 'config.json'))
+  const locationSuffix =
+    err instanceof ConfigParseError && err.location !== undefined ? ` (at ${err.location})` : ''
+  return (
+    `${err.name}: The config at \`${configPath}\` is invalid${locationSuffix} — ` +
+    'run `vaultkeeper config init --force` to overwrite it.'
+  )
+}
+
 /** Format an error for display on stderr. */
-export function formatError(err: unknown): string {
+export function formatError(err: unknown, configDir: string): string {
+  if (err instanceof ConfigParseError || err instanceof ConfigValidationError) {
+    return formatConfigError(err, configDir)
+  }
   if (err instanceof Error) {
     return `${err.name}: ${err.message}`
   }

--- a/packages/cli/test/unit/commands/config.test.ts
+++ b/packages/cli/test/unit/commands/config.test.ts
@@ -173,6 +173,9 @@ describe('configCommand', () => {
       expect(stderrOutput).toContain('vaultkeeper config init --backend file')
     })
 
+    // Issue #114: the remediation must be CLI-native ("run `vaultkeeper
+    // config init --force`"), never the library's "install @vaultkeeper/cli"
+    // text — this CLI is already installed.
     it('should exit non-zero with a parse error, path, location, and remediation hint on invalid JSON (issue #68)', async () => {
       await fs.mkdir(configDir, { recursive: true })
       await fs.writeFile(path.join(configDir, 'config.json'), '{ bad json', 'utf8')
@@ -182,7 +185,8 @@ describe('configCommand', () => {
       expect(stdoutOutput).toBe('')
       expect(stderrOutput).toContain(path.join(configDir, 'config.json'))
       expect(stderrOutput).toMatch(/line \d+, column \d+/)
-      expect(stderrOutput).toContain('vaultkeeper config init')
+      expect(stderrOutput).toContain('vaultkeeper config init --force')
+      expect(stderrOutput).not.toContain('install @vaultkeeper/cli')
     })
 
     it('never dumps invalid JSON with exit 0 (regression: issue #68 repro)', async () => {
@@ -194,7 +198,12 @@ describe('configCommand', () => {
       expect(stdoutOutput).not.toContain('bad json')
     })
 
-    it('exits non-zero with a schema validation error, path, and remediation hint on structurally invalid config', async () => {
+    // Issue #114: the CLI's own message no longer echoes the library's
+    // field-level reason verbatim (that text lives only alongside the
+    // library's "install @vaultkeeper/cli" remediation — issue #100); it
+    // instead builds a CLI-native message from the error's remediation-free
+    // structured fields (path here; also location for a parse error).
+    it('exits non-zero with a CLI-native remediation, path, and recovery command on structurally invalid config', async () => {
       await fs.mkdir(configDir, { recursive: true })
       await fs.writeFile(
         path.join(configDir, 'config.json'),
@@ -205,8 +214,8 @@ describe('configCommand', () => {
       const code = await configCommand(['show'], configDir)
       expect(code).toBe(1)
       expect(stderrOutput).toContain(path.join(configDir, 'config.json'))
-      expect(stderrOutput).toContain('version must be 1')
-      expect(stderrOutput).toContain('vaultkeeper config init')
+      expect(stderrOutput).toContain('vaultkeeper config init --force')
+      expect(stderrOutput).not.toContain('install @vaultkeeper/cli')
     })
   })
 

--- a/packages/cli/test/unit/commands/delete.test.ts
+++ b/packages/cli/test/unit/commands/delete.test.ts
@@ -8,16 +8,23 @@ const mockDeleteFn = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockGetTypes = vi.hoisted(() => vi.fn().mockReturnValue(['file']))
 const mockCreate = vi.hoisted(() => vi.fn())
 
-vi.mock('vaultkeeper', () => ({
-  VaultKeeper: {
-    init: mockInit,
-  },
-  BackendRegistry: {
-    getTypes: mockGetTypes,
-    create: mockCreate,
-  },
-  defaultBackendType: vi.fn().mockReturnValue('file'),
-}))
+// Partial mock: keep real exports (e.g. ConfigParseError/ConfigValidationError,
+// needed by formatError's instanceof checks — issue #114) alongside the
+// mocked entry points this suite controls.
+vi.mock('vaultkeeper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vaultkeeper')>()
+  return {
+    ...actual,
+    VaultKeeper: {
+      init: mockInit,
+    },
+    BackendRegistry: {
+      getTypes: mockGetTypes,
+      create: mockCreate,
+    },
+    defaultBackendType: vi.fn().mockReturnValue('file'),
+  }
+})
 
 describe('deleteCommand', () => {
   let stderrOutput: string

--- a/packages/cli/test/unit/commands/dev-mode.test.ts
+++ b/packages/cli/test/unit/commands/dev-mode.test.ts
@@ -5,11 +5,18 @@ const configDir = '/tmp/vaultkeeper-test-config-dir'
 // vi.hoisted ensures the mock factory can reference mockInit before imports are resolved.
 const mockInit = vi.hoisted(() => vi.fn())
 
-vi.mock('vaultkeeper', () => ({
-  VaultKeeper: {
-    init: mockInit,
-  },
-}))
+// Partial mock: keep real exports (e.g. ConfigParseError/ConfigValidationError,
+// needed by formatError's instanceof checks — issue #114) alongside the
+// mocked entry points this suite controls.
+vi.mock('vaultkeeper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vaultkeeper')>()
+  return {
+    ...actual,
+    VaultKeeper: {
+      init: mockInit,
+    },
+  }
+})
 
 describe('devModeCommand', () => {
   let stderrOutput: string

--- a/packages/cli/test/unit/commands/doctor.test.ts
+++ b/packages/cli/test/unit/commands/doctor.test.ts
@@ -8,13 +8,20 @@ const configDir = '/tmp/vaultkeeper-test-config-dir'
 const mockDoctor = vi.fn()
 const mockLoadConfig = vi.fn()
 
-vi.mock('vaultkeeper', () => ({
-  VaultKeeper: {
-    doctor: mockDoctor,
-  },
-  loadConfig: mockLoadConfig,
-  defaultBackendType: vi.fn().mockReturnValue('file'),
-}))
+// Partial mock: keep real exports (e.g. ConfigParseError/ConfigValidationError,
+// needed by formatError's instanceof checks — issue #114) alongside the
+// mocked entry points this suite controls.
+vi.mock('vaultkeeper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vaultkeeper')>()
+  return {
+    ...actual,
+    VaultKeeper: {
+      doctor: mockDoctor,
+    },
+    loadConfig: mockLoadConfig,
+    defaultBackendType: vi.fn().mockReturnValue('file'),
+  }
+})
 
 describe('doctorCommand', () => {
   let stderrOutput: string

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -28,13 +28,20 @@ const IdentityMismatchError = vi.hoisted(
     },
 )
 
-vi.mock('vaultkeeper', () => ({
-  VaultKeeper: {
-    init: mockInit,
-  },
-  IdentityMismatchError,
-  defaultBackendType: vi.fn().mockReturnValue('file'),
-}))
+// Partial mock: keep real exports (e.g. ConfigParseError/ConfigValidationError,
+// needed by formatError's instanceof checks — issue #114) alongside the
+// mocked entry points this suite controls.
+vi.mock('vaultkeeper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vaultkeeper')>()
+  return {
+    ...actual,
+    VaultKeeper: {
+      init: mockInit,
+    },
+    IdentityMismatchError,
+    defaultBackendType: vi.fn().mockReturnValue('file'),
+  }
+})
 
 // Prevent any real approval prompts from blocking tests
 vi.mock('../../../src/approval.js', () => ({

--- a/packages/cli/test/unit/commands/revoke-key.test.ts
+++ b/packages/cli/test/unit/commands/revoke-key.test.ts
@@ -5,11 +5,18 @@ const configDir = '/tmp/vaultkeeper-test-config-dir'
 // vi.hoisted ensures the mock factory can reference mockInit before imports are resolved.
 const mockInit = vi.hoisted(() => vi.fn())
 
-vi.mock('vaultkeeper', () => ({
-  VaultKeeper: {
-    init: mockInit,
-  },
-}))
+// Partial mock: keep real exports (e.g. ConfigParseError/ConfigValidationError,
+// needed by formatError's instanceof checks — issue #114) alongside the
+// mocked entry points this suite controls.
+vi.mock('vaultkeeper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vaultkeeper')>()
+  return {
+    ...actual,
+    VaultKeeper: {
+      init: mockInit,
+    },
+  }
+})
 
 describe('revokeKeyCommand', () => {
   let stderrOutput: string

--- a/packages/cli/test/unit/commands/rotate-key.test.ts
+++ b/packages/cli/test/unit/commands/rotate-key.test.ts
@@ -5,11 +5,18 @@ const configDir = '/tmp/vaultkeeper-test-config-dir'
 // vi.hoisted ensures the mock factory can reference mockInit before imports are resolved.
 const mockInit = vi.hoisted(() => vi.fn())
 
-vi.mock('vaultkeeper', () => ({
-  VaultKeeper: {
-    init: mockInit,
-  },
-}))
+// Partial mock: keep real exports (e.g. ConfigParseError/ConfigValidationError,
+// needed by formatError's instanceof checks — issue #114) alongside the
+// mocked entry points this suite controls.
+vi.mock('vaultkeeper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vaultkeeper')>()
+  return {
+    ...actual,
+    VaultKeeper: {
+      init: mockInit,
+    },
+  }
+})
 
 describe('rotateKeyCommand', () => {
   let stderrOutput: string

--- a/packages/cli/test/unit/commands/store.test.ts
+++ b/packages/cli/test/unit/commands/store.test.ts
@@ -8,16 +8,23 @@ const mockStore = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
 const mockGetTypes = vi.hoisted(() => vi.fn().mockReturnValue(['file']))
 const mockCreate = vi.hoisted(() => vi.fn())
 
-vi.mock('vaultkeeper', () => ({
-  VaultKeeper: {
-    init: mockInit,
-  },
-  BackendRegistry: {
-    getTypes: mockGetTypes,
-    create: mockCreate,
-  },
-  defaultBackendType: vi.fn().mockReturnValue('file'),
-}))
+// Partial mock: keep real exports (e.g. ConfigParseError/ConfigValidationError,
+// needed by formatError's instanceof checks — issue #114) alongside the
+// mocked entry points this suite controls.
+vi.mock('vaultkeeper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vaultkeeper')>()
+  return {
+    ...actual,
+    VaultKeeper: {
+      init: mockInit,
+    },
+    BackendRegistry: {
+      getTypes: mockGetTypes,
+      create: mockCreate,
+    },
+    defaultBackendType: vi.fn().mockReturnValue('file'),
+  }
+})
 
 function mockStdinWith(value: string): void {
   vi.spyOn(process.stdin, Symbol.asyncIterator).mockImplementation(function* () {

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from 'vitest'
+import * as path from 'node:path'
+import { ConfigParseError, ConfigValidationError } from 'vaultkeeper'
 import { formatError } from '../../src/output.js'
+
+const CONFIG_DIR = '/home/user/.config/vaultkeeper'
 
 describe('formatError', () => {
   it('should format Error instances with name and message', () => {
     const err = new Error('something broke')
-    expect(formatError(err)).toBe('Error: something broke')
+    expect(formatError(err, CONFIG_DIR)).toBe('Error: something broke')
   })
 
   it('should format custom error classes', () => {
@@ -14,12 +18,69 @@ describe('formatError', () => {
         this.name = 'CustomError'
       }
     }
-    expect(formatError(new CustomError('bad'))).toBe('CustomError: bad')
+    expect(formatError(new CustomError('bad'), CONFIG_DIR)).toBe('CustomError: bad')
   })
 
   it('should stringify non-Error values', () => {
-    expect(formatError('string error')).toBe('string error')
-    expect(formatError(42)).toBe('42')
-    expect(formatError(null)).toBe('null')
+    expect(formatError('string error', CONFIG_DIR)).toBe('string error')
+    expect(formatError(42, CONFIG_DIR)).toBe('42')
+    expect(formatError(null, CONFIG_DIR)).toBe('null')
+  })
+
+  // Regression: issue #114 — the CLI must never surface the library's
+  // "install @vaultkeeper/cli" remediation (issue #100) to a user who is
+  // already running this CLI. ConfigParseError/ConfigValidationError get a
+  // CLI-native message built from their structured fields instead.
+  describe('config errors get a CLI-native remediation (issue #114)', () => {
+    it('rewrites ConfigParseError to a CLI-native message naming the path and recovery command', () => {
+      const configPath = '/home/user/.config/vaultkeeper/config.json'
+      const err = new ConfigParseError(
+        `Failed to parse config file at ${configPath} at line 3, column 12: Unexpected token. ` +
+          "Fix the file — either install @vaultkeeper/cli and run 'vaultkeeper config init --force' " +
+          'to overwrite it with a valid config, or repair/replace it programmatically via this ' +
+          'library (pass an explicit `config` or `configDir`, or write a valid config.json yourself).',
+        configPath,
+        'line 3, column 12',
+      )
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).toContain(configPath)
+      expect(formatted).toContain('vaultkeeper config init --force')
+      expect(formatted).not.toContain('install @vaultkeeper/cli')
+      expect(formatted).not.toContain('programmatically')
+    })
+
+    it('rewrites ConfigValidationError to a CLI-native message naming the path and recovery command', () => {
+      const configPath = '/home/user/.config/vaultkeeper/config.json'
+      const err = new ConfigValidationError(
+        `Invalid config at ${configPath}: backends[0].type must be a non-empty string. ` +
+          "Fix the file — either install @vaultkeeper/cli and run 'vaultkeeper config init --force' " +
+          'to overwrite it with a valid config, or repair/replace it programmatically via this ' +
+          'library (pass an explicit `config` or `configDir`, or write a valid config.json yourself).',
+        'backends[0].type',
+        configPath,
+      )
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).toContain(configPath)
+      expect(formatted).toContain('vaultkeeper config init --force')
+      expect(formatted).not.toContain('install @vaultkeeper/cli')
+      expect(formatted).not.toContain('programmatically')
+    })
+
+    it('falls back to configDir when ConfigValidationError.configFilePath is undefined', () => {
+      // configFilePath is undefined when the error came from validating an
+      // in-memory value rather than a loaded file. The CLI never triggers
+      // this path itself (it only validates via loadConfig), but formatError
+      // must still produce a message naming a file path per AC3.
+      const err = new ConfigValidationError('backends must be a non-empty array', 'backends')
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).toContain(path.join(CONFIG_DIR, 'config.json'))
+      expect(formatted).toContain('vaultkeeper config init --force')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Refs #114

The CLI was surfacing `ConfigParseError`/`ConfigValidationError`'s raw `.message`, which is the library's generic remediation: "...either install @vaultkeeper/cli and run vaultkeeper config init --force, or repair/replace it programmatically via this library...". A user who is already running `vaultkeeper` (the CLI) was told to install the CLI they already had.

`formatError` (used by every CLI command's catch block: `store`, `delete`, `exec`, `approve`, `rotate-key`, `revoke-key`, `dev-mode`, `doctor`, `config show`/`init`) now special-cases these two error types and builds a CLI-native message from their structured, remediation-free fields (file path, and — for a parse error — its line/column location), rather than reusing `.message`:

> `ConfigValidationError: The config at `<path>` is invalid — run `vaultkeeper config init --force` to overwrite it.`

The library's own message (for JS-API/programmatic consumers, issue #100) is completely unchanged — `packages/vaultkeeper/src/config.ts` and `errors.ts` were not touched.

## Acceptance criteria → tests

1. **CLI prints a CLI-native remediation, not "install @vaultkeeper/cli"**
   - `packages/cli/test/unit/output.test.ts` → `formatError > config errors get a CLI-native remediation (issue #114) > rewrites ConfigParseError...` / `...ConfigValidationError...`
   - `packages/cli-tests/test/e2e/config.test.ts` → `should exit non-zero with path, parse location, and remediation hint for corrupt config.json (issue #68 repro)` and `should exit non-zero with path and remediation hint for a structurally invalid config.json` (both now assert `.not.toContain('install @vaultkeeper/cli')`)

2. **Library keeps its own remediation for library consumers (no regression of issue #100)**
   - Unchanged: `packages/vaultkeeper/test/unit/cli-reference-guard.test.ts` (still passing, untouched) and `packages/vaultkeeper/test/unit/config.test.ts`'s existing assertions on `err.message` containing `vaultkeeper config init` — library source files were not modified.

3. **CLI's message still names the recovery command and file path**
   - Same tests as (1); each asserts `.toContain(configPath)` and `.toContain('vaultkeeper config init --force')`.

4. **Subprocess regression test: corrupt config → `config show`/`store` prints CLI-native message**
   - `packages/cli-tests/test/e2e/config.test.ts` (config show, both parse and validation error cases)
   - `packages/cli-tests/test/e2e/store-delete.test.ts` → `store should exit non-zero with a CLI-native remediation (path, parse location, config init --force) for corrupt config.json (issues #68, #114)`

## Before / after

Before:
```
ConfigValidationError: Invalid config at /home/user/.config/vaultkeeper/config.json: Config version must be 1. Fix the file — either install @vaultkeeper/cli and run 'vaultkeeper config init --force' to overwrite it with a valid config, or repair/replace it programmatically via this library (pass an explicit `config` or `configDir`, or write a valid config.json yourself).
```

After:
```
ConfigValidationError: The config at `/home/user/.config/vaultkeeper/config.json` is invalid — run `vaultkeeper config init --force` to overwrite it.
```

## Non-goals / scope notes

- Recovery behavior (`config init --force`) is unchanged — this only changes the message shown before recovery.
- Unit tests in `packages/cli/test/unit/commands/*.test.ts` that used a full `vi.mock('vaultkeeper', () => ({...}))` replacement had to switch to a partial mock (`importOriginal`) so `formatError`'s `instanceof` checks against the real `ConfigParseError`/`ConfigValidationError` classes still work under mocking — this is a mechanical test-infra fix, not a behavior change.
- **Known related gap, deliberately out of scope**: `doctor`'s "config" preflight check (`packages/vaultkeeper/src/doctor/runner.ts`) stores the raw library error message as `PreflightCheck.reason`, which `doctorCommand` prints verbatim in `nextSteps` — so `vaultkeeper doctor` against a corrupt config still shows the library's "install @vaultkeeper/cli" text today. Fixing that well requires exposing structured error info on `ScopedPreflightCheck` (a public API shape change), which is a larger design decision beyond this issue's stated acceptance criteria and governing files. Recommend a follow-up issue.

## Test plan
- [x] `pnpm check` (typecheck + lint + api-report) green
- [x] `pnpm test` green (249/249 in `@vaultkeeper/cli`, full workspace green)
- [x] Prettier run on all changed files