### PR TITLE
Correct the DecryptionError changeset to a minor bump

### DIFF
--- a/.changeset/dev-mode-and-typed-errors.md
+++ b/.changeset/dev-mode-and-typed-errors.md
@@ -1,5 +1,5 @@
 ---
-'vaultkeeper': patch
+'vaultkeeper': minor
 '@vaultkeeper/cli': patch
 ---
 


### PR DESCRIPTION
## Summary

#126 added a brand-new public export (`DecryptionError`) but its changeset marked `vaultkeeper` as a `patch`. New public API surface is a semver `minor` — without this, the pending Version Packages PR (#81) would ship the new API as 0.6.1 instead of 0.7.0, and caret-pinned consumers expecting only fixes in a patch would get a new type surface unannounced.

One-line diff: `'vaultkeeper': patch` → `'vaultkeeper': minor` in `.changeset/dev-mode-and-typed-errors.md`. `@vaultkeeper/cli` stays `patch` (its changes are fixes).

Flagged in the #126 review; the PR merged before the item was addressed, so this lands the correction separately, ahead of the next Version Packages regeneration.

## Test plan

- [x] Changeset-file-only diff — no build/lint/test surface. The changesets action will regenerate #81 on merge; verify it shows `vaultkeeper@0.7.0`.