### PR TITLE
Make bare `vaultkeeper` invocation exit 2 (usage error)

### DIFF
--- a/.changeset/cli-bare-invocation-exit-code.md
+++ b/.changeset/cli-bare-invocation-exit-code.md
@@ -1,0 +1,9 @@
+---
+'@vaultkeeper/cli': patch
+---
+
+Make a bare `vaultkeeper` invocation exit `2` instead of `0`.
+
+Running `vaultkeeper` with no subcommand previously printed help to stdout and exited `0`, which let `vaultkeeper && next_step` proceed as if a command had succeeded. A bare invocation is a bad invocation (like an unknown command), so it now prints usage to stderr and exits `2`. An explicit `vaultkeeper --help` / `-h` is still a successful usage request and exits `0` on stdout.
+
+This completes the CLI exit-code convention: `0` success, `1` a valid invocation that failed at runtime, `2` a bad invocation (usage / argument-validation error). Empty-stdin `store` already exits `2`.

--- a/packages/cli-tests/test/e2e/exit-code-matrix.test.ts
+++ b/packages/cli-tests/test/e2e/exit-code-matrix.test.ts
@@ -1,27 +1,30 @@
 /**
- * Pins the CLI's exit-code taxonomy (0 success / 1 runtime error / 2 usage
- * error, established in issue #69) across a set of misuse cases that should
- * be treated equivalently, so a future change can't silently reintroduce a
- * straggler.
+ * Pins the CLI's exit-code taxonomy across the full matrix of invocation
+ * outcomes, so a future change can't silently reintroduce a straggler.
  *
- * Issue #118 closed two remaining gaps found against this taxonomy:
- *   - `store` with empty stdin previously returned 1 (runtime), inconsistent
- *     with `store --name ''` / missing `--name`, which return 2 (usage) for
- *     the same underlying problem: no usable input was given.
- *   - A bare invocation (no arguments) is NOT equivalent misuse to a
- *     misspelled subcommand — the former is the documented "print help"
- *     convenience (issue #69, still exit 0), the latter is a genuine usage
- *     error (exit 2). This suite pins both sides of that distinction so it
- *     is verified, not just assumed.
+ * Convention (documented in packages/cli/src/bin.ts):
+ *   0 — success
+ *   1 — a valid invocation that failed at runtime (e.g. SecretNotFoundError)
+ *   2 — a bad invocation: usage / argument-validation error
+ *
+ * History:
+ *   - Issue #69 established the taxonomy and fixed bad-flag stragglers.
+ *   - Issue #118 normalized empty-stdin `store` from 1 → 2.
+ *   - Issue #151 normalized a bare invocation (no subcommand) from 0 → 2:
+ *     printing help with exit 0 let `vaultkeeper && next_step` proceed as if a
+ *     command had succeeded. A bare invocation is a bad invocation, like an
+ *     unknown command, and now exits 2 with usage on stderr. An explicit
+ *     `--help` / `-h` is still a successful usage request (exit 0, stdout).
  *
  * @see https://github.com/mike-north/vaultkeeper/issues/69
  * @see https://github.com/mike-north/vaultkeeper/issues/118
+ * @see https://github.com/mike-north/vaultkeeper/issues/151
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
 import type { CliTestEnv } from '@vaultkeeper/cli-test-helpers'
 
-describe('exit-code matrix (issue #118)', () => {
+describe('exit-code matrix', () => {
   let env: CliTestEnv | undefined
 
   afterEach(async () => {
@@ -31,18 +34,21 @@ describe('exit-code matrix (issue #118)', () => {
     }
   })
 
-  it('a bare invocation (no arguments) exits 0 and prints help', async () => {
-    env = await createCliTestEnv()
-    const result = await env.run([])
-    expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
-  })
+  // --- 2: bad invocation (usage / validation) ---
 
-  it('a misspelled/unknown subcommand exits 2, unlike a bare invocation', async () => {
+  it('an unknown subcommand exits 2 with usage', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['stroe'])
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('Unknown command')
+    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
+  })
+
+  it('an unknown flag exits 2 (usage error)', async () => {
+    env = await createCliTestEnv()
+    const result = await env.runWithStdin(['store', '--bogus'], 'sk-live-abc123')
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('Usage:')
   })
 
   it('store with a missing --name exits 2 (usage error)', async () => {
@@ -62,10 +68,38 @@ describe('exit-code matrix (issue #118)', () => {
 
   // Regression: issue #118 — this previously exited 1, inconsistent with the
   // two cases above for the same class of misuse (no usable input given).
-  it('store with empty stdin exits 2 (usage error), matching missing/empty --name', async () => {
+  it('store with empty stdin exits 2 with a usage hint', async () => {
     env = await createCliTestEnv()
     const result = await env.runWithStdin(['store', '--name', 'test-secret', '--skip-doctor'], '')
     expect(result.exitCode).toBe(2)
     expect(result.stderr).toContain('No secret provided on stdin')
+    expect(result.stderr).toContain('Usage:')
+  })
+
+  // Regression: issue #151 — a bare invocation previously exited 0, which let
+  // `vaultkeeper && next_step` proceed as if a command had succeeded.
+  it('a bare invocation (no arguments) exits 2 with usage on stderr', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run([])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
+  })
+
+  // --- 1: valid invocation that failed at runtime ---
+
+  it('deleting a secret that does not exist exits 1 (runtime error)', async () => {
+    env = await createCliTestEnv({ env: { VAULTKEEPER_SKIP_DOCTOR: '1' } })
+    const result = await env.run(['delete', '--name', 'does-not-exist'])
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain('not found')
+  })
+
+  // --- 0: success ---
+
+  it('a successful store exits 0', async () => {
+    env = await createCliTestEnv({ env: { VAULTKEEPER_SKIP_DOCTOR: '1' } })
+    const result = await env.runWithStdin(['store', '--name', 'FOO'], 'sk-live-abc123')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('stored successfully')
   })
 })

--- a/packages/cli-tests/test/e2e/help.test.ts
+++ b/packages/cli-tests/test/e2e/help.test.ts
@@ -15,11 +15,14 @@ describe('help and usage', () => {
     }
   })
 
-  it('should print help and exit 0 when no arguments are given', async () => {
+  it('should print usage to stderr and exit 2 when no arguments are given', async () => {
+    // A bare invocation is a usage error, not success (issue #151): usage goes
+    // to stderr and the exit code is 2 so `vaultkeeper && next_step` does not
+    // proceed as if a command had succeeded. An explicit --help/-h still exits 0.
     env = await createCliTestEnv()
     const result = await env.run([])
-    expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
   it('should print help and exit 0 for --help', async () => {

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -9,10 +9,14 @@
  * parseArgs consumes argv[2..] and extracts the subcommand as positionals[0].
  * commandArgs is argv[3..] — everything after the subcommand.
  *
- * Exit codes:
+ * Exit-code convention:
  *   0 — success
- *   1 — runtime / vault error
- *   2 — usage error (unknown command, missing required argument, bad flag)
+ *   1 — a valid invocation that failed at runtime (e.g. SecretNotFoundError)
+ *   2 — a bad invocation: usage / argument-validation error. Covers an unknown
+ *       command, an unknown top-level flag, a missing/invalid required
+ *       argument, empty stdin for `store`, and a bare invocation with no
+ *       subcommand (which prints usage to stderr rather than exiting 0, so
+ *       `vaultkeeper && next_step` does not proceed as if it succeeded).
  *
  * @internal
  */
@@ -81,8 +85,8 @@ const { positionals } = parseArgs({
 const subcommand = positionals[0]
 const commandArgs = filteredArgv.slice(1)
 
-function printHelp(): void {
-  process.stdout.write(
+function printHelp(stream: NodeJS.WritableStream = process.stdout): void {
+  stream.write(
     'Usage: vaultkeeper [--config-dir <path>] <command> [options]\n\n' +
       'Commands:\n' +
       '  exec         Run a command with a secret injected as an env var\n' +
@@ -117,11 +121,20 @@ async function main(): Promise<number> {
     return 0
   }
 
-  // A bare invocation (no arguments at all) or --help/-h prints help and
-  // exits 0 — this is the "getting started" case.
-  if (filteredArgv.length === 0 || firstArg === '--help' || firstArg === '-h') {
+  // An explicit --help / -h is a successful request for usage: print to
+  // stdout and exit 0.
+  if (firstArg === '--help' || firstArg === '-h') {
     printHelp()
     return 0
+  }
+
+  // A bare invocation (no arguments at all) is a usage error, not success:
+  // print usage to stderr and exit 2 so that `vaultkeeper && next_step` does
+  // not proceed as if a command had succeeded (issue #151). This aligns bare
+  // invocation with the unknown-command case, which already exits 2.
+  if (filteredArgv.length === 0) {
+    printHelp(process.stderr)
+    return 2
   }
 
   // A first token that looks like a flag (starts with '-') but isn't a
@@ -136,10 +149,11 @@ async function main(): Promise<number> {
 
   // Defensive fallback: parseArgs with allowPositionals should always set
   // subcommand to firstArg when firstArg doesn't start with '-', but if it
-  // somehow didn't, treat it the same as a bare invocation.
+  // somehow didn't, treat it the same as a bare invocation — a usage error
+  // (issue #151), not a successful help print.
   if (subcommand === undefined) {
-    printHelp()
-    return 0
+    printHelp(process.stderr)
+    return 2
   }
 
   const configDir = resolveConfigDir(configDirFlag)

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -130,8 +130,11 @@ async function main(): Promise<number> {
 
   // A bare invocation (no arguments at all) is a usage error, not success:
   // print usage to stderr and exit 2 so that `vaultkeeper && next_step` does
-  // not proceed as if a command had succeeded (issue #151). This aligns bare
-  // invocation with the unknown-command case, which already exits 2.
+  // not proceed as if a command had succeeded (issue #151). This matches the
+  // exit CODE of the unknown-command case (both 2); the output STREAM
+  // deliberately differs — a bare invocation has no error line, so its usage
+  // goes to stderr, whereas unknown-command writes its "Unknown command"
+  // error to stderr and the usage that follows to stdout.
   if (filteredArgv.length === 0) {
     printHelp(process.stderr)
     return 2

--- a/packages/cli/test/unit/bin.test.ts
+++ b/packages/cli/test/unit/bin.test.ts
@@ -31,12 +31,15 @@ function runCli(args: string[]): Promise<CliResult> {
 }
 
 describe('bin.ts entry point', () => {
-  it('should print help and exit 0 when no arguments are given', async () => {
+  // Regression: issue #151 — a bare invocation previously printed help to
+  // stdout and exited 0, which let `vaultkeeper && next_step` proceed as if a
+  // command had succeeded. It is now a usage error: usage on stderr, exit 2.
+  it('should print usage to stderr and exit 2 when no arguments are given', async () => {
     const result = await runCli([])
-    expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
-    expect(result.stdout).toContain('exec')
-    expect(result.stdout).toContain('doctor')
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
+    expect(result.stderr).toContain('exec')
+    expect(result.stderr).toContain('doctor')
   })
 
   it('should print help and exit 0 for --help', async () => {


### PR DESCRIPTION
## Summary

Fixes the last CLI exit-code inconsistency from the wave-4 usability study (subject A4). A bare `vaultkeeper` with no subcommand printed help and exited **0**, so `vaultkeeper && next_step` proceeded as if a command had succeeded. It now prints usage to **stderr** and exits **2**, matching the unknown-command case.

An explicit `vaultkeeper --help` / `-h` remains a successful usage request (stdout, exit 0).

The other case in the issue — empty-stdin `store` — already exits 2 (landed via #118), so this PR closes the remaining gap.

## Exit-code convention (now documented in `bin.ts`)

- `0` — success
- `1` — a valid invocation that failed at runtime (e.g. `SecretNotFoundError`)
- `2` — a bad invocation: usage / argument-validation error

## Before / after

```
$ vaultkeeper; echo $?
```
| | exit code | stream |
|---|---|---|
| before | `0` | help on stdout |
| after | `2` | usage on stderr |

Empty-stdin `store` (already correct, pinned by this PR's matrix test):
```
$ printf '' | vaultkeeper store --name FOO; echo $?   # 2, with a Usage: hint
```

## Tests

New/updated exit-code matrix UAT (`packages/cli-tests/test/e2e/exit-code-matrix.test.ts`) drives the real binary as a subprocess across the full matrix:

- unknown subcommand → 2
- unknown flag → 2
- empty-stdin store → 2 (with `Usage:`)
- bare invocation → 2 (usage on stderr)
- missing secret at runtime → 1
- successful command → 0

`help.test.ts` and `bin.test.ts` bare-invocation assertions updated to the new convention.

Verified green: `pnpm --filter @vaultkeeper/cli test`, `pnpm --filter @vaultkeeper/cli-tests test`, `pnpm check`.

Refs #151