### PR TITLE
Close the TS-version matrix gate for release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,16 @@ jobs:
       - name: Make binary executable
         run: chmod +x target/release/vaultkeeper
 
-      - name: Test (including conformance)
+      # Standalone, non-workspace install of the pinned TypeScript compiler
+      # versions used by the consumer-typecheck TS-version matrix (#125).
+      # Kept out of pnpm-workspace.yaml — see that directory's package.json
+      # for why — so it needs its own install step here. Mirrors ci.yml's
+      # step exactly: release validation must run the same matrix as CI,
+      # not silently skip it (#136).
+      - name: Install TS-version matrix compilers
+        run: pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace
+
+      - name: Test (including conformance and TS-version matrix)
         run: pnpm test
 
   release:

--- a/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
+++ b/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
@@ -39,11 +39,20 @@
  * the conformance runner's `describe.skipIf` pattern) — not a silent early
  * `return`, which Vitest would otherwise report as a false pass — so local
  * runs without that setup step show honest "skipped" cells instead of
- * misleadingly green ones; CI always installs the fixtures first, so every
- * cell actually runs there.
+ * misleadingly green ones.
+ *
+ * That skip is outside-CI only. Both `ci.yml` and `release.yml` install the
+ * fixtures before running `pnpm test`, so inside CI (`process.env.CI` set) a
+ * missing pinned compiler is never treated as a skip — the cell still runs
+ * and fails with a remediation message naming the install command. This
+ * means a future workflow refactor that drops or reorders the install step
+ * is caught by a failing test rather than silently turning this gate off
+ * (#136). See `ts-version-matrix-gate.ts` for the extracted skip/fail
+ * predicate and `test/unit/ts-version-matrix-gate.test.ts` for its coverage.
  *
  * @see https://github.com/mike-north/vaultkeeper/issues/72
  * @see https://github.com/mike-north/vaultkeeper/issues/125
+ * @see https://github.com/mike-north/vaultkeeper/issues/136
  */
 
 import { describe, it, expect, afterEach } from 'vitest'
@@ -53,6 +62,7 @@ import { promisify } from 'node:util'
 import { createRequire } from 'node:module'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { shouldSkipMatrixCell, missingCompilerMessage } from './ts-version-matrix-gate.js'
 
 const execFileAsync = promisify(execFile)
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -79,6 +89,11 @@ function resolveFixtureTypescriptRoot(packageAlias: string): string | undefined 
  * `typescriptRoot` is resolved once at module load (a synchronous
  * `require.resolve`), not inside the test body, so `it.skipIf` below can
  * make a real skip/run decision per cell before Vitest registers the test.
+ *
+ * TODO(#136): optional hardening — assert each resolved compiler's real
+ * `<typescriptRoot>/package.json` version matches its pin here, so these
+ * labels and the READMEs' "5.0.4-7.0.2" claim are verified rather than
+ * assumed. Deferred: not required by #136's acceptance criteria.
  */
 const TS_VERSIONS = [
   { label: 'TypeScript 5.0.4 (stated floor)', packageAlias: 'typescript-5-0' },
@@ -118,6 +133,11 @@ const consumerSource = [
   `export { useAccessor, useSignRequest, useVerifyRequest, useTestVault, useCliTestEnv }`,
 ].join('\n')
 
+// `process.env.CI` is read once at module load, matching how
+// `typescriptRoot` is resolved for TS_VERSIONS above — both are per-run
+// facts, not per-test state.
+const inCI = process.env.CI !== undefined
+
 describe('published .d.ts typechecks across the supported TypeScript version matrix (issue #125)', () => {
   let project: Project | undefined
 
@@ -133,12 +153,18 @@ describe('published .d.ts typechecks across the supported TypeScript version mat
     // when the pinned compiler was never actually invoked. Mirrors the
     // conformance runner's `describe.skipIf` pattern for an unavailable
     // dependency.
-    it.skipIf(!typescriptRoot)(
+    //
+    // Outside CI this skips cleanly when the fixtures haven't been
+    // installed locally. Inside CI it never skips: a missing compiler there
+    // means the fixtures-install workflow step regressed, so the cell must
+    // run and fail rather than silently disappear (#136).
+    it.skipIf(shouldSkipMatrixCell(typescriptRoot, inCI))(
       `typechecks under ${label}`,
       async () => {
-        // Narrowed by skipIf above: this branch only runs when resolved.
+        // Only reachable without a resolved compiler when running in CI —
+        // shouldSkipMatrixCell would have skipped this cell otherwise.
         if (!typescriptRoot) {
-          throw new Error(`unreachable: "${label}" should have been skipped`)
+          throw new Error(missingCompilerMessage(label))
         }
 
         project = new Project('vaultkeeper-dts-consumer', '1.0.0')

--- a/packages/vaultkeeper/test/e2e/ts-version-matrix-gate.ts
+++ b/packages/vaultkeeper/test/e2e/ts-version-matrix-gate.ts
@@ -1,0 +1,27 @@
+/**
+ * Skip/fail predicate for the TS-version compatibility matrix
+ * (`consumer-typecheck.test.ts`, issue #125) extracted as a pure function so
+ * it can be unit-tested directly, without invoking `tsc` or a CI environment
+ * (see `test/unit/ts-version-matrix-gate.test.ts`).
+ *
+ * Outside CI, a missing pinned compiler is a real skip: installing
+ * `./ts-version-fixtures` is a manual, opt-in local setup step, and a
+ * developer who hasn't run it shouldn't see a failing suite.
+ *
+ * Inside CI (`process.env.CI` set), the fixtures install is a required
+ * workflow step, so a missing compiler there means that step regressed —
+ * the cell must fail loudly with a remediation message instead of quietly
+ * registering as "skipped", which would silently disable the gate (#136).
+ */
+export function shouldSkipMatrixCell(typescriptRoot: string | undefined, isCI: boolean): boolean {
+  return typescriptRoot === undefined && !isCI
+}
+
+/** Command used by both `ci.yml` and `release.yml` to install the pinned TS-version matrix compilers. */
+export const FIXTURES_INSTALL_COMMAND =
+  'pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace'
+
+/** Actionable remediation message thrown when a matrix cell resolves no pinned compiler while running in CI. */
+export function missingCompilerMessage(label: string): string {
+  return `${label}: pinned compiler not installed — run ${FIXTURES_INSTALL_COMMAND} (CI must run this before pnpm test)`
+}

--- a/packages/vaultkeeper/test/unit/ts-version-matrix-gate.test.ts
+++ b/packages/vaultkeeper/test/unit/ts-version-matrix-gate.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import {
+  shouldSkipMatrixCell,
+  missingCompilerMessage,
+  FIXTURES_INSTALL_COMMAND,
+} from '../e2e/ts-version-matrix-gate.js'
+
+/**
+ * Unit coverage for the TS-version matrix's skip/fail predicate (issue
+ * #136). The predicate decides, per matrix cell in
+ * `consumer-typecheck.test.ts`, whether a missing pinned compiler is a
+ * harmless local skip or a CI failure — this is the logic that must stay
+ * correct so a future workflow refactor that drops the fixtures-install
+ * step is caught (fails loudly) rather than silently skipping every cell.
+ */
+describe('ts-version matrix skip/fail predicate (issue #136)', () => {
+  it('skips a missing pinned compiler outside CI', () => {
+    expect(shouldSkipMatrixCell(undefined, false)).toBe(true)
+  })
+
+  it('does not skip a missing pinned compiler inside CI (so the cell runs and fails)', () => {
+    expect(shouldSkipMatrixCell(undefined, true)).toBe(false)
+  })
+
+  it('runs a resolved pinned compiler outside CI', () => {
+    expect(shouldSkipMatrixCell('/fixtures/typescript-5-0', false)).toBe(false)
+  })
+
+  it('runs a resolved pinned compiler inside CI', () => {
+    expect(shouldSkipMatrixCell('/fixtures/typescript-5-0', true)).toBe(false)
+  })
+
+  it('names the fixtures install command in the remediation message', () => {
+    const message = missingCompilerMessage('TypeScript 5.0.4 (stated floor)')
+    expect(message).toContain('TypeScript 5.0.4 (stated floor)')
+    expect(message).toContain(FIXTURES_INSTALL_COMMAND)
+  })
+
+  it('remediation message names a command that matches the CI install step exactly', () => {
+    expect(FIXTURES_INSTALL_COMMAND).toBe(
+      'pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Refs #136

`release.yml`'s `ci` job runs `pnpm test` but never installed the pinned TypeScript compilers `consumer-typecheck.test.ts`'s matrix needs, so all four matrix cells silently registered as Vitest skips during release validation — the release pipeline never actually verified the shipped `.d.ts` against the supported TypeScript range. Separately, a missing pinned compiler skipped the cell everywhere (including CI), so a future workflow refactor that dropped the install step would silently disable this gate with no red test to catch it.

- `.github/workflows/release.yml`'s `ci` job now installs `packages/vaultkeeper/test/e2e/ts-version-fixtures` with the exact same step `ci.yml` uses, right before `pnpm test`.
- `consumer-typecheck.test.ts`'s skip/fail decision is extracted into `ts-version-matrix-gate.ts` as `shouldSkipMatrixCell(typescriptRoot, isCI)`: a missing compiler only skips **outside** CI. Inside CI (`process.env.CI` set) the cell now runs and throws an actionable `missingCompilerMessage(label)` naming the install command, instead of skipping.
- The test file's header comment (previously claiming "CI always installs the fixtures first, so every cell actually runs there") is corrected to describe the new skip-outside-CI / fail-inside-CI behavior.
- `ts-version-matrix-gate.test.ts` adds unit coverage for the extracted predicate and the remediation message, independent of `tsc` or a real CI environment.

## Acceptance criteria → evidence

1. **`release.yml` installs the fixtures with the same step as `ci.yml`.** See the diff in `.github/workflows/release.yml` — identical command (`pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace`), same comment, placed before the (renamed for accuracy) `Test (including conformance and TS-version matrix)` step.
2. **Matrix cells skip only outside CI; inside CI a missing compiler fails with a remediation message.** Verified locally:
   - Fixtures installed, `pnpm test` (no `CI` env): all 4 cells run and pass.
   - Fixtures removed, no `CI` env: all 4 cells report as Vitest **skips** (unchanged local behavior).
   - Fixtures removed, `CI=1`: all 4 cells **fail**, each with `<label>: pinned compiler not installed — run pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace (CI must run this before pnpm test)`. Output below.
3. **Header comment corrected.** `consumer-typecheck.test.ts`'s module doc now states the skip is CI-conditional and explains why (see diff).
4. **Unit-level verification.** `shouldSkipMatrixCell` and `missingCompilerMessage` are extracted to `ts-version-matrix-gate.ts` and unit-tested in `ts-version-matrix-gate.test.ts` (6 cases: skip/run decision for all `{compiler present/absent} × {CI on/off}` combinations, plus the remediation message content and exact install command).

### `CI=1` with fixtures absent (the regression this closes)

```
$ rm -rf packages/vaultkeeper/test/e2e/ts-version-fixtures/node_modules
$ CI=1 pnpm --filter vaultkeeper exec vitest run test/e2e/consumer-typecheck.test.ts

 ❯ test/e2e/consumer-typecheck.test.ts (4 tests | 4 failed)
   × ... typechecks under TypeScript 5.0.4 (stated floor)
     → TypeScript 5.0.4 (stated floor): pinned compiler not installed — run pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace (CI must run this before pnpm test)
   × ... typechecks under TypeScript 5.9.3 (latest 5.x)
     → TypeScript 5.9.3 (latest 5.x): pinned compiler not installed — ...
   × ... typechecks under TypeScript 6.0.3 (latest 6.x)
     → TypeScript 6.0.3 (latest 6.x): pinned compiler not installed — ...
   × ... typechecks under TypeScript 7.0.2 (latest 7.x)
     → TypeScript 7.0.2 (latest 7.x): pinned compiler not installed — ...

 Test Files  1 failed (1)
      Tests  4 failed (4)
```

### Fixtures installed (normal path)

```
$ pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace
$ pnpm --filter vaultkeeper test

 ✓ test/unit/ts-version-matrix-gate.test.ts (6 tests)
 ✓ test/e2e/consumer-typecheck.test.ts (4 tests)
 Test Files  46 passed (46)
      Tests  734 passed (734)
```

`pnpm check` also passes clean (one pre-existing, unrelated lint warning in `packages/cli/src/config-dir.ts`, not touched by this PR).

## Non-goals

Not changing the pinned TypeScript version set or the fixtures-install mechanism — both verified working as-is. No changeset: this is CI/test-infrastructure only, no published-package behavior changes.