### PR TITLE
Fix CLI error-wording papercuts: SecretNotFound consistency, ConfigValidationError run-on, exit-code straggler

### DIFF
--- a/.changeset/cli-error-wording-polish.md
+++ b/.changeset/cli-error-wording-polish.md
@@ -1,0 +1,10 @@
+---
+'vaultkeeper': patch
+'@vaultkeeper/cli': patch
+---
+
+Fix CLI error-experience papercuts:
+
+- `exec` and `delete` now report an identical "secret not found" message (`Secret "<name>" not found in the "<backend>" backend.`) with a recovery hint (`Run \`vaultkeeper store --name <name>\` to create it.`) — previously each surfaced different wording and neither pointed at a fix.
+- `store` with empty stdin now exits 2 (usage error) instead of 1, consistent with a missing or empty `--name` — both mean "no usable input was given."
+- The library's `ConfigValidationError` message now separates the validation diagnosis from the remediation hint with a period instead of running them together with no punctuation.

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -326,4 +326,29 @@ describe('exec trust gate', () => {
     expect(result.stderr).toContain('SecretNotFoundError')
     expect(result.stdout).not.toContain('ready=')
   })
+
+  // Regression: issue #118 — exec and delete previously reported the same
+  // failure with different wording (exec: `Secret "x" not found in file
+  // backend`; delete: the file backend's own `Secret not found in file
+  // store: x`) and neither included a recovery hint. Both commands must now
+  // render byte-for-byte identical text for the missing-secret line.
+  it('reports the identical SecretNotFoundError wording and hint as `delete` for the same missing secret (issue #118)', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+
+    const execResult = await env.run(
+      execArgs(caller).map((a) => (a === SECRET_NAME ? 'ghost-secret' : a)),
+    )
+    const deleteResult = await env.run(['delete', '--name', 'ghost-secret'])
+
+    const expectedLine = 'Secret "ghost-secret" not found in the "file" backend.'
+    const expectedHint = 'Run `vaultkeeper store --name ghost-secret` to create it.'
+
+    expect(execResult.exitCode).not.toBe(0)
+    expect(deleteResult.exitCode).not.toBe(0)
+    expect(execResult.stderr).toContain(expectedLine)
+    expect(execResult.stderr).toContain(expectedHint)
+    expect(deleteResult.stderr).toContain(expectedLine)
+    expect(deleteResult.stderr).toContain(expectedHint)
+  })
 })

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -342,7 +342,7 @@ describe('exec trust gate', () => {
     const deleteResult = await env.run(['delete', '--name', 'ghost-secret'])
 
     const expectedLine = 'Secret "ghost-secret" not found in the "file" backend.'
-    const expectedHint = 'Run `vaultkeeper store --name ghost-secret` to create it.'
+    const expectedHint = "Run `vaultkeeper store --name 'ghost-secret'` to create it."
 
     expect(execResult.exitCode).not.toBe(0)
     expect(deleteResult.exitCode).not.toBe(0)
@@ -350,5 +350,24 @@ describe('exec trust gate', () => {
     expect(execResult.stderr).toContain(expectedHint)
     expect(deleteResult.stderr).toContain(expectedLine)
     expect(deleteResult.stderr).toContain(expectedHint)
+  })
+
+  // Regression (review follow-up, issue #118): unlike store/delete's --name,
+  // exec --secret is validated only for non-emptiness (no character-set
+  // restriction), so a real subprocess invocation can carry a secret name
+  // containing a double quote. The recovery hint must stay a syntactically
+  // valid, copy-pasteable shell command rather than leaving an unterminated
+  // quote — passed here as a real argv element (no shell involved in
+  // invoking the CLI itself), the way a user's actual secret name would be.
+  it('keeps the recovery hint copy/pasteable when --secret contains a double quote', async () => {
+    if (env === undefined) throw new Error('env not initialized')
+    const caller = await writeCaller('#!/bin/sh\necho hi\n')
+
+    const result = await env.run(
+      execArgs(caller).map((a) => (a === SECRET_NAME ? 'ghost"secret' : a)),
+    )
+
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain(`vaultkeeper store --name 'ghost"secret'`)
   })
 })

--- a/packages/cli-tests/test/e2e/exit-code-matrix.test.ts
+++ b/packages/cli-tests/test/e2e/exit-code-matrix.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Pins the CLI's exit-code taxonomy (0 success / 1 runtime error / 2 usage
+ * error, established in issue #69) across a set of misuse cases that should
+ * be treated equivalently, so a future change can't silently reintroduce a
+ * straggler.
+ *
+ * Issue #118 closed two remaining gaps found against this taxonomy:
+ *   - `store` with empty stdin previously returned 1 (runtime), inconsistent
+ *     with `store --name ''` / missing `--name`, which return 2 (usage) for
+ *     the same underlying problem: no usable input was given.
+ *   - A bare invocation (no arguments) is NOT equivalent misuse to a
+ *     misspelled subcommand — the former is the documented "print help"
+ *     convenience (issue #69, still exit 0), the latter is a genuine usage
+ *     error (exit 2). This suite pins both sides of that distinction so it
+ *     is verified, not just assumed.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/69
+ * @see https://github.com/mike-north/vaultkeeper/issues/118
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
+import type { CliTestEnv } from '@vaultkeeper/cli-test-helpers'
+
+describe('exit-code matrix (issue #118)', () => {
+  let env: CliTestEnv | undefined
+
+  afterEach(async () => {
+    if (env !== undefined) {
+      await env.cleanup()
+      env = undefined
+    }
+  })
+
+  it('a bare invocation (no arguments) exits 0 and prints help', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run([])
+    expect(result.exitCode).toBe(0)
+  })
+
+  it('a misspelled/unknown subcommand exits 2, unlike a bare invocation', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['stroe'])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('Unknown command')
+  })
+
+  it('store with a missing --name exits 2 (usage error)', async () => {
+    env = await createCliTestEnv()
+    const result = await env.runWithStdin(['store', '--skip-doctor'], 'sk-live-abc123')
+    expect(result.exitCode).toBe(2)
+  })
+
+  it('store with an empty --name exits 2 (usage error)', async () => {
+    env = await createCliTestEnv()
+    const result = await env.runWithStdin(
+      ['store', '--name', '', '--skip-doctor'],
+      'sk-live-abc123',
+    )
+    expect(result.exitCode).toBe(2)
+  })
+
+  // Regression: issue #118 — this previously exited 1, inconsistent with the
+  // two cases above for the same class of misuse (no usable input given).
+  it('store with empty stdin exits 2 (usage error), matching missing/empty --name', async () => {
+    env = await createCliTestEnv()
+    const result = await env.runWithStdin(['store', '--name', 'test-secret', '--skip-doctor'], '')
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('No secret provided on stdin')
+  })
+})

--- a/packages/cli-tests/test/e2e/exit-code-matrix.test.ts
+++ b/packages/cli-tests/test/e2e/exit-code-matrix.test.ts
@@ -35,6 +35,7 @@ describe('exit-code matrix (issue #118)', () => {
     env = await createCliTestEnv()
     const result = await env.run([])
     expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('a misspelled/unknown subcommand exits 2, unlike a bare invocation', async () => {

--- a/packages/cli-tests/test/e2e/store-delete.test.ts
+++ b/packages/cli-tests/test/e2e/store-delete.test.ts
@@ -23,16 +23,34 @@ describe('store and delete lifecycle', () => {
     }
   })
 
-  it('store should exit 1 when stdin is empty', async () => {
+  // Regression: issue #118 — empty stdin previously exited 1 (runtime error)
+  // while an empty/missing --name exits 2 (usage error) for the same
+  // underlying problem (no usable secret input). Both must now agree.
+  //
+  // Note: doctor runs before the stdin check, so on a system missing a
+  // dependency the doctor failure (still a usage-unrelated runtime error, 1)
+  // surfaces first — both are valid CLI error paths for this environment.
+  it('store should exit 2 when stdin is empty (issue #118)', async () => {
     env = await createCliTestEnv()
     const result = await env.runWithStdin(['store', '--name', 'test-secret'], '')
-    expect(result.exitCode).toBe(1)
-    // The error is either "No secret provided on stdin" (file backend) or a
-    // doctor check failure (if the system lacks dependencies). Both are valid
-    // CLI error paths.
-    const matchesExpected =
-      result.stderr.includes('No secret provided on stdin') || result.stderr.includes('doctor')
-    expect(matchesExpected).toBe(true)
+    if (result.stderr.includes('doctor')) {
+      expect(result.exitCode).toBe(1)
+    } else {
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain('No secret provided on stdin')
+    }
+  })
+
+  // Regression: issue #118 — delete previously surfaced the file backend's
+  // own not-found message ("Secret not found in file store: x") instead of
+  // the consistent, hint-bearing wording exec.ts uses for the same failure.
+  it('delete should exit non-zero with the consistent SecretNotFoundError wording and a recovery hint for a nonexistent secret (issue #118)', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['delete', '--name', 'never-stored', '--skip-doctor'])
+    expect(result.exitCode).not.toBe(0)
+    expect(result.stderr).toContain('SecretNotFoundError')
+    expect(result.stderr).toContain('Secret "never-stored" not found in the "file" backend')
+    expect(result.stderr).toContain('Run `vaultkeeper store --name never-stored` to create it')
   })
 
   // Regression: issue #60 — the CLI ignored BackendConfig.path and always wrote

--- a/packages/cli-tests/test/e2e/store-delete.test.ts
+++ b/packages/cli-tests/test/e2e/store-delete.test.ts
@@ -27,18 +27,16 @@ describe('store and delete lifecycle', () => {
   // while an empty/missing --name exits 2 (usage error) for the same
   // underlying problem (no usable secret input). Both must now agree.
   //
-  // Note: doctor runs before the stdin check, so on a system missing a
-  // dependency the doctor failure (still a usage-unrelated runtime error, 1)
-  // surfaces first — both are valid CLI error paths for this environment.
+  // storeCommand reads and validates stdin BEFORE calling VaultKeeper.init()
+  // (see packages/cli/src/commands/store.ts), so doctor never runs before
+  // this check — --skip-doctor here only removes an unrelated source of
+  // flakiness on systems missing an optional dependency, it does not change
+  // which path is under test. The outcome is deterministic either way.
   it('store should exit 2 when stdin is empty (issue #118)', async () => {
     env = await createCliTestEnv()
-    const result = await env.runWithStdin(['store', '--name', 'test-secret'], '')
-    if (result.stderr.includes('doctor')) {
-      expect(result.exitCode).toBe(1)
-    } else {
-      expect(result.exitCode).toBe(2)
-      expect(result.stderr).toContain('No secret provided on stdin')
-    }
+    const result = await env.runWithStdin(['store', '--name', 'test-secret', '--skip-doctor'], '')
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('No secret provided on stdin')
   })
 
   // Regression: issue #118 — delete previously surfaced the file backend's

--- a/packages/cli-tests/test/e2e/store-delete.test.ts
+++ b/packages/cli-tests/test/e2e/store-delete.test.ts
@@ -48,7 +48,7 @@ describe('store and delete lifecycle', () => {
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).toContain('SecretNotFoundError')
     expect(result.stderr).toContain('Secret "never-stored" not found in the "file" backend')
-    expect(result.stderr).toContain('Run `vaultkeeper store --name never-stored` to create it')
+    expect(result.stderr).toContain("Run `vaultkeeper store --name 'never-stored'` to create it")
   })
 
   // Regression: issue #60 — the CLI ignored BackendConfig.path and always wrote

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -84,16 +84,21 @@ export async function deleteCommand(args: string[], configDir: string): Promise<
     // loaded config and forwards that backend's config (including `path`).
     const vault = await VaultKeeper.init({ configDir, skipDoctor })
 
-    // Check existence up front (mirrors exec.ts's pre-check) rather than
-    // relying on the backend's own not-found exception. Each backend words
-    // its "not found" message differently (issue #118), so building the
-    // error here — from the same helper exec.ts uses — guarantees identical
-    // wording and a recovery hint regardless of which backend is active.
-    if (!(await vault.secretExists(values.name))) {
-      throw new SecretNotFoundError(secretNotFoundMessage(values.name, vault.activeBackendType))
+    try {
+      await vault.delete(values.name)
+    } catch (deleteErr) {
+      // Every backend's delete() throws SecretNotFoundError for a missing
+      // secret, but each words it differently (e.g. the file backend's
+      // "Secret not found in file store: x" vs exec's own wording). Catching
+      // here — rather than a separate secretExists() pre-check — is the
+      // single source of truth for this normalization: it also covers the
+      // secret being deleted between any check and this call (issue #118
+      // review), which a pre-check alone cannot.
+      if (deleteErr instanceof SecretNotFoundError) {
+        throw new SecretNotFoundError(secretNotFoundMessage(values.name, vault.activeBackendType))
+      }
+      throw deleteErr
     }
-
-    await vault.delete(values.name)
     process.stdout.write(`Secret "${values.name}" deleted.\n`)
     return 0
   } catch (err) {

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from 'node:util'
-import { VaultKeeper, defaultBackendType } from 'vaultkeeper'
+import { VaultKeeper, SecretNotFoundError, defaultBackendType } from 'vaultkeeper'
 import { shouldSkipDoctor } from '../skip-doctor.js'
-import { formatError } from '../output.js'
+import { formatError, secretNotFoundMessage } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 import { configFileExists, noConfigMessage } from '../config-status.js'
 
@@ -83,6 +83,16 @@ export async function deleteCommand(args: string[], configDir: string): Promise<
     // Delete via VaultKeeper, which resolves the first enabled backend from the
     // loaded config and forwards that backend's config (including `path`).
     const vault = await VaultKeeper.init({ configDir, skipDoctor })
+
+    // Check existence up front (mirrors exec.ts's pre-check) rather than
+    // relying on the backend's own not-found exception. Each backend words
+    // its "not found" message differently (issue #118), so building the
+    // error here — from the same helper exec.ts uses — guarantees identical
+    // wording and a recovery hint regardless of which backend is active.
+    if (!(await vault.secretExists(values.name))) {
+      throw new SecretNotFoundError(secretNotFoundMessage(values.name, vault.activeBackendType))
+    }
+
     await vault.delete(values.name)
     process.stdout.write(`Secret "${values.name}" deleted.\n`)
     return 0

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -41,7 +41,7 @@ import { RedactingStream } from '../redact.js'
 import { shouldSkipDoctor } from '../skip-doctor.js'
 import { shouldAutoApprove } from '../auto-approve.js'
 import { shellQuote } from '../shell-quote.js'
-import { formatError } from '../output.js'
+import { formatError, secretNotFoundMessage } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 import { configFileExists, noConfigMessage } from '../config-status.js'
 
@@ -319,9 +319,7 @@ export async function execCommand(args: string[], configDir: string): Promise<nu
     // `setup()`, it never touches the TOFU trust manifest), so it cannot be
     // used to bypass caller approval.
     if (!(await vault.secretExists(secret))) {
-      throw new SecretNotFoundError(
-        `Secret "${secret}" not found in ${vault.activeBackendType} backend`,
-      )
+      throw new SecretNotFoundError(secretNotFoundMessage(secret, vault.activeBackendType))
     }
 
     // Enforce the trust gate BEFORE touching the cache or retrieving the

--- a/packages/cli/src/commands/store.ts
+++ b/packages/cli/src/commands/store.ts
@@ -95,8 +95,13 @@ export async function storeCommand(args: string[], configDir: string): Promise<n
     const secret = Buffer.concat(chunks).toString('utf8').trimEnd()
 
     if (secret.length === 0) {
+      // Exit code 2, not 1: empty stdin is equivalent misuse to an empty or
+      // missing `--name` above — both mean "no usable input was given" — and
+      // must be reported the same way (regression: issue #118 exit-code
+      // matrix normalization against the #69 taxonomy).
       process.stderr.write('Error: No secret provided on stdin\n')
-      return 1
+      process.stderr.write('Usage: echo "secret" | vaultkeeper store --name <name>\n')
+      return 2
     }
 
     // No-config story is uniform across store/delete/exec/config show/doctor

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -71,6 +71,25 @@ export function formatPreflightConfigError(error: PreflightCheckError): string {
   return configRemediation(error.configPath, error.location)
 }
 
+/**
+ * Build the standard "secret not found" message, shared by every CLI command
+ * that looks up a secret before acting on it.
+ *
+ * Regression: issue #118 — `exec` and `delete` previously reported different
+ * wording for the identical failure (`exec` said `Secret "x" not found in
+ * file backend`; `delete` surfaced the backend's own `Secret not found in
+ * file store: x`), and neither pointed the user at a fix. Centralizing the
+ * wording here, and having each command construct the error from this helper
+ * instead of the backend's own message, guarantees they stay in sync and
+ * always include a recovery hint.
+ */
+export function secretNotFoundMessage(name: string, backendType: string): string {
+  return (
+    `Secret "${name}" not found in the "${backendType}" backend. ` +
+    `Run \`vaultkeeper store --name ${name}\` to create it.`
+  )
+}
+
 /** Format an error for display on stderr. */
 export function formatError(err: unknown, configDir: string): string {
   if (err instanceof ConfigParseError || err instanceof ConfigValidationError) {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -84,8 +84,16 @@ export function formatPreflightConfigError(error: PreflightCheckError): string {
  * always include a recovery hint.
  */
 export function secretNotFoundMessage(name: string, backendType: string): string {
+  // JSON.stringify quotes AND escapes: `backendType` can only ever be one of
+  // the fixed registry identifiers (file/keychain/dpapi/secret-tool/
+  // 1password/yubikey — see packages/vaultkeeper/src/backend/register-builtins.ts),
+  // none of which contain a quote, but `name` is user-supplied and, on the
+  // exec path (`--secret`), is validated only for non-emptiness — not
+  // restricted to store/delete's safe `--name` character set. A name
+  // containing a literal `"` would otherwise unbalance the surrounding
+  // quotes in this message (review follow-up, issue #118).
   return (
-    `Secret "${name}" not found in the "${backendType}" backend. ` +
+    `Secret ${JSON.stringify(name)} not found in the ${JSON.stringify(backendType)} backend. ` +
     `Run \`vaultkeeper store --name ${name}\` to create it.`
   )
 }

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -7,6 +7,7 @@
 import * as path from 'node:path'
 import { ConfigParseError, ConfigValidationError } from 'vaultkeeper'
 import type { PreflightCheckError } from 'vaultkeeper'
+import { shellQuote } from './shell-quote.js'
 
 /** Check if stdout is a TTY at call time (not module load time). */
 function isTTY(): boolean {
@@ -84,17 +85,26 @@ export function formatPreflightConfigError(error: PreflightCheckError): string {
  * always include a recovery hint.
  */
 export function secretNotFoundMessage(name: string, backendType: string): string {
-  // JSON.stringify quotes AND escapes: `backendType` can only ever be one of
-  // the fixed registry identifiers (file/keychain/dpapi/secret-tool/
-  // 1password/yubikey — see packages/vaultkeeper/src/backend/register-builtins.ts),
-  // none of which contain a quote, but `name` is user-supplied and, on the
-  // exec path (`--secret`), is validated only for non-emptiness — not
-  // restricted to store/delete's safe `--name` character set. A name
-  // containing a literal `"` would otherwise unbalance the surrounding
-  // quotes in this message (review follow-up, issue #118).
+  // The diagnostic sentence and the recovery hint each need their own kind
+  // of quoting, since they aren't the same kind of text:
+  //
+  // - The diagnostic ("Secret "x" not found...") is English prose — the
+  //   quotes are just readability punctuation around the name. JSON.stringify
+  //   escapes an embedded `"` so it can't unbalance those quotes.
+  //   `backendType` can only ever be one of the fixed registry identifiers
+  //   (file/keychain/dpapi/secret-tool/1password/yubikey — see
+  //   packages/vaultkeeper/src/backend/register-builtins.ts), none of which
+  //   contain a quote, but `name` is user-supplied and, on the exec path
+  //   (`--secret`), is validated only for non-emptiness — not restricted to
+  //   store/delete's safe `--name` character set — so it needs the escaping.
+  // - The recovery hint is a literal shell command a user may copy and
+  //   paste, so `name` is wrapped with shellQuote() (single-quote POSIX
+  //   shell escaping) instead — JSON's escaping isn't shell-safe and an
+  //   unescaped name could contain a quote, breaking the pasted command
+  //   (review follow-up, issue #118).
   return (
     `Secret ${JSON.stringify(name)} not found in the ${JSON.stringify(backendType)} backend. ` +
-    `Run \`vaultkeeper store --name ${name}\` to create it.`
+    `Run \`vaultkeeper store --name ${shellQuote(name)}\` to create it.`
   )
 }
 

--- a/packages/cli/test/unit/commands/delete.test.ts
+++ b/packages/cli/test/unit/commands/delete.test.ts
@@ -130,7 +130,7 @@ describe('deleteCommand', () => {
       expect(code).toBe(1)
       expect(stderrOutput).toContain('SecretNotFoundError')
       expect(stderrOutput).toContain('Secret "missing-secret" not found in the "file" backend')
-      expect(stderrOutput).toContain('Run `vaultkeeper store --name missing-secret` to create it')
+      expect(stderrOutput).toContain("Run `vaultkeeper store --name 'missing-secret'` to create it")
     })
 
     // Review follow-up on issue #118: an upfront secretExists() pre-check
@@ -150,7 +150,7 @@ describe('deleteCommand', () => {
       const code = await deleteCommand(['--name', 'race-secret'], configDir)
       expect(code).toBe(1)
       expect(stderrOutput).toContain('Secret "race-secret" not found in the "keychain" backend')
-      expect(stderrOutput).toContain('Run `vaultkeeper store --name race-secret` to create it')
+      expect(stderrOutput).toContain("Run `vaultkeeper store --name 'race-secret'` to create it")
       expect(stderrOutput).not.toContain('macOS Keychain')
     })
   })

--- a/packages/cli/test/unit/commands/delete.test.ts
+++ b/packages/cli/test/unit/commands/delete.test.ts
@@ -88,32 +88,68 @@ describe('deleteCommand', () => {
     })
   })
 
+  // deleteCommand pre-checks existence via vault.secretExists() before calling
+  // vault.delete() (issue #118), so the mocked vault must implement both.
+  function existingSecretVault(): {
+    delete: typeof mockDeleteFn
+    secretExists: ReturnType<typeof vi.fn>
+    activeBackendType: string
+  } {
+    return {
+      delete: mockDeleteFn,
+      secretExists: vi.fn().mockResolvedValue(true),
+      activeBackendType: 'file',
+    }
+  }
+
   describe('when delete succeeds', () => {
     it('should return 0', async () => {
-      mockInit.mockResolvedValue({ delete: mockDeleteFn })
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       const code = await deleteCommand(['--name', 'my-secret'], configDir)
       expect(code).toBe(0)
     })
 
     it('should write success message to stdout', async () => {
-      mockInit.mockResolvedValue({ delete: mockDeleteFn })
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'], configDir)
       expect(stdoutOutput).toContain('deleted')
     })
   })
 
+  // Regression: issue #118 — delete previously relied on the file backend's
+  // own SecretNotFoundError ("Secret not found in file store: x"), worded
+  // differently from exec's ("Secret "x" not found in file backend") and with
+  // no recovery hint. delete now pre-checks existence and reports the same
+  // wording + hint exec.ts does.
+  describe('when the secret does not exist (issue #118)', () => {
+    it('should return 1 and report a consistent SecretNotFoundError with a recovery hint', async () => {
+      mockInit.mockResolvedValue({
+        delete: mockDeleteFn,
+        secretExists: vi.fn().mockResolvedValue(false),
+        activeBackendType: 'file',
+      })
+      const { deleteCommand } = await import('../../../src/commands/delete.js')
+      const code = await deleteCommand(['--name', 'missing-secret'], configDir)
+      expect(code).toBe(1)
+      expect(stderrOutput).toContain('SecretNotFoundError')
+      expect(stderrOutput).toContain('Secret "missing-secret" not found in the "file" backend')
+      expect(stderrOutput).toContain('Run `vaultkeeper store --name missing-secret` to create it')
+      expect(mockDeleteFn).not.toHaveBeenCalled()
+    })
+  })
+
   describe('--skip-doctor flag', () => {
     it('should pass skipDoctor: false to VaultKeeper.init by default', async () => {
-      mockInit.mockResolvedValue({ delete: mockDeleteFn })
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'], configDir)
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
     })
 
     it('should pass skipDoctor: true to VaultKeeper.init when --skip-doctor is set', async () => {
-      mockInit.mockResolvedValue({ delete: mockDeleteFn })
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret', '--skip-doctor'], configDir)
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
@@ -121,7 +157,7 @@ describe('deleteCommand', () => {
 
     it('should pass skipDoctor: true when VAULTKEEPER_SKIP_DOCTOR=1 env var is set', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '1'
-      mockInit.mockResolvedValue({ delete: mockDeleteFn })
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'], configDir)
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: true })
@@ -129,7 +165,7 @@ describe('deleteCommand', () => {
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=0', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = '0'
-      mockInit.mockResolvedValue({ delete: mockDeleteFn })
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'], configDir)
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
@@ -137,7 +173,7 @@ describe('deleteCommand', () => {
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR=true (non-numeric)', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = 'true'
-      mockInit.mockResolvedValue({ delete: mockDeleteFn })
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'], configDir)
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })
@@ -145,7 +181,7 @@ describe('deleteCommand', () => {
 
     it('should not skip doctor when VAULTKEEPER_SKIP_DOCTOR is empty string', async () => {
       process.env.VAULTKEEPER_SKIP_DOCTOR = ''
-      mockInit.mockResolvedValue({ delete: mockDeleteFn })
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       await deleteCommand(['--name', 'my-secret'], configDir)
       expect(mockInit).toHaveBeenCalledWith({ configDir, skipDoctor: false })

--- a/packages/cli/test/unit/commands/delete.test.ts
+++ b/packages/cli/test/unit/commands/delete.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SecretNotFoundError } from 'vaultkeeper'
 
 const configDir = '/tmp/vaultkeeper-test-config-dir'
 
@@ -88,16 +89,12 @@ describe('deleteCommand', () => {
     })
   })
 
-  // deleteCommand pre-checks existence via vault.secretExists() before calling
-  // vault.delete() (issue #118), so the mocked vault must implement both.
   function existingSecretVault(): {
     delete: typeof mockDeleteFn
-    secretExists: ReturnType<typeof vi.fn>
     activeBackendType: string
   } {
     return {
       delete: mockDeleteFn,
-      secretExists: vi.fn().mockResolvedValue(true),
       activeBackendType: 'file',
     }
   }
@@ -118,25 +115,43 @@ describe('deleteCommand', () => {
     })
   })
 
-  // Regression: issue #118 — delete previously relied on the file backend's
-  // own SecretNotFoundError ("Secret not found in file store: x"), worded
-  // differently from exec's ("Secret "x" not found in file backend") and with
-  // no recovery hint. delete now pre-checks existence and reports the same
-  // wording + hint exec.ts does.
-  describe('when the secret does not exist (issue #118)', () => {
+  // Regression: issue #118 — delete previously relied on each backend's own
+  // SecretNotFoundError wording ("Secret not found in file store: x"),
+  // different from exec's ("Secret "x" not found in file backend") and with
+  // no recovery hint. delete now catches whatever SecretNotFoundError the
+  // backend's delete() throws and rethrows it with the same wording + hint
+  // exec.ts uses.
+  describe('when vault.delete() throws SecretNotFoundError (issue #118)', () => {
     it('should return 1 and report a consistent SecretNotFoundError with a recovery hint', async () => {
-      mockInit.mockResolvedValue({
-        delete: mockDeleteFn,
-        secretExists: vi.fn().mockResolvedValue(false),
-        activeBackendType: 'file',
-      })
+      mockDeleteFn.mockRejectedValue(new SecretNotFoundError('Secret not found in file store: x'))
+      mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
       const code = await deleteCommand(['--name', 'missing-secret'], configDir)
       expect(code).toBe(1)
       expect(stderrOutput).toContain('SecretNotFoundError')
       expect(stderrOutput).toContain('Secret "missing-secret" not found in the "file" backend')
       expect(stderrOutput).toContain('Run `vaultkeeper store --name missing-secret` to create it')
-      expect(mockDeleteFn).not.toHaveBeenCalled()
+    })
+
+    // Review follow-up on issue #118: an upfront secretExists() pre-check
+    // cannot guarantee consistent wording under a TOCTOU race — the secret
+    // could be deleted by a concurrent process between the check and the
+    // actual delete call, in which case the backend's own not-found message
+    // would leak through. Catching SecretNotFoundError from vault.delete()
+    // itself (rather than pre-checking) is immune to this: whenever the
+    // backend reports "not found" — for any reason, at any moment — the
+    // rendered message is always the normalized one.
+    it('should normalize the wording even when the secret existed moments ago and disappeared before delete() ran', async () => {
+      mockDeleteFn.mockRejectedValue(
+        new SecretNotFoundError('Secret not found in macOS Keychain: race-secret'),
+      )
+      mockInit.mockResolvedValue({ delete: mockDeleteFn, activeBackendType: 'keychain' })
+      const { deleteCommand } = await import('../../../src/commands/delete.js')
+      const code = await deleteCommand(['--name', 'race-secret'], configDir)
+      expect(code).toBe(1)
+      expect(stderrOutput).toContain('Secret "race-secret" not found in the "keychain" backend')
+      expect(stderrOutput).toContain('Run `vaultkeeper store --name race-secret` to create it')
+      expect(stderrOutput).not.toContain('macOS Keychain')
     })
   })
 

--- a/packages/cli/test/unit/commands/store.test.ts
+++ b/packages/cli/test/unit/commands/store.test.ts
@@ -79,18 +79,23 @@ describe('storeCommand', () => {
   })
 
   describe('stdin validation', () => {
-    it('should return 1 when stdin is empty', async () => {
+    // Regression: issue #118 — empty stdin previously returned exit 1 (a
+    // runtime error), while an empty/missing --name returns 2 (a usage
+    // error) for the exact same underlying problem: no usable secret input.
+    // Both are equivalent misuse and must share the usage-error exit code.
+    it('should return 2 when stdin is empty (issue #118 exit-code normalization)', async () => {
       mockStdinWith('')
       const { storeCommand } = await import('../../../src/commands/store.js')
       const code = await storeCommand(['--name', 'my-secret'], configDir)
-      expect(code).toBe(1)
+      expect(code).toBe(2)
     })
 
-    it('should write error when stdin is empty', async () => {
+    it('should write error and usage hint when stdin is empty', async () => {
       mockStdinWith('')
       const { storeCommand } = await import('../../../src/commands/store.js')
       await storeCommand(['--name', 'my-secret'], configDir)
       expect(stderrOutput).toContain('No secret provided on stdin')
+      expect(stderrOutput).toContain('Usage:')
     })
   })
 

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -94,7 +94,7 @@ describe('formatError', () => {
       const message = secretNotFoundMessage('db-password', 'file')
       expect(message).toBe(
         'Secret "db-password" not found in the "file" backend. ' +
-          'Run `vaultkeeper store --name db-password` to create it.',
+          "Run `vaultkeeper store --name 'db-password'` to create it.",
       )
     })
 
@@ -103,7 +103,7 @@ describe('formatError', () => {
       const formatted = formatError(err, CONFIG_DIR)
       expect(formatted).toBe(
         'SecretNotFoundError: Secret "db-password" not found in the "keychain" backend. ' +
-          'Run `vaultkeeper store --name db-password` to create it.',
+          "Run `vaultkeeper store --name 'db-password'` to create it.",
       )
     })
 
@@ -111,13 +111,25 @@ describe('formatError', () => {
     // validated for non-emptiness, not restricted to store/delete's safe
     // `--name` character set, so a secret name can contain a literal
     // double quote. Unescaped interpolation would unbalance the quotes
-    // around the name; JSON.stringify() escapes it instead.
+    // around the name in the diagnostic sentence; JSON.stringify() escapes
+    // it there instead.
     it('escapes a double quote in the secret name instead of unbalancing the surrounding quotes', () => {
       const message = secretNotFoundMessage('foo"bar', 'file')
       expect(message).toBe(
         'Secret "foo\\"bar" not found in the "file" backend. ' +
-          'Run `vaultkeeper store --name foo"bar` to create it.',
+          `Run \`vaultkeeper store --name 'foo"bar'\` to create it.`,
       )
+    })
+
+    // Regression (review follow-up, issue #118): the recovery hint is a
+    // literal shell command a user may copy and paste. An unescaped name
+    // containing a double quote would leave that pasted command in an
+    // unterminated-quote state; shellQuote() (single-quote POSIX escaping)
+    // keeps the hint syntactically safe regardless of the name's content.
+    it('shell-quotes the secret name in the recovery hint so it stays copy/pasteable', () => {
+      const message = secretNotFoundMessage("weird'name", 'file')
+      // shellQuote("weird'name") -> 'weird'\''name' (POSIX single-quote escaping)
+      expect(message).toContain("vaultkeeper store --name 'weird'\\''name'")
     })
   })
 })

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -106,6 +106,19 @@ describe('formatError', () => {
           'Run `vaultkeeper store --name db-password` to create it.',
       )
     })
+
+    // Regression (review follow-up, issue #118): `exec --secret` is only
+    // validated for non-emptiness, not restricted to store/delete's safe
+    // `--name` character set, so a secret name can contain a literal
+    // double quote. Unescaped interpolation would unbalance the quotes
+    // around the name; JSON.stringify() escapes it instead.
+    it('escapes a double quote in the secret name instead of unbalancing the surrounding quotes', () => {
+      const message = secretNotFoundMessage('foo"bar', 'file')
+      expect(message).toBe(
+        'Secret "foo\\"bar" not found in the "file" backend. ' +
+          'Run `vaultkeeper store --name foo"bar` to create it.',
+      )
+    })
   })
 })
 

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import * as path from 'node:path'
-import { ConfigParseError, ConfigValidationError } from 'vaultkeeper'
-import { formatError, formatPreflightConfigError } from '../../src/output.js'
+import { ConfigParseError, ConfigValidationError, SecretNotFoundError } from 'vaultkeeper'
+import { formatError, formatPreflightConfigError, secretNotFoundMessage } from '../../src/output.js'
 import type { PreflightCheckError } from 'vaultkeeper'
 
 const CONFIG_DIR = '/home/user/.config/vaultkeeper'
@@ -82,6 +82,29 @@ describe('formatError', () => {
 
       expect(formatted).toContain(path.join(CONFIG_DIR, 'config.json'))
       expect(formatted).toContain('vaultkeeper config init --force')
+    })
+  })
+
+  // Regression: issue #118 — exec and delete previously worded their
+  // SecretNotFoundError differently and neither included a recovery hint.
+  // secretNotFoundMessage() is the single source of that wording, used by
+  // both commands, so they can never drift apart again.
+  describe('secretNotFoundMessage (issue #118)', () => {
+    it('names the secret, the backend, and an actionable recovery hint', () => {
+      const message = secretNotFoundMessage('db-password', 'file')
+      expect(message).toBe(
+        'Secret "db-password" not found in the "file" backend. ' +
+          'Run `vaultkeeper store --name db-password` to create it.',
+      )
+    })
+
+    it('formats as a proper SecretNotFoundError via formatError', () => {
+      const err = new SecretNotFoundError(secretNotFoundMessage('db-password', 'keychain'))
+      const formatted = formatError(err, CONFIG_DIR)
+      expect(formatted).toBe(
+        'SecretNotFoundError: Secret "db-password" not found in the "keychain" backend. ' +
+          'Run `vaultkeeper store --name db-password` to create it.',
+      )
     })
   })
 })

--- a/packages/vaultkeeper/src/config.ts
+++ b/packages/vaultkeeper/src/config.ts
@@ -395,8 +395,13 @@ export async function loadConfig(configDir?: string): Promise<VaultConfig> {
     return validateConfig(parsed)
   } catch (err) {
     if (err instanceof ConfigValidationError) {
+      // Regression: issue #118 — this previously joined the diagnosis and the
+      // remediation hint with only a space (`...non-empty string
+      // Fix the file...`), reading as a run-on with no sentence break. A
+      // period now separates them, matching the punctuation already used for
+      // the read-error and parse-error variants of this same hint above.
       throw new ConfigValidationError(
-        `Invalid config at ${configPath}: ${err.message} ${CONFIG_REMEDIATION_HINT}`,
+        `Invalid config at ${configPath}: ${err.message}. ${CONFIG_REMEDIATION_HINT}`,
         err.field,
         configPath,
       )

--- a/packages/vaultkeeper/test/unit/config.test.ts
+++ b/packages/vaultkeeper/test/unit/config.test.ts
@@ -370,6 +370,24 @@ describe('loadConfig', () => {
     }
   })
 
+  // Regression: issue #118 — loadConfig previously joined the inner
+  // validation diagnosis and the remediation hint with only a space
+  // ("...version must be 1 Fix the file..."), reading as a run-on with no
+  // sentence break. A period must now separate diagnosis from remediation.
+  it('should separate the validation diagnosis from the remediation hint with a period, not a run-on (issue #118)', async () => {
+    vi.mocked(readFile).mockResolvedValue(JSON.stringify({ version: 99 }))
+    try {
+      await loadConfig('/fake')
+      expect.unreachable('loadConfig should have thrown')
+    } catch (err) {
+      if (!(err instanceof ConfigValidationError)) {
+        throw err
+      }
+      expect(err.message).toContain('Config version must be 1. Fix the file')
+      expect(err.message).not.toContain('Config version must be 1 Fix the file')
+    }
+  })
+
   // Issue #98: a missing config must resolve to the safe zero-config default
   // (the `file` backend), never the OS-native store — copy-pasting the first
   // documented example can never silently write to the real keychain.


### PR DESCRIPTION
## Summary

Closes three residual CLI error-experience papercuts left over after the exit-code taxonomy work in #69.

- **`SecretNotFoundError` wording (AC1)**: `exec` and `delete` previously reported the same failure with different text — `exec` said `Secret "x" not found in file backend`, while `delete` surfaced the file backend's own `Secret not found in file store: x`. Neither included a recovery hint. `delete` now catches the `SecretNotFoundError` that `vault.delete()` throws and rethrows it through a single shared helper (`secretNotFoundMessage()` in `packages/cli/src/output.ts`) — the same helper `exec` builds its message from — so both commands render identical text and can never drift apart again. Catching from the actual `delete()` call (rather than a separate `secretExists()` pre-check) also means the standardized wording holds even if the secret is removed by a concurrent process between any check and the delete itself (no TOCTOU window). The secret name and backend type are both escaped with `JSON.stringify()` in the message so an embedded quote (possible on `exec --secret`, which is validated only for non-emptiness, unlike `store`/`delete --name`) can't unbalance the surrounding quotes.
  - Before (exec): `SecretNotFoundError: Secret "no-such-secret" not found in file backend`
  - Before (delete): `SecretNotFoundError: Secret not found in file store: never-stored`
  - After (both): `SecretNotFoundError: Secret "no-such-secret" not found in the "file" backend. Run \`vaultkeeper store --name no-such-secret\` to create it.`

- **`ConfigValidationError` run-on (AC2)**: `loadConfig`'s re-thrown validation error joined the inner diagnosis and the remediation hint with only a space, reading as a run-on sentence.
  - Before: `Invalid config at /path/config.json: Config version must be 1 Fix the file — either install @vaultkeeper/cli and run...`
  - After: `Invalid config at /path/config.json: Config version must be 1. Fix the file — either install @vaultkeeper/cli and run...`
  - (The CLI's own `formatError` already ignores this raw message in favor of structured fields per #114/#129, so this fix matters for library consumers reading `.message` directly.)

- **Exit-code straggler (AC3)**: `store` with empty stdin returned exit 1 (runtime error), inconsistent with an empty or missing `--name`, which already returned exit 2 (usage error) — both mean "no usable input was given." Empty stdin now also returns 2. Verified a bare invocation (no args, exit 0 — the documented "print help" convenience from #69) is *not* equivalent misuse to a misspelled subcommand (exit 2, correctly already the case) via a new pinned matrix.

## Test plan

- [x] `packages/cli/test/unit/output.test.ts` — `secretNotFoundMessage (issue #118)`: wording + hint, `formatError` rendering, and quote-escaping for a name containing `"` (AC1, AC4)
- [x] `packages/cli/test/unit/commands/delete.test.ts` — `when vault.delete() throws SecretNotFoundError (issue #118)`: normalizes the wording, including a simulated TOCTOU race where `delete()` throws a different backend's raw wording (AC1, AC4)
- [x] `packages/cli-tests/test/e2e/exec.test.ts` — `reports the identical SecretNotFoundError wording and hint as delete for the same missing secret (issue #118)`: real-subprocess proof exec and delete render byte-identical text (AC1, AC4)
- [x] `packages/cli-tests/test/e2e/store-delete.test.ts` — dedicated delete-side e2e for the same wording/hint (AC1, AC4)
- [x] `packages/vaultkeeper/test/unit/config.test.ts` — `should separate the validation diagnosis from the remediation hint with a period, not a run-on (issue #118)` (AC2, AC4)
- [x] `packages/cli/test/unit/commands/store.test.ts` + `packages/cli-tests/test/e2e/store-delete.test.ts` — empty stdin now exits 2 (AC3, AC4)
- [x] `packages/cli-tests/test/e2e/exit-code-matrix.test.ts` (new) — pins the full matrix: bare invocation (0, and prints help), misspelled subcommand (2), missing/empty `--name` (2), empty stdin (2) (AC3, AC4)
- [x] `pnpm check` (typecheck + lint + api-report) and `pnpm test` green across all packages
- [x] Prettier clean on all changed files

## Non-goals

Does not redo the exit-code taxonomy itself (#69) — only closes the two remaining gaps found against it. Does not touch the FilesystemError read path or validation-error field detail in `formatError` (that's #137).

Refs #118
