### PR TITLE
Make the matrix-gate workflow-consistency test read the real workflow files

### DIFF
--- a/packages/vaultkeeper/test/unit/ts-version-matrix-gate.test.ts
+++ b/packages/vaultkeeper/test/unit/ts-version-matrix-gate.test.ts
@@ -1,9 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, it, expect } from 'vitest'
 import {
   shouldSkipMatrixCell,
   missingCompilerMessage,
   FIXTURES_INSTALL_COMMAND,
 } from '../e2e/ts-version-matrix-gate.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '..', '..', '..', '..')
 
 /**
  * Unit coverage for the TS-version matrix's skip/fail predicate (issue
@@ -36,9 +42,16 @@ describe('ts-version matrix skip/fail predicate (issue #136)', () => {
     expect(message).toContain(FIXTURES_INSTALL_COMMAND)
   })
 
-  it('remediation message names a command that matches the CI install step exactly', () => {
-    expect(FIXTURES_INSTALL_COMMAND).toBe(
-      'pnpm --dir packages/vaultkeeper/test/e2e/ts-version-fixtures install --frozen-lockfile --ignore-workspace',
-    )
-  })
+  // The drift #136 guards against is a workflow edit dropping or changing
+  // the fixtures-install step. Asserting against the workflow files (not a
+  // string literal copied from the constant) means renaming the step,
+  // removing it, or changing its flags fails this test at PR time, before
+  // the in-CI cell failure can ever fire on a workflow run.
+  it.each(['.github/workflows/ci.yml', '.github/workflows/release.yml'])(
+    '%s runs the fixtures-install command the remediation message names',
+    (workflow) => {
+      const contents = readFileSync(resolve(repoRoot, workflow), 'utf8')
+      expect(contents).toContain(FIXTURES_INSTALL_COMMAND)
+    },
+  )
 })


### PR DESCRIPTION
## Summary

Follow-up to #144 (flagged in its review, merged before the fix landed). The `remediation message names a command that matches the CI install step exactly` test asserted `FIXTURES_INSTALL_COMMAND` equals a string literal that was a copy of the constant — tautological: it could only fail if someone edited the constant, never if a workflow refactor dropped or changed the fixtures-install step, which is the exact drift #136 exists to catch.

The test now reads `.github/workflows/ci.yml` and `.github/workflows/release.yml` and asserts each contains `FIXTURES_INSTALL_COMMAND` verbatim (via `it.each`). Renaming, removing, or re-flagging the install step in either workflow now fails a unit test at PR time — before the in-CI matrix-cell failure could ever fire on a workflow run.

Test-only change: no changeset (no published package behavior changes).

## Test plan

- [x] `pnpm exec vitest run test/unit/ts-version-matrix-gate.test.ts` — 7/7 pass (both workflow files contain the command)
- [x] `eslint` + `tsc --noEmit` clean on the changed file

Refs #136, #144