### PR TITLE
Cover the config-read remediation gap and restore field-level validation detail

### DIFF
--- a/.changeset/cli-config-read-remediation.md
+++ b/.changeset/cli-config-read-remediation.md
@@ -1,0 +1,8 @@
+---
+'@vaultkeeper/cli': patch
+---
+
+Fix two CLI config-error remediation gaps left over from #129:
+
+- An unreadable `config.json` (e.g. `EACCES`/`EPERM` from a root-owned file or `chmod 000`) now gets a CLI-native message naming the file path and suggesting a permissions check — it no longer falls through to the library's "install `@vaultkeeper/cli`" text, and it never recommends `config init --force` (which would hit the same permission error trying to write the replacement file).
+- A structurally invalid `config.json` now names the failing field again (e.g. `` The config at `<path>` is invalid (`version`) — run `vaultkeeper config init --force` to overwrite it. ``) — #129 dropped this detail with no replacement.

--- a/packages/cli-tests/test/e2e/config.test.ts
+++ b/packages/cli-tests/test/e2e/config.test.ts
@@ -211,6 +211,35 @@ describe('config command', () => {
     expect(result.stderr).not.toContain('install @vaultkeeper/cli')
   })
 
+  // Issue #137: an unreadable config.json (chmod 000, simulating EACCES/EPERM
+  // in the wild — e.g. a root-owned config) is a third config-error path that
+  // #114/#129 didn't cover, since it's a FilesystemError rather than
+  // ConfigParseError/ConfigValidationError. The CLI must still name the
+  // config path and never recommend `config init --force` — that command
+  // would hit the exact same permission error trying to write the
+  // replacement file, so it's a dead end here (unlike the parse/validation
+  // cases, where it's the documented recovery). Skipped on Windows (chmod
+  // semantics differ) and when running as root (root bypasses the
+  // permission bits entirely, so the repro wouldn't reproduce EACCES).
+  const isWindows = process.platform === 'win32'
+  const isRoot = typeof process.getuid === 'function' && process.getuid() === 0
+  describe.skipIf(isWindows || isRoot)('unreadable config.json (issue #137)', () => {
+    it('names the config path, suggests checking permissions, and never suggests install/force-reinit', async () => {
+      env = await createCliTestEnv()
+      const configPath = path.join(env.configDir, 'config.json')
+      await fs.chmod(configPath, 0o000)
+
+      const result = await env.run(['config', 'show'])
+
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stdout).toBe('')
+      expect(result.stderr).toContain(configPath)
+      expect(result.stderr).not.toContain('install @vaultkeeper/cli')
+      expect(result.stderr).not.toContain('config init --force')
+      expect(result.stderr.toLowerCase()).toContain('permission')
+    })
+  })
+
   it('should exit 2 for config with no subcommand', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['config'])

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -95,12 +95,19 @@ function isUnreadableConfigFile(err: unknown, configDir: string): err is Filesys
  * The remediation here deliberately does NOT suggest `config init --force`:
  * that command would hit the exact same permission error trying to write the
  * replacement file, so it's a dead end for this failure mode.
+ *
+ * Review follow-up (issue #137, PR #158): an earlier draft suggested running
+ * `ls -l <path>` as an example command. That's POSIX-only — confusing on
+ * Windows, which this CLI supports via the dpapi backend — and embedded the
+ * path unquoted, which breaks if it contains spaces/metacharacters (e.g. a
+ * user-supplied `--config-dir`). Platform-neutral prose avoids both problems
+ * without introducing platform-branching for a single message.
  */
 function formatConfigReadError(err: FilesystemError): string {
   return (
     `${err.name}: The config at \`${err.path}\` could not be read — ` +
-    'check that the file exists and that your user has permission to read it ' +
-    `(e.g. \`ls -l ${err.path}\`), then try again.`
+    "check the file's permissions and ownership, and that it exists — the " +
+    'current user cannot read it. Then try again.'
   )
 }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -70,9 +70,10 @@ function formatConfigError(
 }
 
 /**
- * True when `err` is the `FilesystemError` `loadConfig` throws for an
- * unreadable `config.json` (e.g. `EACCES`/`EPERM`) — as opposed to any other
- * filesystem failure. `FileBackend` secret reads never live at
+ * True when `err` is the `FilesystemError` `loadConfig` throws for a failed
+ * read of `config.json` — any errno (`EACCES`/`EPERM`/`EISDIR`/etc.), not
+ * only permission failures; `formatConfigReadError` picks the actual wording
+ * from `err.code`. `FileBackend` secret reads never live at
  * `configDir/config.json`, so this check can't collide with a backend read
  * failure (issue #137).
  */
@@ -85,6 +86,15 @@ function isUnreadableConfigFile(err: unknown, configDir: string): err is Filesys
 }
 
 /**
+ * Errno codes handled by `isUnreadableConfigFile` that are actually
+ * permission problems. `undefined` (no errno code recovered — see
+ * `FilesystemError.code`'s docs) is treated the same way, conservatively:
+ * it's the pre-#141 shape, and a permissions hint is still broadly correct
+ * for a read failure of unknown cause.
+ */
+const PERMISSION_ERROR_CODES = new Set(['EACCES', 'EPERM'])
+
+/**
  * Build the CLI-native remediation for an unreadable `config.json`.
  *
  * Regression: issue #114 fixed this wrong-audience remediation for parse and
@@ -92,9 +102,11 @@ function isUnreadableConfigFile(err: unknown, configDir: string): err is Filesys
  * EACCES/EPERM `config.json`, e.g. a root-owned or chmod'd file) still fell
  * through to `formatError`'s generic `Error` branch, printing the library's
  * own message — which still names `install @vaultkeeper/cli` (issue #137).
- * The remediation here deliberately does NOT suggest `config init --force`:
- * that command would hit the exact same permission error trying to write the
- * replacement file, so it's a dead end for this failure mode.
+ * The remediation here deliberately does NOT suggest `config init --force`
+ * for any variant below: that command would either hit the exact same read
+ * failure trying to write the replacement file (a permission problem) or be
+ * the wrong fix entirely (e.g. overwriting a directory doesn't make it a
+ * file) — a dead end either way.
  *
  * Review follow-up (issue #137, PR #158): an earlier draft suggested running
  * `ls -l <path>` as an example command. That's POSIX-only — confusing on
@@ -102,12 +114,27 @@ function isUnreadableConfigFile(err: unknown, configDir: string): err is Filesys
  * path unquoted, which breaks if it contains spaces/metacharacters (e.g. a
  * user-supplied `--config-dir`). Platform-neutral prose avoids both problems
  * without introducing platform-branching for a single message.
+ *
+ * Review follow-up (issue #137, PR #158): `isUnreadableConfigFile` matches
+ * *any* read-path `FilesystemError` on `config.json`, not only permission
+ * failures — `EISDIR`, `ENOSPC`-adjacent codes, etc. can also reach here, and
+ * asserting "the current user cannot read it" would be an outright wrong
+ * diagnosis for those. `FilesystemError.code` (added in #141) lets this
+ * branch on the actual errno rather than assume permissions: a genuine
+ * permission code (or no code at all, conservatively) keeps the permissions
+ * wording; any other code gets an honest, code-naming message instead.
  */
 function formatConfigReadError(err: FilesystemError): string {
+  if (err.code === undefined || PERMISSION_ERROR_CODES.has(err.code)) {
+    return (
+      `${err.name}: The config at \`${err.path}\` could not be read — ` +
+      "check the file's permissions and ownership, and that it exists — the " +
+      'current user cannot read it. Then try again.'
+    )
+  }
   return (
-    `${err.name}: The config at \`${err.path}\` could not be read — ` +
-    "check the file's permissions and ownership, and that it exists — the " +
-    'current user cannot read it. Then try again.'
+    `${err.name}: The config at \`${err.path}\` could not be read (${err.code}) — ` +
+    'check that the path is a regular, readable file, then try again.'
   )
 }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -5,7 +5,7 @@
  */
 
 import * as path from 'node:path'
-import { ConfigParseError, ConfigValidationError } from 'vaultkeeper'
+import { ConfigParseError, ConfigValidationError, FilesystemError } from 'vaultkeeper'
 import type { PreflightCheckError } from 'vaultkeeper'
 import { shellQuote } from './shell-quote.js'
 
@@ -32,18 +32,22 @@ export function dim(text: string): string {
  * — correct advice for a library consumer that doesn't have a CLI installed
  * (issue #100), but wrong for a user who is already running this CLI
  * (issue #114). Only structured fields that are safe to depend on are used
- * (the file path, and — for a parse error — its line/column location); the
- * library-internal validation reason text lives only in `.message`
- * alongside the wrong remediation, so it is deliberately not reused here.
- * `configDir` is a fallback for `ConfigValidationError.configFilePath`,
- * which is `undefined` when the error came from validating an in-memory
- * value rather than a loaded file — a case the CLI itself never hits, since
- * it only ever validates via `loadConfig`/`VaultKeeper.init`.
+ * (the file path, and — for a parse error, its line/column location; for a
+ * validation error, its `field`); the library-internal validation *reason*
+ * text (e.g. "must be a non-empty string") lives only in `.message`
+ * alongside the wrong remediation, so it is deliberately not reused here —
+ * but `field` (the dotted/bracketed path to the offending field, e.g.
+ * `version`) is itself a structured, remediation-free field and safe to
+ * surface (issue #137). `configDir` is a fallback for
+ * `ConfigValidationError.configFilePath`, which is `undefined` when the
+ * error came from validating an in-memory value rather than a loaded file —
+ * a case the CLI itself never hits, since it only ever validates via
+ * `loadConfig`/`VaultKeeper.init`.
  */
-function configRemediation(configPath: string, location: string | undefined): string {
-  const locationSuffix = location !== undefined ? ` (at ${location})` : ''
+function configRemediation(configPath: string, detail: string | undefined): string {
+  const detailSuffix = detail !== undefined ? ` (${detail})` : ''
   return (
-    `The config at \`${configPath}\` is invalid${locationSuffix} — ` +
+    `The config at \`${configPath}\` is invalid${detailSuffix} — ` +
     'run `vaultkeeper config init --force` to overwrite it.'
   )
 }
@@ -56,8 +60,48 @@ function formatConfigError(
     err instanceof ConfigParseError
       ? err.path
       : (err.configFilePath ?? path.join(configDir, 'config.json'))
-  const location = err instanceof ConfigParseError ? err.location : undefined
-  return `${err.name}: ${configRemediation(configPath, location)}`
+  const detail =
+    err instanceof ConfigParseError
+      ? err.location !== undefined
+        ? `at ${err.location}`
+        : undefined
+      : `\`${err.field}\``
+  return `${err.name}: ${configRemediation(configPath, detail)}`
+}
+
+/**
+ * True when `err` is the `FilesystemError` `loadConfig` throws for an
+ * unreadable `config.json` (e.g. `EACCES`/`EPERM`) — as opposed to any other
+ * filesystem failure. `FileBackend` secret reads never live at
+ * `configDir/config.json`, so this check can't collide with a backend read
+ * failure (issue #137).
+ */
+function isUnreadableConfigFile(err: unknown, configDir: string): err is FilesystemError {
+  return (
+    err instanceof FilesystemError &&
+    err.permission === 'read' &&
+    err.path === path.join(configDir, 'config.json')
+  )
+}
+
+/**
+ * Build the CLI-native remediation for an unreadable `config.json`.
+ *
+ * Regression: issue #114 fixed this wrong-audience remediation for parse and
+ * validation errors, but the read-failure path (`FilesystemError` from an
+ * EACCES/EPERM `config.json`, e.g. a root-owned or chmod'd file) still fell
+ * through to `formatError`'s generic `Error` branch, printing the library's
+ * own message — which still names `install @vaultkeeper/cli` (issue #137).
+ * The remediation here deliberately does NOT suggest `config init --force`:
+ * that command would hit the exact same permission error trying to write the
+ * replacement file, so it's a dead end for this failure mode.
+ */
+function formatConfigReadError(err: FilesystemError): string {
+  return (
+    `${err.name}: The config at \`${err.path}\` could not be read — ` +
+    'check that the file exists and that your user has permission to read it ' +
+    `(e.g. \`ls -l ${err.path}\`), then try again.`
+  )
 }
 
 /**
@@ -69,7 +113,8 @@ function formatConfigError(
  * the CLI.
  */
 export function formatPreflightConfigError(error: PreflightCheckError): string {
-  return configRemediation(error.configPath, error.location)
+  const detail = error.location !== undefined ? `at ${error.location}` : undefined
+  return configRemediation(error.configPath, detail)
 }
 
 /**
@@ -112,6 +157,9 @@ export function secretNotFoundMessage(name: string, backendType: string): string
 export function formatError(err: unknown, configDir: string): string {
   if (err instanceof ConfigParseError || err instanceof ConfigValidationError) {
     return formatConfigError(err, configDir)
+  }
+  if (isUnreadableConfigFile(err, configDir)) {
+    return formatConfigReadError(err)
   }
   if (err instanceof Error) {
     return `${err.name}: ${err.message}`

--- a/packages/cli/test/unit/commands/config.test.ts
+++ b/packages/cli/test/unit/commands/config.test.ts
@@ -199,11 +199,15 @@ describe('configCommand', () => {
     })
 
     // Issue #114: the CLI's own message no longer echoes the library's
-    // field-level reason verbatim (that text lives only alongside the
-    // library's "install @vaultkeeper/cli" remediation — issue #100); it
-    // instead builds a CLI-native message from the error's remediation-free
-    // structured fields (path here; also location for a parse error).
-    it('exits non-zero with a CLI-native remediation, path, and recovery command on structurally invalid config', async () => {
+    // field-level *reason* verbatim (that text lives only in `.message`,
+    // alongside the library's "install @vaultkeeper/cli" remediation — issue
+    // #100); it instead builds a CLI-native message from the error's
+    // remediation-free structured fields (path; also location for a parse
+    // error). Issue #137: the failing field's *name* (`ConfigValidationError
+    // .field`, itself a structured, remediation-free field) is restored —
+    // #129 dropped the field-level detail entirely with no replacement, so
+    // this re-asserts it via the structured field rather than `.message`.
+    it('exits non-zero with a CLI-native remediation, path, failing field, and recovery command on structurally invalid config', async () => {
       await fs.mkdir(configDir, { recursive: true })
       await fs.writeFile(
         path.join(configDir, 'config.json'),
@@ -214,6 +218,7 @@ describe('configCommand', () => {
       const code = await configCommand(['show'], configDir)
       expect(code).toBe(1)
       expect(stderrOutput).toContain(path.join(configDir, 'config.json'))
+      expect(stderrOutput).toContain('`version`')
       expect(stderrOutput).toContain('vaultkeeper config init --force')
       expect(stderrOutput).not.toContain('install @vaultkeeper/cli')
     })

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -90,6 +90,11 @@ describe('formatError', () => {
     })
   })
 
+  /** Build a Node.js-shaped filesystem error with a `code` (e.g. 'EACCES'). */
+  function fsError(code: string, message: string): NodeJS.ErrnoException {
+    return Object.assign(new Error(message), { code })
+  }
+
   // Issue #137: an unreadable config.json (EACCES/EPERM) throws
   // FilesystemError, not ConfigParseError/ConfigValidationError, so #129/#114's
   // fix didn't cover it — formatError fell through to the generic `Error`
@@ -99,7 +104,7 @@ describe('formatError', () => {
   // hit the same permission error trying to write the replacement file), and
   // points at checking permissions instead.
   describe('unreadable config.json gets a CLI-native remediation (issue #137)', () => {
-    it('rewrites a read-permission FilesystemError on config.json to a CLI-native message', () => {
+    it('rewrites a read FilesystemError with no errno code (pre-#141 shape) to permissions wording, conservatively', () => {
       const configPath = path.join(CONFIG_DIR, 'config.json')
       const err = new FilesystemError(
         `Cannot read config file at ${configPath}: permission denied. ` +
@@ -116,6 +121,51 @@ describe('formatError', () => {
       expect(formatted).not.toContain('install @vaultkeeper/cli')
       expect(formatted).not.toContain('config init --force')
       expect(formatted.toLowerCase()).toContain('permission')
+    })
+
+    // Review follow-up (issue #137, PR #158): FilesystemError.code (added in
+    // #141) lets the CLI distinguish an actual permission failure (EACCES,
+    // EPERM) from any other read errno — a genuine permission code keeps the
+    // permissions wording.
+    it('rewrites an EACCES-coded FilesystemError to permissions wording', () => {
+      const configPath = path.join(CONFIG_DIR, 'config.json')
+      const err = new FilesystemError(
+        `Cannot read config file at ${configPath}: permission denied.`,
+        configPath,
+        'read',
+        fsError('EACCES', 'permission denied'),
+      )
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).toContain(configPath)
+      expect(formatted.toLowerCase()).toContain('permission')
+      expect(formatted).not.toContain('install @vaultkeeper/cli')
+      expect(formatted).not.toContain('config init --force')
+    })
+
+    // Review follow-up (issue #137, PR #158): isUnreadableConfigFile matches
+    // *any* read-path FilesystemError on config.json, including non-permission
+    // failures like EISDIR (e.g. config.json is actually a directory). The
+    // old unconditional "the current user cannot read it" wording would be a
+    // wrong diagnosis here — the message must instead name the actual errno
+    // and avoid the permissions claim it can't back up.
+    it('rewrites an EISDIR-coded FilesystemError to honest, code-naming wording (not a permissions claim)', () => {
+      const configPath = path.join(CONFIG_DIR, 'config.json')
+      const err = new FilesystemError(
+        `Cannot read config file at ${configPath}: EISDIR.`,
+        configPath,
+        'read',
+        fsError('EISDIR', 'illegal operation on a directory'),
+      )
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).toContain(configPath)
+      expect(formatted).toContain('EISDIR')
+      expect(formatted.toLowerCase()).not.toContain('permission')
+      expect(formatted).not.toContain('install @vaultkeeper/cli')
+      expect(formatted).not.toContain('config init --force')
     })
 
     // Review follow-up (PR #158): an earlier draft suggested `ls -l <path>`

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -118,6 +118,25 @@ describe('formatError', () => {
       expect(formatted.toLowerCase()).toContain('permission')
     })
 
+    // Review follow-up (PR #158): an earlier draft suggested `ls -l <path>`
+    // as an example command — POSIX-only (confusing on the Windows dpapi
+    // backend) and an unquoted path that breaks on spaces/metacharacters
+    // (e.g. a user-supplied --config-dir). The message must stay
+    // platform-neutral prose with no embedded shell command.
+    it('does not embed a POSIX-only shell command example (e.g. `ls -l`) in the remediation', () => {
+      const configPath = path.join(CONFIG_DIR, 'config.json')
+      const err = new FilesystemError(
+        `Cannot read config file at ${configPath}: permission denied.`,
+        configPath,
+        'read',
+      )
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).not.toContain('ls -l')
+      expect(formatted).not.toContain('`ls')
+    })
+
     it('does not intercept a FilesystemError for a write failure on config.json', () => {
       // Only a 'read' permission failure on config.json is the config-read
       // path; other permissions (or other paths) fall through to the

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import * as path from 'node:path'
-import { ConfigParseError, ConfigValidationError, SecretNotFoundError } from 'vaultkeeper'
+import {
+  ConfigParseError,
+  ConfigValidationError,
+  FilesystemError,
+  SecretNotFoundError,
+} from 'vaultkeeper'
 import { formatError, formatPreflightConfigError, secretNotFoundMessage } from '../../src/output.js'
 import type { PreflightCheckError } from 'vaultkeeper'
 
@@ -82,6 +87,69 @@ describe('formatError', () => {
 
       expect(formatted).toContain(path.join(CONFIG_DIR, 'config.json'))
       expect(formatted).toContain('vaultkeeper config init --force')
+    })
+  })
+
+  // Issue #137: an unreadable config.json (EACCES/EPERM) throws
+  // FilesystemError, not ConfigParseError/ConfigValidationError, so #129/#114's
+  // fix didn't cover it — formatError fell through to the generic `Error`
+  // branch and printed the library's own message, still naming
+  // "install @vaultkeeper/cli". This must get its own CLI-native remediation
+  // that names the path, never suggests `config init --force` (that would
+  // hit the same permission error trying to write the replacement file), and
+  // points at checking permissions instead.
+  describe('unreadable config.json gets a CLI-native remediation (issue #137)', () => {
+    it('rewrites a read-permission FilesystemError on config.json to a CLI-native message', () => {
+      const configPath = path.join(CONFIG_DIR, 'config.json')
+      const err = new FilesystemError(
+        `Cannot read config file at ${configPath}: permission denied. ` +
+          "Fix the file — either install @vaultkeeper/cli and run 'vaultkeeper config init --force' " +
+          'to overwrite it with a valid config, or repair/replace it programmatically via this ' +
+          'library (pass an explicit `config` or `configDir`, or write a valid config.json yourself).',
+        configPath,
+        'read',
+      )
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).toContain(configPath)
+      expect(formatted).not.toContain('install @vaultkeeper/cli')
+      expect(formatted).not.toContain('config init --force')
+      expect(formatted.toLowerCase()).toContain('permission')
+    })
+
+    it('does not intercept a FilesystemError for a write failure on config.json', () => {
+      // Only a 'read' permission failure on config.json is the config-read
+      // path; other permissions (or other paths) fall through to the
+      // generic Error branch unchanged.
+      const configPath = path.join(CONFIG_DIR, 'config.json')
+      const err = new FilesystemError(
+        `Cannot write config file at ${configPath}: EACCES`,
+        configPath,
+        'write',
+      )
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).toBe(`FilesystemError: Cannot write config file at ${configPath}: EACCES`)
+    })
+
+    it('does not intercept a read-permission FilesystemError for a different path (e.g. a backend secret file)', () => {
+      // FileBackend secret reads never live at configDir/config.json, but
+      // guard the boundary explicitly so a future refactor can't silently
+      // widen this to swallow unrelated read failures.
+      const secretPath = path.join(CONFIG_DIR, 'secrets', 'db-password.json')
+      const err = new FilesystemError(
+        `Cannot read secret file at ${secretPath}: permission denied.`,
+        secretPath,
+        'read',
+      )
+
+      const formatted = formatError(err, CONFIG_DIR)
+
+      expect(formatted).toBe(
+        `FilesystemError: Cannot read secret file at ${secretPath}: permission denied.`,
+      )
     })
   })
 
@@ -167,16 +235,45 @@ describe('formatPreflightConfigError', () => {
     expect(formatted).not.toContain('install @vaultkeeper/cli')
   })
 
-  it('shares the exact remediation wording with formatError (one voice across commands)', () => {
+  it('shares the exact remediation wording with formatError for a config-parse failure (one voice across commands)', () => {
+    const err = new ConfigParseError(
+      `Failed to parse config file at ${configPath} at line 3, column 12: bad. ` +
+        'install @vaultkeeper/cli and run ...',
+      configPath,
+      'line 3, column 12',
+    )
+    // formatError prefixes the error name; the core sentence must match.
+    const errorPath = formatError(err, CONFIG_DIR)
+    const doctorPath = formatPreflightConfigError({
+      kind: 'config-parse',
+      configPath,
+      location: 'line 3, column 12',
+    })
+
+    expect(errorPath).toBe(`ConfigParseError: ${doctorPath}`)
+  })
+
+  // Issue #137: formatError now includes ConfigValidationError.field in its
+  // message (e.g. "is invalid (`version`)"), giving CLI users back the
+  // field-level detail #129 dropped. The doctor path's PreflightCheckError
+  // deliberately does NOT gain a `field` — extending that structured type is
+  // an explicit non-goal of #137 (see #130/#145's shipped design) — so the
+  // two paths diverge here rather than sharing wording exactly.
+  it('includes the failing field in formatError but not in the doctor path (issue #137, non-goal boundary)', () => {
     const err = new ConfigValidationError(
       `Invalid config at ${configPath}: bad. install @vaultkeeper/cli and run ...`,
       'version',
       configPath,
     )
-    // formatError prefixes the error name; the core sentence must match.
     const errorPath = formatError(err, CONFIG_DIR)
     const doctorPath = formatPreflightConfigError({ kind: 'config-validation', configPath })
 
-    expect(errorPath).toBe(`ConfigValidationError: ${doctorPath}`)
+    expect(errorPath).toBe(
+      `ConfigValidationError: The config at \`${configPath}\` is invalid (\`version\`) — ` +
+        'run `vaultkeeper config init --force` to overwrite it.',
+    )
+    expect(doctorPath).toBe(
+      `The config at \`${configPath}\` is invalid — run \`vaultkeeper config init --force\` to overwrite it.`,
+    )
   })
 })


### PR DESCRIPTION
## Summary

#129 gave `ConfigParseError`/`ConfigValidationError` a CLI-native remediation, but two review findings were left unaddressed:

1. An unreadable `config.json` (EACCES/EPERM) throws `FilesystemError`, not one of the two handled classes, so `formatError` fell through to the generic `Error` branch and printed the library's own message — still naming `install @vaultkeeper/cli`, and (via the library's shared remediation hint) implying `config init --force`, which would hit the exact same permission error trying to write the replacement file. `formatError` now detects this specific case (`FilesystemError` with `permission === 'read'` and `path === configDir/config.json` — a check that can't collide with a `FileBackend` secret read, which never lives at that path) and builds a message that names the path and suggests checking file permissions instead.
2. `ConfigValidationError` lost its field-level diagnostic in #129 with no replacement, leaving only a generic "is invalid" message that pointed straight at a destructive overwrite. The CLI message now includes the structured, remediation-free `ConfigValidationError.field` (e.g. `` The config at `<path>` is invalid (`version`) — run `vaultkeeper config init --force` to overwrite it. ``) — the validation *reason* text in `.message` is still not reused, only the safe structured field.

Non-goals (per issue): no structured `field` added to `PreflightCheckError`/the doctor path (#130/#145 territory) — an existing unit test asserted `formatError` and `formatPreflightConfigError` produce identical wording for a validation failure; that test is updated to reflect the two paths intentionally diverging now that only `formatError` surfaces the field. Library messages are unchanged (#100 constraint) — this is CLI-side formatting only.

## Test plan

- [x] `packages/cli-tests/test/e2e/config.test.ts` — new subprocess e2e test: `chmod 000` on `config.json` (skipped on Windows and when running as root, since root bypasses permission bits) asserts the CLI output names the config path, does not contain `install @vaultkeeper/cli`, does not recommend `config init --force`, and suggests checking permissions. **Criterion 1.**
- [x] `packages/cli/test/unit/output.test.ts` — unit coverage for `formatError`'s new `FilesystemError` branch: rewrites a read-permission failure on `config.json`, and does *not* intercept a write-permission failure or a read-permission failure on a different path (e.g. a backend secret file).
- [x] `packages/cli/test/unit/commands/config.test.ts` — re-asserts the failing field (`` `version` ``) appears in `config show`'s stderr for a structurally invalid config. **Criterion 2.**
- [x] `packages/cli/test/unit/output.test.ts` — updated `formatPreflightConfigError`/`formatError` parity tests: parse-kind wording still matches exactly; validation-kind now documents the intentional field-only divergence. **Criterion 3** (library messages unchanged, verified by the untouched `vaultkeeper` unit tests all still passing).
- [x] `pnpm check` and `pnpm test` green across the workspace.

Refs #137