### PR TITLE
Complete the plain-Error audit: type remaining sites

### DIFF
--- a/.changeset/plain-error-audit-completion.md
+++ b/.changeset/plain-error-audit-completion.md
@@ -1,0 +1,11 @@
+---
+'vaultkeeper': patch
+'@vaultkeeper/cli': patch
+---
+
+Complete the plain-`Error` audit (issues #115/#126 covered `config.ts` and the file backend): every remaining `throw new Error(...)` in product source now throws a typed error instead.
+
+- `vaultkeeper`: `util/at-rest.ts` and `backend/yubikey-backend.ts`'s encrypted-envelope decoding now throw `DecryptionError` (malformed envelope, unsupported/legacy file version, or a failed AES-GCM auth tag check) instead of a plain `Error`. `util/platform.ts`'s `currentPlatform()`, `backend/one-password-constants.ts`'s `getIntegrationVersion()`, and `yubikey-backend.ts`'s YubiKey HMAC response validation now throw `SetupError`. `util/exec.ts`'s `execCommand`/`execCommandFull` and the YubiKey `ykman` challenge-response call now throw `ExecError`. `OnePasswordBackend`'s constructor validation (mutually exclusive `accessMode`/`serviceAccountToken`/`account` options) now throws `ConfigValidationError`, and its per-access worker crash/spawn-failure paths now throw `BackendUnavailableError`. No new public error classes or fields were added — every site reuses an existing `VaultError` subclass.
+- `@vaultkeeper/cli`: the non-interactive-approval-required error (in both `approval.ts`'s `promptApproval` and `commands/exec.ts`'s trust gate) now throws a new internal `NonInteractiveApprovalError` (not part of the public API, matching the existing internal `ConfigDirFlagError` pattern) instead of a plain `Error`.
+
+A new repo-wide guard test (`no-plain-error.test.ts` in both packages) scans every source file under `src/` and fails if a plain `Error` construction (`throw`/`reject`) reappears.

--- a/docs/api/vaultkeeper.execerror.md
+++ b/docs/api/vaultkeeper.execerror.md
@@ -4,7 +4,9 @@
 
 ## ExecError class
 
-Thrown when a delegated `exec()` call fails due to an invalid request (e.g. a `{{secret}}` placeholder in the `command` field) or a process-level error (e.g. the command binary is not found or cannot be spawned).
+Thrown when spawning or running a subprocess fails.
+
+This covers a delegated `exec()` call failing due to an invalid request (e.g. a `{{secret}}` placeholder in the `command` field) or a process-level error (e.g. the command binary is not found or cannot be spawned) — and also vaultkeeper's own internal tool invocations (doctor version probes, the keychain/secret-tool/dpapi/yubikey credential helpers), which run through the same subprocess utility. Callers that need to handle only delegated-exec failures should scope their `catch` to the code paths that call `exec()`<!-- -->, not discriminate on this type alone.
 
 **Signature:**
 

--- a/docs/api/vaultkeeper.md
+++ b/docs/api/vaultkeeper.md
@@ -140,7 +140,9 @@ Thrown when a hardware device (e.g. YubiKey or smart card) required for authenti
 
 </td><td>
 
-Thrown when a delegated `exec()` call fails due to an invalid request (e.g. a `{{secret}}` placeholder in the `command` field) or a process-level error (e.g. the command binary is not found or cannot be spawned).
+Thrown when spawning or running a subprocess fails.
+
+This covers a delegated `exec()` call failing due to an invalid request (e.g. a `{{secret}}` placeholder in the `command` field) or a process-level error (e.g. the command binary is not found or cannot be spawned) — and also vaultkeeper's own internal tool invocations (doctor version probes, the keychain/secret-tool/dpapi/yubikey credential helpers), which run through the same subprocess utility. Callers that need to handle only delegated-exec failures should scope their `catch` to the code paths that call `exec()`<!-- -->, not discriminate on this type alone.
 
 
 </td></tr>

--- a/packages/cli/src/approval.ts
+++ b/packages/cli/src/approval.ts
@@ -2,17 +2,29 @@ import * as readline from 'node:readline'
 import type { ApprovalInfo } from './types.js'
 
 /**
+ * Thrown when interactive approval is required (a caller is not yet trusted)
+ * but stdin is not a TTY, so no approval prompt can be shown. Follows the
+ * same locally-scoped-`Error`-subclass pattern as `ConfigDirFlagError`
+ * (`config-dir.ts`): this is a CLI presentation-layer concern (there is no
+ * concept of an interactive terminal in the `vaultkeeper` library), so it
+ * does not extend the library's `VaultError` hierarchy.
+ *
+ * @internal
+ */
+export class NonInteractiveApprovalError extends Error {}
+
+/**
  * Display an interactive approval prompt on the TTY.
  *
  * @param info - The access request details to display.
  * @returns `true` if the user approves, `false` otherwise.
- * @throws If stdin is not a TTY.
+ * @throws {NonInteractiveApprovalError} If stdin is not a TTY.
  *
  * @internal
  */
 export async function promptApproval(info: ApprovalInfo): Promise<boolean> {
   if (!process.stdin.isTTY) {
-    throw new Error(
+    throw new NonInteractiveApprovalError(
       'Secret access requires interactive approval. Run this command in a terminal.',
     )
   }

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -35,7 +35,7 @@ import {
   SecretNotFoundError,
   defaultBackendType,
 } from 'vaultkeeper'
-import { promptApproval } from '../approval.js'
+import { promptApproval, NonInteractiveApprovalError } from '../approval.js'
 import { readCachedToken, writeCachedToken, invalidateCache } from '../cache.js'
 import { RedactingStream } from '../redact.js'
 import { shouldSkipDoctor } from '../skip-doctor.js'
@@ -83,8 +83,9 @@ type TrustGateOutcome = 'trusted' | 'approved' | 'denied'
  *   or `denied` (user declined).
  * @throws {IdentityMismatchError} When the caller's hash changed from a
  *   previously approved value.
- * @throws When approval is required but cannot be obtained (non-TTY stdin
- *   without `--yes`), or when the caller path cannot be read for hashing.
+ * @throws {NonInteractiveApprovalError} When approval is required but cannot
+ *   be obtained (non-TTY stdin without `--yes`).
+ * @throws When the caller path cannot be read for hashing.
  */
 async function enforceTrustGate(
   vault: VaultKeeper,
@@ -126,7 +127,7 @@ async function enforceTrustGate(
   // caller path is shell-quoted so the suggested command is copy-paste safe.
   // isTTY is `true` only on a real terminal; `undefined`/`false` means non-TTY.
   if (!process.stdin.isTTY) {
-    throw new Error(
+    throw new NonInteractiveApprovalError(
       `Secret access for ${callerPath} requires approval, but stdin is not a TTY, ` +
         `so no interactive prompt can be shown.\n` +
         `To approve non-interactively, either:\n` +

--- a/packages/cli/test/unit/approval.test.ts
+++ b/packages/cli/test/unit/approval.test.ts
@@ -19,4 +19,18 @@ describe('promptApproval', () => {
     }
     await expect(promptApproval(info)).rejects.toThrow('interactive approval')
   })
+
+  // Regression: issue #127 — this previously threw a plain `Error`, breaking
+  // instanceof-based handling. It must now throw a typed
+  // NonInteractiveApprovalError.
+  it('should throw a typed NonInteractiveApprovalError when stdin is not a TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, writable: true })
+    const { promptApproval, NonInteractiveApprovalError } = await import('../../src/approval.js')
+    const info: ApprovalInfo = {
+      caller: './test.sh',
+      trustInfo: 'Unknown',
+      secret: 'my-key',
+    }
+    await expect(promptApproval(info)).rejects.toBeInstanceOf(NonInteractiveApprovalError)
+  })
 })

--- a/packages/cli/test/unit/commands/exec.test.ts
+++ b/packages/cli/test/unit/commands/exec.test.ts
@@ -7,6 +7,23 @@ const configDir = '/tmp/vaultkeeper-test-config-dir'
 
 const mockInit = vi.hoisted(() => vi.fn())
 
+// Records every error formatError() is asked to render, so tests can assert
+// on the thrown error's *type* (e.g. instanceof NonInteractiveApprovalError)
+// even though execCommand's top-level catch only ever surfaces a stringified
+// message and an exit code — issue #127.
+const capturedFormatErrorCalls = vi.hoisted((): unknown[] => [])
+
+vi.mock('../../../src/output.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/output.js')>()
+  return {
+    ...actual,
+    formatError: (err: unknown, dir: string) => {
+      capturedFormatErrorCalls.push(err)
+      return actual.formatError(err, dir)
+    },
+  }
+})
+
 // A real IdentityMismatchError subclass so `.name`/`.message` format exactly as
 // the CLI expects when it constructs and formats the mismatch error. Defined
 // via vi.hoisted so it is initialized before the hoisted vi.mock factory runs.
@@ -43,10 +60,17 @@ vi.mock('vaultkeeper', async (importOriginal) => {
   }
 })
 
-// Prevent any real approval prompts from blocking tests
-vi.mock('../../../src/approval.js', () => ({
-  promptApproval: vi.fn().mockResolvedValue(false),
-}))
+// Prevent any real approval prompts from blocking tests. Keeps the real
+// NonInteractiveApprovalError export (needed by commands/exec.ts's own
+// `throw new NonInteractiveApprovalError(...)` for the non-TTY trust-gate
+// path — issue #127) alongside the mocked entry point this suite controls.
+vi.mock('../../../src/approval.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/approval.js')>()
+  return {
+    ...actual,
+    promptApproval: vi.fn().mockResolvedValue(false),
+  }
+})
 
 vi.mock('../../../src/cache.js', () => ({
   readCachedToken: vi.fn().mockResolvedValue(undefined),
@@ -114,6 +138,7 @@ describe('execCommand', () => {
     stderrOutput = ''
     stdoutOutput = ''
     IdentityMismatchError.instances.length = 0
+    capturedFormatErrorCalls.length = 0
     vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
       stderrOutput += String(chunk)
       return true
@@ -684,6 +709,28 @@ describe('execCommand', () => {
         expect(stderrOutput).toContain("vaultkeeper approve --script '/path/to/script.sh'")
         expect(stderrOutput).toContain('--yes')
         expect(stderrOutput).toContain('VAULTKEEPER_YES=1')
+      } finally {
+        restoreTTY()
+      }
+    })
+
+    // Regression: issue #127 — this previously threw a plain `Error`,
+    // breaking instanceof-based handling. It must now throw a typed
+    // NonInteractiveApprovalError (the exit code and stderr message are
+    // unchanged, since NonInteractiveApprovalError doesn't override `.name`
+    // any differently than the native Error it replaces).
+    it('rejects with a typed NonInteractiveApprovalError for an untrusted caller on non-TTY stdin', async () => {
+      const restoreTTY = forceStdinTTY(false)
+      try {
+        const vault = pendingVaultMock()
+        mockInit.mockResolvedValue(vault)
+
+        const code = await execCommand(EXEC_ARGS, configDir)
+
+        expect(code).toBe(1)
+        const { NonInteractiveApprovalError } = await import('../../../src/approval.js')
+        expect(capturedFormatErrorCalls).toHaveLength(1)
+        expect(capturedFormatErrorCalls[0]).toBeInstanceOf(NonInteractiveApprovalError)
       } finally {
         restoreTTY()
       }

--- a/packages/cli/test/unit/no-plain-error.test.ts
+++ b/packages/cli/test/unit/no-plain-error.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Repo-wide guard: CLAUDE.md states "Never throw plain `Error` objects —
+ * always use a typed subclass from the error hierarchy." Issue #127 audited
+ * `@vaultkeeper/cli` (alongside the `vaultkeeper` library — see its own
+ * `no-plain-error.test.ts`) and found several plain `throw new Error(...)`
+ * sites; this guard fails CI if a plain `Error` construction reappears
+ * anywhere under `src/`.
+ *
+ * A "typed subclass" here does not require extending the library's
+ * `VaultError` hierarchy — CLI-only concerns (e.g. `ConfigDirFlagError`,
+ * `NonInteractiveApprovalError`) are legitimately local `Error` subclasses,
+ * since the `vaultkeeper` library has no concept of a CLI flag or an
+ * interactive terminal. The guard only rejects constructing the bare
+ * `Error` class itself.
+ *
+ * Matches three ways a plain `Error` can escape:
+ *   - `throw new Error(...)` / `throw Error(...)` (no `new`) /
+ *     `throw new globalThis.Error(...)`
+ *   - `reject(new Error(...))` inside a `new Promise((resolve, reject) => ...)`
+ *     executor — functionally the same escape as a `throw`, since the
+ *     rejection is what a consumer observes
+ *   - `Promise.reject(new Error(...))`
+ *
+ * This is a source-text scan, not a type-level check, so it is inherently a
+ * best-effort net (e.g. it would not catch a plain Error constructed once
+ * and referenced by variable before being thrown/rejected several lines
+ * later) — but it catches every pattern actually used in this codebase.
+ */
+const PLAIN_ERROR_PATTERN =
+  /(?:throw\s+|reject\(\s*|Promise\.reject\(\s*)(?:new\s+)?(?:globalThis\.)?Error\s*\(/
+
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src')
+
+/** Recursively collect every `.ts` file under `dir`. */
+function collectSourceFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath))
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+describe('plain-Error audit (issue #127)', () => {
+  const sourceFiles = collectSourceFiles(SRC_DIR)
+
+  it('finds source files to scan', () => {
+    expect(sourceFiles.length).toBeGreaterThan(0)
+  })
+
+  it.each(sourceFiles.map((f) => [path.relative(SRC_DIR, f), f] as const))(
+    'contains no plain-Error throw/reject in %s',
+    (_relPath, filePath) => {
+      const source = fs.readFileSync(filePath, 'utf8')
+      expect(source).not.toMatch(PLAIN_ERROR_PATTERN)
+    },
+  )
+
+  describe('PLAIN_ERROR_PATTERN (negative control)', () => {
+    it('matches a bare throw', () => {
+      expect('throw new Error("x")').toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('matches reject(new Error(...))', () => {
+      expect('reject(new Error("x"))').toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('does not match a typed local Error subclass being thrown', () => {
+      expect('throw new NonInteractiveApprovalError("x")').not.toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('does not match a class declaration extending Error', () => {
+      expect('export class ConfigDirFlagError extends Error {}').not.toMatch(PLAIN_ERROR_PATTERN)
+    })
+  })
+})

--- a/packages/vaultkeeper/src/backend/dpapi-backend.ts
+++ b/packages/vaultkeeper/src/backend/dpapi-backend.ts
@@ -10,7 +10,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as os from 'node:os'
 import { execCommand, execCommandFull } from '../util/exec.js'
-import { SecretNotFoundError } from '../errors.js'
+import { SecretNotFoundError, toFilesystemError } from '../errors.js'
 import type { ListableBackend } from './types.js'
 
 /**
@@ -124,7 +124,9 @@ export class DpapiBackend implements ListableBackend {
       if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
         throw new SecretNotFoundError(`Secret not found in Windows DPAPI store: ${id}`)
       }
-      throw err
+      // Same contract as FileBackend.delete (#126): a non-ENOENT unlink
+      // failure surfaces as a typed FilesystemError, never a raw Node error.
+      throw toFilesystemError(err, 'secret file', entryPath, 'delete')
     }
   }
 

--- a/packages/vaultkeeper/src/backend/file-backend.ts
+++ b/packages/vaultkeeper/src/backend/file-backend.ts
@@ -173,7 +173,7 @@ export class FileBackend implements ListableBackend {
 
     const key = await getOrCreateKey(storageDir)
     try {
-      return decryptGcm(key, encoded)
+      return decryptGcm(key, encoded, entryPath)
     } catch (err) {
       throw new DecryptionError(
         `Failed to decrypt secret: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/vaultkeeper/src/backend/one-password-backend.ts
+++ b/packages/vaultkeeper/src/backend/one-password-backend.ts
@@ -21,6 +21,7 @@ import {
   BackendLockedError,
   BackendUnavailableError,
   AuthorizationDeniedError,
+  ConfigValidationError,
 } from '../errors.js'
 import type { ListableBackend } from './types.js'
 
@@ -117,13 +118,15 @@ export class OnePasswordBackend implements ListableBackend {
 
   constructor(options: OnePasswordBackendOptions) {
     if (options.accessMode === 'per-access' && options.serviceAccountToken !== undefined) {
-      throw new Error(
+      throw new ConfigValidationError(
         'per-access mode requires desktop biometric authentication and cannot be used with a service account token',
+        'options.accessMode',
       )
     }
     if (options.account !== undefined && options.serviceAccountToken !== undefined) {
-      throw new Error(
+      throw new ConfigValidationError(
         'account and serviceAccountToken are mutually exclusive — provide one or the other, not both',
+        'options.serviceAccountToken',
       )
     }
     this.vaultId = options.vault
@@ -366,7 +369,13 @@ export class OnePasswordBackend implements ListableBackend {
         if (raw === '') {
           const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
           const detail = stderr !== '' ? stderr : `exit code ${String(code)}`
-          reject(new Error(`1Password per-access worker crashed for secret ${id}: ${detail}`))
+          reject(
+            new BackendUnavailableError(
+              `1Password per-access worker crashed for secret ${id}: ${detail}`,
+              'worker-crashed',
+              ['1password'],
+            ),
+          )
           return
         }
 
@@ -422,7 +431,11 @@ export class OnePasswordBackend implements ListableBackend {
 
       child.on('error', (err) => {
         reject(
-          new Error(`Failed to spawn 1Password per-access worker at ${workerPath}: ${String(err)}`),
+          new BackendUnavailableError(
+            `Failed to spawn 1Password per-access worker at ${workerPath}: ${String(err)}`,
+            'worker-spawn-failed',
+            ['1password'],
+          ),
         )
       })
     })

--- a/packages/vaultkeeper/src/backend/one-password-constants.ts
+++ b/packages/vaultkeeper/src/backend/one-password-constants.ts
@@ -10,6 +10,7 @@
 import { readFileSync, existsSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { SetupError } from '../errors.js'
 
 /** Name reported to the 1Password SDK for integration tracking. */
 export const INTEGRATION_NAME = 'vaultkeeper'
@@ -87,7 +88,8 @@ export function getIntegrationVersion(): string {
       return cachedVersion
     }
   }
-  throw new Error(
+  throw new SetupError(
     `Could not read version from vaultkeeper package.json. Tried paths: ${candidates.join(', ')}`,
+    'vaultkeeper package.json',
   )
 }

--- a/packages/vaultkeeper/src/backend/yubikey-backend.ts
+++ b/packages/vaultkeeper/src/backend/yubikey-backend.ts
@@ -18,7 +18,14 @@ import * as path from 'node:path'
 import * as os from 'node:os'
 import * as crypto from 'node:crypto'
 import { execCommandFull } from '../util/exec.js'
-import { SecretNotFoundError, PluginNotFoundError, DeviceNotPresentError } from '../errors.js'
+import {
+  SecretNotFoundError,
+  PluginNotFoundError,
+  DeviceNotPresentError,
+  DecryptionError,
+  SetupError,
+  ExecError,
+} from '../errors.js'
 import type { ListableBackend } from './types.js'
 
 const YKMAN_INSTALL_URL = 'https://developers.yubico.com/yubikey-manager/'
@@ -109,8 +116,9 @@ const HMAC_RESPONSE_RE = /^[0-9a-fA-F]{40}$/
 function deriveKey(hmacResponse: string, id: string): Buffer {
   const trimmed = hmacResponse.trim()
   if (!HMAC_RESPONSE_RE.test(trimmed)) {
-    throw new Error(
+    throw new SetupError(
       `Invalid YubiKey HMAC response: expected exactly ${String(HMAC_RESPONSE_HEX_LENGTH)} hex characters (20 bytes), got ${String(trimmed.length)} characters`,
+      'ykman',
     )
   }
   // The ykman response is a hex string; convert to raw bytes as the IKM.
@@ -167,8 +175,11 @@ function encryptGcm(key: Buffer, plaintext: string): string {
  *
  * The key buffer is always zeroed in a finally block, guaranteeing cleanup even
  * if `createDecipheriv` or `setAuthTag` throws before the decrypt attempt.
+ *
+ * @param path - The path of the encrypted entry, for attribution on a thrown
+ * {@link DecryptionError}.
  */
-function decryptGcm(key: Buffer, encoded: string): string {
+function decryptGcm(key: Buffer, encoded: string, path: string): string {
   const parts = encoded.split(':')
   const versionSegment = parts[0] ?? ''
 
@@ -179,33 +190,36 @@ function decryptGcm(key: Buffer, encoded: string): string {
   if (!isNumericVersion) {
     // No recognisable version prefix — treat as legacy CBC or corrupt file.
     key.fill(0)
-    throw new Error(
+    throw new DecryptionError(
       'Encrypted file uses a legacy format (AES-256-CBC). ' +
         'Delete the secret and re-store it to migrate to AES-256-GCM.',
+      path,
     )
   }
 
   if (versionSegment !== FORMAT_VERSION) {
     // A future format version this binary does not know how to decode.
     key.fill(0)
-    throw new Error(
+    throw new DecryptionError(
       `Unsupported encrypted file version: ${versionSegment}. ` +
         `This vaultkeeper build only supports version ${FORMAT_VERSION}. ` +
         'Upgrade vaultkeeper to read this secret.',
+      path,
     )
   }
 
   if (parts.length !== 4) {
     key.fill(0)
-    throw new Error(
+    throw new DecryptionError(
       `Invalid encrypted file format: expected ${FORMAT_VERSION}:iv:authTag:ciphertext`,
+      path,
     )
   }
 
   const [_version, ivB64, authTagB64, ciphertextB64] = parts
   if (ivB64 === undefined || authTagB64 === undefined || ciphertextB64 === undefined) {
     key.fill(0)
-    throw new Error('Invalid encrypted file format: missing part')
+    throw new DecryptionError('Invalid encrypted file format: missing part', path)
   }
 
   let decrypted: Buffer | undefined
@@ -222,8 +236,9 @@ function decryptGcm(key: Buffer, encoded: string): string {
     try {
       decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
     } catch (err) {
-      throw new Error(
+      throw new DecryptionError(
         `GCM authentication failed — ciphertext may be tampered: ${err instanceof Error ? err.message : String(err)}`,
+        path,
       )
     }
 
@@ -298,7 +313,7 @@ export class YubikeyBackend implements ListableBackend {
     const challenge = Buffer.from(`vaultkeeper:${id}`, 'utf8').toString('hex')
     const responseResult = await execCommandFull('ykman', ['otp', 'calculate', '2', challenge])
     if (responseResult.exitCode !== 0) {
-      throw new Error(`YubiKey challenge-response failed: ${responseResult.stderr}`)
+      throw new ExecError(`YubiKey challenge-response failed: ${responseResult.stderr}`, 'ykman')
     }
     return responseResult.stdout.trim()
   }
@@ -337,7 +352,7 @@ export class YubikeyBackend implements ListableBackend {
     const hmacResponse = await this.challengeResponse(id)
     const key = deriveKey(hmacResponse, id)
 
-    return decryptGcm(key, encoded)
+    return decryptGcm(key, encoded, entryPath)
   }
 
   async delete(id: string): Promise<void> {

--- a/packages/vaultkeeper/src/backend/yubikey-backend.ts
+++ b/packages/vaultkeeper/src/backend/yubikey-backend.ts
@@ -228,16 +228,19 @@ function decryptGcm(key: Buffer, encoded: string, path: string): string {
     const authTag = Buffer.from(authTagB64, 'base64')
     const ciphertext = Buffer.from(ciphertextB64, 'base64')
 
-    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv, {
-      authTagLength: GCM_TAG_LENGTH_BITS / 8,
-    })
-    decipher.setAuthTag(authTag)
-
+    // createDecipheriv/setAuthTag sit inside this try too: the iv and
+    // authTag lengths come from the on-disk file, so a truncated/corrupt
+    // entry can throw a native RangeError/TypeError before decryption even
+    // starts — every native crypto failure must wrap as DecryptionError.
     try {
+      const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv, {
+        authTagLength: GCM_TAG_LENGTH_BITS / 8,
+      })
+      decipher.setAuthTag(authTag)
       decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
     } catch (err) {
       throw new DecryptionError(
-        `GCM authentication failed — ciphertext may be tampered: ${err instanceof Error ? err.message : String(err)}`,
+        `GCM authentication failed — ciphertext may be tampered or corrupt: ${err instanceof Error ? err.message : String(err)}`,
         path,
       )
     }

--- a/packages/vaultkeeper/src/errors.ts
+++ b/packages/vaultkeeper/src/errors.ts
@@ -250,10 +250,16 @@ export class ExecutableTrustRequiredError extends VaultError {
 // --- Access Pattern Failures ---
 
 /**
- * Thrown when a delegated `exec()` call fails due to an invalid request
+ * Thrown when spawning or running a subprocess fails.
+ *
+ * This covers a delegated `exec()` call failing due to an invalid request
  * (e.g. a `{{secret}}` placeholder in the `command` field) or a
- * process-level error (e.g. the command binary is not found or cannot
- * be spawned).
+ * process-level error (e.g. the command binary is not found or cannot be
+ * spawned) — and also vaultkeeper's own internal tool invocations (doctor
+ * version probes, the keychain/secret-tool/dpapi/yubikey credential helpers),
+ * which run through the same subprocess utility. Callers that need to handle
+ * only delegated-exec failures should scope their `catch` to the code paths
+ * that call `exec()`, not discriminate on this type alone.
  *
  * @public
  */

--- a/packages/vaultkeeper/src/keys/storage.ts
+++ b/packages/vaultkeeper/src/keys/storage.ts
@@ -110,7 +110,7 @@ export async function loadKeyState(configDir: string): Promise<KeyStateSnapshot 
   const wrapKey = await getOrCreateWrapKey(path.join(configDir, KEY_WRAP_FILE))
   let json: string
   try {
-    json = decryptGcm(wrapKey, envelope)
+    json = decryptGcm(wrapKey, envelope, statePath)
   } catch {
     // Envelope failed authentication (tampered, or wrap key lost/rotated).
     // Treat as absent so a fresh key state is generated rather than crashing.

--- a/packages/vaultkeeper/src/util/at-rest.ts
+++ b/packages/vaultkeeper/src/util/at-rest.ts
@@ -17,7 +17,7 @@
 
 import * as fs from 'node:fs/promises'
 import * as crypto from 'node:crypto'
-import { toFilesystemError } from '../errors.js'
+import { toFilesystemError, DecryptionError } from '../errors.js'
 
 const GCM_IV_BYTES = 12
 const GCM_KEY_BYTES = 32
@@ -46,18 +46,21 @@ export function encryptGcm(key: Buffer, plaintext: string): string {
  *
  * @param key - The same 32-byte AES-256 wrapping key used to encrypt.
  * @param encoded - The colon-separated envelope.
+ * @param path - The path of the encrypted entry being decrypted, for
+ * attribution on a thrown {@link DecryptionError}. Callers that don't yet
+ * have a path (e.g. an in-memory envelope) may omit it.
  * @returns The decrypted UTF-8 plaintext.
- * @throws {Error} If the envelope is malformed or authentication fails.
+ * @throws {DecryptionError} If the envelope is malformed or authentication fails.
  * @internal
  */
-export function decryptGcm(key: Buffer, encoded: string): string {
+export function decryptGcm(key: Buffer, encoded: string, path = ''): string {
   const parts = encoded.split(':')
   if (parts.length !== 3) {
-    throw new Error('Invalid encrypted envelope: expected iv:authTag:ciphertext')
+    throw new DecryptionError('Invalid encrypted envelope: expected iv:authTag:ciphertext', path)
   }
   const [ivB64, authTagB64, ciphertextB64] = parts
   if (ivB64 === undefined || authTagB64 === undefined || ciphertextB64 === undefined) {
-    throw new Error('Invalid encrypted envelope: missing part')
+    throw new DecryptionError('Invalid encrypted envelope: missing part', path)
   }
   const iv = Buffer.from(ivB64, 'base64')
   const authTag = Buffer.from(authTagB64, 'base64')

--- a/packages/vaultkeeper/src/util/at-rest.ts
+++ b/packages/vaultkeeper/src/util/at-rest.ts
@@ -70,8 +70,18 @@ export function decryptGcm(key: Buffer, encoded: string, path = ''): string {
     authTagLength: GCM_TAG_LENGTH_BITS / 8,
   })
   decipher.setAuthTag(authTag)
-  const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
-  return decrypted.toString('utf8')
+  try {
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+    return decrypted.toString('utf8')
+  } catch (err) {
+    // decipher.final() throws a native crypto Error when the GCM auth tag
+    // fails to verify (tampered/corrupt ciphertext or wrong key) — wrap it so
+    // the documented @throws {DecryptionError} contract holds on every path.
+    throw new DecryptionError(
+      `Failed to decrypt envelope: ${err instanceof Error ? err.message : String(err)}`,
+      path,
+    )
+  }
 }
 
 /**

--- a/packages/vaultkeeper/src/util/at-rest.ts
+++ b/packages/vaultkeeper/src/util/at-rest.ts
@@ -66,17 +66,20 @@ export function decryptGcm(key: Buffer, encoded: string, path = ''): string {
   const authTag = Buffer.from(authTagB64, 'base64')
   const ciphertext = Buffer.from(ciphertextB64, 'base64')
 
-  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv, {
-    authTagLength: GCM_TAG_LENGTH_BITS / 8,
-  })
-  decipher.setAuthTag(authTag)
   try {
+    // Inside the try from createDecipheriv onward: the iv and authTag lengths
+    // come from the on-disk envelope, so a truncated/corrupt entry can make
+    // createDecipheriv or setAuthTag throw a native RangeError/TypeError —
+    // not just decipher.final()'s auth-tag failure.
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv, {
+      authTagLength: GCM_TAG_LENGTH_BITS / 8,
+    })
+    decipher.setAuthTag(authTag)
     const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
     return decrypted.toString('utf8')
   } catch (err) {
-    // decipher.final() throws a native crypto Error when the GCM auth tag
-    // fails to verify (tampered/corrupt ciphertext or wrong key) — wrap it so
-    // the documented @throws {DecryptionError} contract holds on every path.
+    // Wrap every native crypto failure so the documented
+    // @throws {DecryptionError} contract holds on every path.
     throw new DecryptionError(
       `Failed to decrypt envelope: ${err instanceof Error ? err.message : String(err)}`,
       path,

--- a/packages/vaultkeeper/src/util/exec.ts
+++ b/packages/vaultkeeper/src/util/exec.ts
@@ -22,7 +22,10 @@ export interface ExecCommandResult {
 
 /**
  * Execute a command and return stdout.
- * @throws {ExecError} if the command exits with a non-zero code.
+ * @throws {ExecError} if the command exits with a non-zero code, or if the
+ *   process cannot be spawned for any reason other than the binary being
+ *   missing (e.g. `EACCES`).
+ * @throws {PluginNotFoundError} if the command binary is not found (`ENOENT`).
  */
 export async function execCommand(
   command: string,

--- a/packages/vaultkeeper/src/util/exec.ts
+++ b/packages/vaultkeeper/src/util/exec.ts
@@ -104,7 +104,10 @@ export function execCommandFull(
           ),
         )
       } else {
-        reject(error)
+        // Any other spawn failure (EACCES on the binary, EMFILE, ...) must
+        // surface typed, not as the raw Node error — the last plain-error
+        // escape on this utility's failure paths.
+        reject(new ExecError(`Failed to spawn '${command}': ${error.message}`, command))
       }
     })
   })

--- a/packages/vaultkeeper/src/util/exec.ts
+++ b/packages/vaultkeeper/src/util/exec.ts
@@ -3,7 +3,7 @@
  */
 
 import { spawn } from 'node:child_process'
-import { PluginNotFoundError } from '../errors.js'
+import { PluginNotFoundError, ExecError } from '../errors.js'
 
 /** Options for command execution. */
 export interface ExecCommandOptions {
@@ -22,7 +22,7 @@ export interface ExecCommandResult {
 
 /**
  * Execute a command and return stdout.
- * @throws Error if the command exits with a non-zero code.
+ * @throws {ExecError} if the command exits with a non-zero code.
  */
 export async function execCommand(
   command: string,
@@ -31,7 +31,10 @@ export async function execCommand(
 ): Promise<string> {
   const result = await execCommandFull(command, args, options)
   if (result.exitCode !== 0) {
-    throw new Error(`Command failed with exit code ${String(result.exitCode)}: ${result.stderr}`)
+    throw new ExecError(
+      `Command failed with exit code ${String(result.exitCode)}: ${result.stderr}`,
+      command,
+    )
   }
   return result.stdout.trim()
 }
@@ -67,7 +70,7 @@ export function execCommandFull(
     if (options?.timeoutMs !== undefined) {
       setTimeout(() => {
         proc.kill('SIGTERM')
-        reject(new Error(`Command timed out after ${String(options.timeoutMs)}ms`))
+        reject(new ExecError(`Command timed out after ${String(options.timeoutMs)}ms`, command))
       }, options.timeoutMs)
     }
 

--- a/packages/vaultkeeper/src/util/exec.ts
+++ b/packages/vaultkeeper/src/util/exec.ts
@@ -75,6 +75,10 @@ export function execCommandFull(
 
     if (options?.timeoutMs !== undefined) {
       timeoutHandle = setTimeout(() => {
+        // The timer has already fired, so there is nothing left to clear —
+        // reset to undefined so the later 'close'/'error' handler's guard
+        // matches reality instead of calling clearTimeout on a stale handle.
+        timeoutHandle = undefined
         proc.kill('SIGTERM')
         reject(new ExecError(`Command timed out after ${String(options.timeoutMs)}ms`, command))
       }, options.timeoutMs)

--- a/packages/vaultkeeper/src/util/exec.ts
+++ b/packages/vaultkeeper/src/util/exec.ts
@@ -53,6 +53,12 @@ export function execCommandFull(
     })
     let stdout = ''
     let stderr = ''
+    // Undefined when no timeoutMs was given, or once the timer has fired.
+    // Tracked so 'close'/'error' can clear it — otherwise an already-settled
+    // promise still leaves the timer pending, which keeps the event loop
+    // alive until it fires and calls proc.kill() on an already-exited
+    // process (regression: PR #164 review, issue #127).
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
 
     proc.stdout?.on('data', (data: Buffer) => {
       stdout += data.toString()
@@ -68,17 +74,23 @@ export function execCommandFull(
     }
 
     if (options?.timeoutMs !== undefined) {
-      setTimeout(() => {
+      timeoutHandle = setTimeout(() => {
         proc.kill('SIGTERM')
         reject(new ExecError(`Command timed out after ${String(options.timeoutMs)}ms`, command))
       }, options.timeoutMs)
     }
 
     proc.on('close', (code) => {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle)
+      }
       resolve({ stdout, stderr, exitCode: code ?? 1 })
     })
 
     proc.on('error', (error) => {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle)
+      }
       if ('code' in error && error.code === 'ENOENT') {
         reject(
           new PluginNotFoundError(

--- a/packages/vaultkeeper/src/util/platform.ts
+++ b/packages/vaultkeeper/src/util/platform.ts
@@ -2,19 +2,25 @@
  * Platform detection utilities.
  */
 
+import { SetupError } from '../errors.js'
+
 /**
  * The OS platform identifier used for platform-specific behavior.
  * @public
  */
 export type Platform = 'darwin' | 'win32' | 'linux'
 
-/** Get the current platform. */
+/**
+ * Get the current platform.
+ * @throws {SetupError} If `process.platform` is not one of the three
+ * supported platforms.
+ */
 export function currentPlatform(): Platform {
   const p = process.platform
   if (p === 'darwin' || p === 'win32' || p === 'linux') {
     return p
   }
-  throw new Error(`Unsupported platform: ${p}`)
+  throw new SetupError(`Unsupported platform: ${p}`, 'platform')
 }
 
 /** Check if running on macOS. */

--- a/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
@@ -17,7 +17,7 @@ vi.mock('node:fs/promises', () => ({
 import * as fs from 'node:fs/promises'
 import { execCommand, execCommandFull } from '../../../src/util/exec.js'
 import { DpapiBackend } from '../../../src/backend/dpapi-backend.js'
-import { SecretNotFoundError } from '../../../src/errors.js'
+import { SecretNotFoundError, FilesystemError } from '../../../src/errors.js'
 
 const mockExecCommand = vi.mocked(execCommand)
 const mockExecCommandFull = vi.mocked(execCommandFull)
@@ -150,6 +150,25 @@ describe('DpapiBackend', () => {
       mockFs.unlink.mockRejectedValue(fsError)
 
       await expect(backend.delete('missing')).rejects.toBeInstanceOf(SecretNotFoundError)
+    })
+
+    // Regression for the #127/#164 review: a non-ENOENT unlink failure
+    // previously rethrew the raw Node error, escaping the VaultError
+    // hierarchy — the same contract gap #126 fixed in FileBackend.delete.
+    it('wraps a non-ENOENT unlink failure (e.g. EACCES) as a typed FilesystemError', async () => {
+      const fsError = Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+      mockFs.unlink.mockRejectedValueOnce(fsError)
+
+      const caught = await backend.delete('protected').then(
+        () => undefined,
+        (err: unknown) => err,
+      )
+      expect(caught).toBeInstanceOf(FilesystemError)
+      if (caught instanceof FilesystemError) {
+        expect(caught.permission).toBe('delete')
+        expect(caught.code).toBe('EACCES')
+        expect(caught.cause).toBe(fsError)
+      }
     })
 
     it('should rethrow non-ENOENT errors', async () => {

--- a/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
@@ -171,11 +171,18 @@ describe('DpapiBackend', () => {
       }
     })
 
-    it('should rethrow non-ENOENT errors', async () => {
+    it('wraps an EPERM unlink failure as a typed FilesystemError (never a raw rethrow)', async () => {
       const permError = Object.assign(new Error('EPERM'), { code: 'EPERM' })
-      mockFs.unlink.mockRejectedValue(permError)
+      mockFs.unlink.mockRejectedValueOnce(permError)
 
-      await expect(backend.delete('protected')).rejects.toThrow('EPERM')
+      const caught = await backend.delete('protected').then(
+        () => undefined,
+        (err: unknown) => err,
+      )
+      expect(caught).toBeInstanceOf(FilesystemError)
+      if (caught instanceof FilesystemError) {
+        expect(caught.code).toBe('EPERM')
+      }
     })
   })
 

--- a/packages/vaultkeeper/test/unit/backend/one-password-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/one-password-backend.test.ts
@@ -97,6 +97,7 @@ import {
   BackendUnavailableError,
   AuthorizationDeniedError,
   PluginNotFoundError,
+  ConfigValidationError,
 } from '../../../src/errors.js'
 
 // ---- Test helpers ----
@@ -316,6 +317,25 @@ describe('OnePasswordBackend', () => {
       ).toThrow('per-access mode requires desktop biometric authentication')
     })
 
+    // Regression: issue #127 — this previously threw a plain `Error`,
+    // breaking instanceof-based handling. It must now throw a typed
+    // ConfigValidationError naming the offending options field.
+    it('should throw a typed ConfigValidationError when per-access mode is combined with serviceAccountToken', () => {
+      try {
+        new OnePasswordBackend({
+          vault: VAULT_ID,
+          serviceAccountToken: 'token',
+          accessMode: 'per-access',
+        })
+        expect.unreachable('constructor should have thrown')
+      } catch (err) {
+        if (!(err instanceof ConfigValidationError)) {
+          throw err
+        }
+        expect(err.field).toBe('options.accessMode')
+      }
+    })
+
     it('should throw when both account and serviceAccountToken are provided', () => {
       expect(
         () =>
@@ -325,6 +345,25 @@ describe('OnePasswordBackend', () => {
             serviceAccountToken: 'token',
           }),
       ).toThrow('account and serviceAccountToken are mutually exclusive')
+    })
+
+    // Regression: issue #127 — this previously threw a plain `Error`,
+    // breaking instanceof-based handling. It must now throw a typed
+    // ConfigValidationError naming the offending options field.
+    it('should throw a typed ConfigValidationError when both account and serviceAccountToken are provided', () => {
+      try {
+        new OnePasswordBackend({
+          vault: VAULT_ID,
+          account: 'my-account',
+          serviceAccountToken: 'token',
+        })
+        expect.unreachable('constructor should have thrown')
+      } catch (err) {
+        if (!(err instanceof ConfigValidationError)) {
+          throw err
+        }
+        expect(err.field).toBe('options.serviceAccountToken')
+      }
     })
   })
 
@@ -667,14 +706,25 @@ describe('OnePasswordBackend', () => {
       await expect(backend.retrieve('my-secret')).rejects.toBeInstanceOf(SecretNotFoundError)
     })
 
-    it('should throw Error with worker path when spawn itself errors', async () => {
+    // Regression: issue #127 — this previously rejected with a plain `Error`,
+    // breaking instanceof-based handling. It must now reject with a typed
+    // BackendUnavailableError.
+    it('should throw a typed BackendUnavailableError with worker path when spawn itself errors', async () => {
       const backend = makePerAccessBackend()
       const proc = makeWorkerErrorProcess(new Error('spawn ENOENT'))
       mockSpawn.mockReturnValue(proc)
 
-      await expect(backend.retrieve('my-secret')).rejects.toThrow(
-        'Failed to spawn 1Password per-access worker',
-      )
+      try {
+        await backend.retrieve('my-secret')
+        expect.unreachable('retrieve should have rejected')
+      } catch (err) {
+        if (!(err instanceof BackendUnavailableError)) {
+          throw err
+        }
+        expect(err.message).toContain('Failed to spawn 1Password per-access worker')
+        expect(err.reason).toBe('worker-spawn-failed')
+        expect(err.attempted).toEqual(['1password'])
+      }
     })
 
     it('should throw SecretNotFoundError when worker returns unparseable output', async () => {
@@ -713,6 +763,26 @@ describe('OnePasswordBackend', () => {
       mockSpawn.mockReturnValue(proc)
 
       await expect(backend.retrieve('my-secret')).rejects.toThrow('exit code 137')
+    })
+
+    // Regression: issue #127 — a worker crash with no stdout previously
+    // rejected with a plain `Error`, breaking instanceof-based handling. It
+    // must now reject with a typed BackendUnavailableError.
+    it('should throw a typed BackendUnavailableError when worker crashes with no stdout', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerProcess({ stdout: '', stderr: '', exitCode: 137 })
+      mockSpawn.mockReturnValue(proc)
+
+      try {
+        await backend.retrieve('my-secret')
+        expect.unreachable('retrieve should have rejected')
+      } catch (err) {
+        if (!(err instanceof BackendUnavailableError)) {
+          throw err
+        }
+        expect(err.reason).toBe('worker-crashed')
+        expect(err.attempted).toEqual(['1password'])
+      }
     })
 
     // Regression for https://github.com/mike-north/vaultkeeper/issues/113: when

--- a/packages/vaultkeeper/test/unit/backend/one-password-constants.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/one-password-constants.test.ts
@@ -4,7 +4,7 @@
  * @see https://developer.1password.com/docs/sdks/
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -29,6 +29,47 @@ describe('one-password-constants', () => {
     expect(getIntegrationVersion()).toBe(
       pkg instanceof Object && 'version' in pkg ? pkg.version : undefined,
     )
+  })
+
+  // Regression: issue #127 — when none of the candidate package.json paths
+  // exist (a broken/incomplete install), getIntegrationVersion() previously
+  // threw a plain `Error`, breaking instanceof-based handling. It must now
+  // throw a typed SetupError naming the missing dependency. Uses a fresh
+  // module instance (via vi.resetModules + mocked node:fs) so the module's
+  // memoized cachedVersion from the test above doesn't short-circuit this.
+  // The SetupError class itself is also re-imported fresh from the same
+  // reset module registry — `instanceof` against the statically-imported
+  // top-of-file class would otherwise compare against a different class
+  // object than the one the freshly-loaded module actually threw.
+  describe('when no candidate package.json exists', () => {
+    beforeEach(() => {
+      vi.resetModules()
+    })
+
+    it('throws a typed SetupError', async () => {
+      vi.doMock('node:fs', () => ({
+        readFileSync: vi.fn(),
+        existsSync: vi.fn().mockReturnValue(false),
+      }))
+
+      const { getIntegrationVersion: getVersionWithMockedFs } =
+        await import('../../../src/backend/one-password-constants.js')
+      const { SetupError: FreshSetupError } = await import('../../../src/errors.js')
+
+      try {
+        getVersionWithMockedFs()
+        expect.unreachable('getIntegrationVersion should have thrown')
+      } catch (err) {
+        if (!(err instanceof FreshSetupError)) {
+          throw err
+        }
+        expect(err.dependency).toBe('vaultkeeper package.json')
+        expect(err.message).toContain('package.json')
+      } finally {
+        vi.doUnmock('node:fs')
+        vi.resetModules()
+      }
+    })
   })
 
   describe('isModuleNotFoundError', () => {

--- a/packages/vaultkeeper/test/unit/backend/yubikey-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/yubikey-backend.test.ts
@@ -31,6 +31,9 @@ import {
   SecretNotFoundError,
   PluginNotFoundError,
   DeviceNotPresentError,
+  DecryptionError,
+  SetupError,
+  ExecError,
 } from '../../../src/errors.js'
 
 const mockExecCommandFull = vi.mocked(execCommandFull)
@@ -276,6 +279,36 @@ describe('YubikeyBackend', () => {
       await expect(backend.retrieve(id)).rejects.toThrow(/GCM authentication failed/)
     })
 
+    // Regression: issue #127 — a tampered ciphertext previously rejected with
+    // a plain `Error`, breaking instanceof-based handling. It must now
+    // reject with a typed DecryptionError naming the entry's path.
+    it('rejects a tampered ciphertext with a typed DecryptionError', async () => {
+      const id = 'tampered-secret-2'
+      const blob = makeEncryptedBlob('original', id)
+      const lastColon = blob.lastIndexOf(':')
+      const ciphertextB64 = blob.slice(lastColon + 1)
+      const ciphertextBytes = Buffer.from(ciphertextB64, 'base64')
+      ciphertextBytes[0] = (ciphertextBytes[0] ?? 0) ^ 0xff
+      const corruptedBlob = blob.slice(0, lastColon + 1) + ciphertextBytes.toString('base64')
+
+      mockDeviceAvailable()
+      mockChallengeResponse(FAKE_HMAC_RESPONSE)
+      mockFs.access.mockResolvedValue(undefined)
+      mockFs.readFile.mockResolvedValue(corruptedBlob)
+
+      try {
+        await backend.retrieve(id)
+        expect.unreachable('retrieve should have rejected')
+      } catch (err) {
+        if (!(err instanceof DecryptionError)) {
+          throw err
+        }
+        // Entry paths are hex-encoded from the secret id (see getEntryPath),
+        // so assert on the shape rather than the literal id substring.
+        expect(err.path).toMatch(/[0-9a-f]+\.enc$/)
+      }
+    })
+
     it('should give a clear error for a legacy AES-256-CBC encrypted file', async () => {
       // A legacy file does not start with a numeric version prefix — simulate
       // binary openssl enc output (e.g. "Salted__...") or any non-versioned content.
@@ -287,6 +320,20 @@ describe('YubikeyBackend', () => {
       mockFs.readFile.mockResolvedValue(legacyContent)
 
       await expect(backend.retrieve('legacy-secret')).rejects.toThrow(/legacy format.*AES-256-CBC/)
+    })
+
+    // Regression: issue #127 — this previously rejected with a plain
+    // `Error`, breaking instanceof-based handling. It must now reject with a
+    // typed DecryptionError.
+    it('rejects a legacy AES-256-CBC file with a typed DecryptionError', async () => {
+      const legacyContent = 'Salted__somebinarycbcdata'
+
+      mockDeviceAvailable()
+      mockChallengeResponse(FAKE_HMAC_RESPONSE)
+      mockFs.access.mockResolvedValue(undefined)
+      mockFs.readFile.mockResolvedValue(legacyContent)
+
+      await expect(backend.retrieve('legacy-secret')).rejects.toBeInstanceOf(DecryptionError)
     })
 
     it('should give a clear "unsupported version" error for a future format version', async () => {
@@ -304,6 +351,20 @@ describe('YubikeyBackend', () => {
       await expect(backend.retrieve('future-secret')).rejects.toThrow(/[Uu]nsupported.*version.*42/)
     })
 
+    // Regression: issue #127 — this previously rejected with a plain
+    // `Error`, breaking instanceof-based handling. It must now reject with a
+    // typed DecryptionError.
+    it('rejects an unsupported future format version with a typed DecryptionError', async () => {
+      const futureVersionBlob = '42:aXY=:dGFn:Y2lwaGVydGV4dA=='
+
+      mockDeviceAvailable()
+      mockChallengeResponse(FAKE_HMAC_RESPONSE)
+      mockFs.access.mockResolvedValue(undefined)
+      mockFs.readFile.mockResolvedValue(futureVersionBlob)
+
+      await expect(backend.retrieve('future-secret')).rejects.toBeInstanceOf(DecryptionError)
+    })
+
     it('should give a clear error for an invalid HMAC response (not 40 hex chars)', async () => {
       // Regression: a truncated or malformed ykman response should produce a
       // descriptive error from deriveKey rather than silently generating a bad key.
@@ -317,6 +378,52 @@ describe('YubikeyBackend', () => {
       mockFs.readFile.mockResolvedValue(blob)
 
       await expect(backend.retrieve(id)).rejects.toThrow(/Invalid YubiKey HMAC response/)
+    })
+
+    // Regression: issue #127 — an invalid HMAC response previously rejected
+    // with a plain `Error`, breaking instanceof-based handling. It must now
+    // reject with a typed SetupError naming the ykman dependency.
+    it('rejects an invalid HMAC response with a typed SetupError', async () => {
+      const id = 'my-secret-2'
+      const blob = makeEncryptedBlob('value', id)
+
+      mockDeviceAvailable()
+      mockChallengeResponse('deadbeef')
+      mockFs.access.mockResolvedValue(undefined)
+      mockFs.readFile.mockResolvedValue(blob)
+
+      try {
+        await backend.retrieve(id)
+        expect.unreachable('retrieve should have rejected')
+      } catch (err) {
+        if (!(err instanceof SetupError)) {
+          throw err
+        }
+        expect(err.dependency).toBe('ykman')
+      }
+    })
+
+    // Regression: issue #127 — a failed ykman challenge-response command
+    // (non-zero exit) previously rejected with a plain `Error`, breaking
+    // instanceof-based handling. It must now reject with a typed ExecError.
+    it('rejects with a typed ExecError when the ykman challenge-response command fails', async () => {
+      const id = 'my-secret-3'
+
+      mockDeviceAvailable()
+      mockExecCommandFull.mockResolvedValueOnce(makeResult(1, '', 'device removed mid-operation'))
+      mockFs.access.mockResolvedValue(undefined)
+      mockFs.readFile.mockResolvedValue(makeEncryptedBlob('value', id))
+
+      try {
+        await backend.retrieve(id)
+        expect.unreachable('retrieve should have rejected')
+      } catch (err) {
+        if (!(err instanceof ExecError)) {
+          throw err
+        }
+        expect(err.command).toBe('ykman')
+        expect(err.message).toContain('device removed mid-operation')
+      }
     })
   })
 

--- a/packages/vaultkeeper/test/unit/config.test.ts
+++ b/packages/vaultkeeper/test/unit/config.test.ts
@@ -1,6 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import {
   validateConfig,
   loadConfig,
@@ -454,25 +452,11 @@ describe('loadConfig', () => {
 // Plain-Error audit (issue #115)
 // ---------------------------------------------------------------------------
 
-// Regression: issue #115 audit — config.ts (all config loading and
-// validation lives in this single file; there is no separate loader module)
-// must throw only typed VaultError subclasses (ConfigValidationError,
-// ConfigParseError, FilesystemError), never a plain `Error`. This greps the
-// source directly so a future edit that reintroduces `throw new Error(...)`
-// fails CI instead of silently regressing the "never throw plain Error"
-// convention (see CLAUDE.md).
-describe('plain-Error audit', () => {
-  it('should contain no plain-Error throw (new/no-new/globalThis) in config.ts', () => {
-    const configSourcePath = fileURLToPath(new URL('../../src/config.ts', import.meta.url))
-    const source = readFileSync(configSourcePath, 'utf8')
-    // Whitespace-tolerant and constructor-form-tolerant: a plain Error can be
-    // thrown as `throw new Error(...)`, `throw Error(...)` (no `new`), or
-    // `throw new globalThis.Error(...)`. Extra spaces or a line break between
-    // tokens would also slip past a naive literal match. Catch all of them so
-    // the "never throw plain Error" guard can't be bypassed.
-    expect(source).not.toMatch(/throw\s+(?:new\s+)?(?:globalThis\.)?Error\s*\(/)
-  })
-})
+// Regression: issue #115 first added this guard scoped to config.ts alone.
+// Issue #127 broadened the "never throw plain Error" audit to every source
+// file in this package (and @vaultkeeper/cli) — see
+// `no-plain-error.test.ts`, which supersedes the narrower per-file check
+// that used to live here.
 
 // ---------------------------------------------------------------------------
 // defaultBackendType

--- a/packages/vaultkeeper/test/unit/no-plain-error.test.ts
+++ b/packages/vaultkeeper/test/unit/no-plain-error.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * Repo-wide guard: CLAUDE.md states "Never throw plain `Error` objects —
+ * always use a typed subclass from the error hierarchy." Issue #115 first
+ * enforced this for `config.ts` alone; issue #127 audited the rest of the
+ * package and broadened the guard to every source file, so a future edit
+ * anywhere under `src/` that reintroduces a plain `Error` construction fails
+ * CI instead of silently regressing the convention.
+ *
+ * Matches three ways a plain `Error` can escape:
+ *   - `throw new Error(...)` / `throw Error(...)` (no `new`) /
+ *     `throw new globalThis.Error(...)`
+ *   - `reject(new Error(...))` inside a `new Promise((resolve, reject) => ...)`
+ *     executor — functionally the same escape as a `throw`, since the
+ *     rejection is what a consumer observes
+ *   - `Promise.reject(new Error(...))`
+ *
+ * This is a source-text scan, not a type-level check, so it is inherently a
+ * best-effort net (e.g. it would not catch a plain Error constructed once
+ * and referenced by variable before being thrown/rejected several lines
+ * later) — but it catches every pattern actually used in this codebase.
+ */
+const PLAIN_ERROR_PATTERN =
+  /(?:throw\s+|reject\(\s*|Promise\.reject\(\s*)(?:new\s+)?(?:globalThis\.)?Error\s*\(/
+
+const SRC_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../src')
+
+/** Recursively collect every `.ts` file under `dir`. */
+function collectSourceFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath))
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+describe('plain-Error audit (issue #127)', () => {
+  const sourceFiles = collectSourceFiles(SRC_DIR)
+
+  it('finds source files to scan', () => {
+    expect(sourceFiles.length).toBeGreaterThan(0)
+  })
+
+  it.each(sourceFiles.map((f) => [path.relative(SRC_DIR, f), f] as const))(
+    'contains no plain-Error throw/reject in %s',
+    (_relPath, filePath) => {
+      const source = fs.readFileSync(filePath, 'utf8')
+      expect(source).not.toMatch(PLAIN_ERROR_PATTERN)
+    },
+  )
+
+  describe('PLAIN_ERROR_PATTERN (negative control)', () => {
+    it('matches a bare throw', () => {
+      expect('throw new Error("x")').toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('matches throw without new', () => {
+      expect('throw Error("x")').toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('matches throw new globalThis.Error', () => {
+      expect('throw new globalThis.Error("x")').toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('matches reject(new Error(...))', () => {
+      expect('reject(new Error("x"))').toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('matches Promise.reject(new Error(...))', () => {
+      expect('Promise.reject(new Error("x"))').toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('does not match a typed VaultError subclass being thrown', () => {
+      expect('throw new SecretNotFoundError("x")').not.toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('does not match a typed VaultError subclass being rejected', () => {
+      expect('reject(new BackendUnavailableError("x", "y", []))').not.toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('does not match a class declaration extending Error', () => {
+      expect('export class ConfigDirFlagError extends Error {}').not.toMatch(PLAIN_ERROR_PATTERN)
+    })
+
+    it('does not match a comment mentioning `new Error(`', () => {
+      expect('// Matches the native `new Error(message, { cause })` form').not.toMatch(
+        PLAIN_ERROR_PATTERN,
+      )
+    })
+  })
+})

--- a/packages/vaultkeeper/test/unit/util/at-rest.test.ts
+++ b/packages/vaultkeeper/test/unit/util/at-rest.test.ts
@@ -49,6 +49,19 @@ describe('encryptGcm / decryptGcm', () => {
     bytes[0] = (bytes[0] ?? 0) ^ 0xff
     const tampered = [parts[0], parts[1], bytes.toString('base64')].join(':')
 
-    expect(() => decryptGcm(KEY, tampered, '/entries/a.enc')).toThrow()
+    // Regression (review thread 3591176966): decipher.final()'s native crypto
+    // Error on GCM auth-tag failure must be wrapped — the documented
+    // @throws {DecryptionError} contract has to hold on the auth-failure
+    // path, not just the malformed-envelope paths.
+    let caught: unknown
+    try {
+      decryptGcm(KEY, tampered, '/entries/a.enc')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(DecryptionError)
+    if (caught instanceof DecryptionError) {
+      expect(caught.path).toBe('/entries/a.enc')
+    }
   })
 })

--- a/packages/vaultkeeper/test/unit/util/at-rest.test.ts
+++ b/packages/vaultkeeper/test/unit/util/at-rest.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import * as crypto from 'node:crypto'
+import { encryptGcm, decryptGcm } from '../../../src/util/at-rest.js'
+import { DecryptionError } from '../../../src/errors.js'
+
+const KEY = crypto.randomBytes(32)
+
+describe('encryptGcm / decryptGcm', () => {
+  it('round-trips plaintext through encrypt then decrypt', () => {
+    const encrypted = encryptGcm(KEY, 'hunter2')
+    expect(decryptGcm(KEY, encrypted, '/entries/a.enc')).toBe('hunter2')
+  })
+
+  // Regression: issue #127 — a malformed envelope (wrong number of
+  // colon-separated parts) previously threw a plain `Error`, breaking
+  // instanceof-based handling. It must now throw a typed DecryptionError
+  // naming the entry's path.
+  it('throws a typed DecryptionError naming the path for a malformed envelope', () => {
+    try {
+      decryptGcm(KEY, 'only:two', '/entries/corrupt.enc')
+      expect.unreachable('decryptGcm should have thrown for a malformed envelope')
+    } catch (err) {
+      if (!(err instanceof DecryptionError)) {
+        throw err
+      }
+      expect(err.path).toBe('/entries/corrupt.enc')
+      expect(err.message).toContain('iv:authTag:ciphertext')
+    }
+  })
+
+  it('defaults path to an empty string when the caller has none to give', () => {
+    try {
+      decryptGcm(KEY, 'only:two')
+      expect.unreachable('decryptGcm should have thrown for a malformed envelope')
+    } catch (err) {
+      if (!(err instanceof DecryptionError)) {
+        throw err
+      }
+      expect(err.path).toBe('')
+    }
+  })
+
+  it('throws a typed DecryptionError for a tampered auth tag', () => {
+    const encrypted = encryptGcm(KEY, 'hunter2')
+    const parts = encrypted.split(':')
+    const ciphertext = parts[2] ?? ''
+    // Flip a byte in the ciphertext so GCM authentication fails.
+    const bytes = Buffer.from(ciphertext, 'base64')
+    bytes[0] = (bytes[0] ?? 0) ^ 0xff
+    const tampered = [parts[0], parts[1], bytes.toString('base64')].join(':')
+
+    expect(() => decryptGcm(KEY, tampered, '/entries/a.enc')).toThrow()
+  })
+})

--- a/packages/vaultkeeper/test/unit/util/exec.test.ts
+++ b/packages/vaultkeeper/test/unit/util/exec.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { execCommand, execCommandFull } from '../../../src/util/exec.js'
 import { PluginNotFoundError, ExecError } from '../../../src/errors.js'
 
@@ -81,5 +81,49 @@ describe('execCommandFull', () => {
     await expect(
       execCommandFull('this-binary-absolutely-does-not-exist-anywhere', ['--version']),
     ).rejects.toThrow(PluginNotFoundError)
+  })
+
+  // Regression: PR #164 review (issue #127) — the timeout timer was never
+  // cleared when the process closed before it fired. Left pending, it kept
+  // the event loop alive until it eventually fired and called proc.kill() on
+  // an already-exited process. A distinctive timeoutMs value (98765, far
+  // from any other timeoutMs used in this file) identifies our setTimeout
+  // call unambiguously among any others the test runner itself may issue.
+  it('clears the timeout timer once the process closes, before it fires', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+    const result = await execCommandFull('echo', ['hello'], { timeoutMs: 98_765 })
+    expect(result.exitCode).toBe(0)
+
+    const ourSetTimeoutCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 98_765)
+    expect(ourSetTimeoutCalls).toHaveLength(1)
+    // Pre-fix, clearTimeout was never called at all on the 'close' path — a
+    // fixed count (rather than inspecting the specific handle, which would
+    // require an unsafe `any`-typed read of the timer-returning spy's mock
+    // results) is enough to prove the timer we scheduled was torn down.
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+
+    setTimeoutSpy.mockRestore()
+    clearTimeoutSpy.mockRestore()
+  })
+
+  // Same regression, via the error path (spawn ENOENT) rather than 'close'.
+  it('clears the timeout timer when spawn errors, before it fires', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+    await expect(
+      execCommandFull('this-binary-absolutely-does-not-exist-anywhere', ['--version'], {
+        timeoutMs: 98_766,
+      }),
+    ).rejects.toThrow(PluginNotFoundError)
+
+    const ourSetTimeoutCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 98_766)
+    expect(ourSetTimeoutCalls).toHaveLength(1)
+    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+
+    setTimeoutSpy.mockRestore()
+    clearTimeoutSpy.mockRestore()
   })
 })

--- a/packages/vaultkeeper/test/unit/util/exec.test.ts
+++ b/packages/vaultkeeper/test/unit/util/exec.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as os from 'node:os'
+import * as path from 'node:path'
 import { execCommand, execCommandFull } from '../../../src/util/exec.js'
 import { PluginNotFoundError, ExecError } from '../../../src/errors.js'
 
@@ -82,6 +85,32 @@ describe('execCommandFull', () => {
       execCommandFull('this-binary-absolutely-does-not-exist-anywhere', ['--version']),
     ).rejects.toThrow(PluginNotFoundError)
   })
+
+  // Regression (review thread 3591242590): non-ENOENT spawn failures (EACCES
+  // on the target, EMFILE, ...) previously rejected with the raw Node error —
+  // the last plain-error escape on this utility's failure paths. Spawning a
+  // non-executable file yields EACCES deterministically on POSIX.
+  it.skipIf(process.platform === 'win32')(
+    'wraps a non-ENOENT spawn failure (EACCES) in a typed ExecError',
+    async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vk-exec-eacces-'))
+      const target = path.join(dir, 'not-executable.sh')
+      try {
+        await fs.writeFile(target, '#!/bin/sh\necho hi\n', { mode: 0o644 })
+
+        const caught = await execCommandFull(target, []).then(
+          () => undefined,
+          (err: unknown) => err,
+        )
+        expect(caught).toBeInstanceOf(ExecError)
+        if (caught instanceof ExecError) {
+          expect(caught.command).toBe(target)
+        }
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true })
+      }
+    },
+  )
 
   // Regression: PR #164 review (issue #127) — the timeout timer was never
   // cleared when the process closed before it fired. Left pending, it kept

--- a/packages/vaultkeeper/test/unit/util/exec.test.ts
+++ b/packages/vaultkeeper/test/unit/util/exec.test.ts
@@ -109,14 +109,18 @@ describe('execCommandFull', () => {
       })
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
 
-    const result = await execCommandFull('echo', ['hello'], { timeoutMs: 98_765 })
-    expect(result.exitCode).toBe(0)
+    // try/finally so a failing assertion (or a rejecting execCommandFull)
+    // can't leak the global setTimeout/clearTimeout spies into later tests.
+    try {
+      const result = await execCommandFull('echo', ['hello'], { timeoutMs: 98_765 })
+      expect(result.exitCode).toBe(0)
 
-    expect(ourTimeoutHandle).toBeDefined()
-    expect(clearTimeoutSpy).toHaveBeenCalledWith(ourTimeoutHandle)
-
-    setTimeoutSpy.mockRestore()
-    clearTimeoutSpy.mockRestore()
+      expect(ourTimeoutHandle).toBeDefined()
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(ourTimeoutHandle)
+    } finally {
+      setTimeoutSpy.mockRestore()
+      clearTimeoutSpy.mockRestore()
+    }
   })
 
   // Same regression, via the error path (spawn ENOENT) rather than 'close'.
@@ -134,16 +138,19 @@ describe('execCommandFull', () => {
       })
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
 
-    await expect(
-      execCommandFull('this-binary-absolutely-does-not-exist-anywhere', ['--version'], {
-        timeoutMs: 98_766,
-      }),
-    ).rejects.toThrow(PluginNotFoundError)
+    // try/finally: same spy-leak guard as the close-path test above.
+    try {
+      await expect(
+        execCommandFull('this-binary-absolutely-does-not-exist-anywhere', ['--version'], {
+          timeoutMs: 98_766,
+        }),
+      ).rejects.toThrow(PluginNotFoundError)
 
-    expect(ourTimeoutHandle).toBeDefined()
-    expect(clearTimeoutSpy).toHaveBeenCalledWith(ourTimeoutHandle)
-
-    setTimeoutSpy.mockRestore()
-    clearTimeoutSpy.mockRestore()
+      expect(ourTimeoutHandle).toBeDefined()
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(ourTimeoutHandle)
+    } finally {
+      setTimeoutSpy.mockRestore()
+      clearTimeoutSpy.mockRestore()
+    }
   })
 })

--- a/packages/vaultkeeper/test/unit/util/exec.test.ts
+++ b/packages/vaultkeeper/test/unit/util/exec.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { execCommand, execCommandFull } from '../../../src/util/exec.js'
-import { PluginNotFoundError } from '../../../src/errors.js'
+import { PluginNotFoundError, ExecError } from '../../../src/errors.js'
 
 describe('execCommand', () => {
   it('returns trimmed stdout on success', async () => {
@@ -10,15 +10,26 @@ describe('execCommand', () => {
   })
 
   it('throws on non-zero exit code with stderr in message', async () => {
-    await expect(
-      execCommand('sh', ['-c', 'echo bad >&2; exit 1']),
-    ).rejects.toThrow(/bad/)
+    await expect(execCommand('sh', ['-c', 'echo bad >&2; exit 1'])).rejects.toThrow(/bad/)
   })
 
   it('throws and includes the exit code in the message', async () => {
-    await expect(
-      execCommand('sh', ['-c', 'exit 2']),
-    ).rejects.toThrow(/2/)
+    await expect(execCommand('sh', ['-c', 'exit 2'])).rejects.toThrow(/2/)
+  })
+
+  // Regression: issue #127 — a non-zero exit code previously rejected with a
+  // plain `Error`, breaking instanceof-based handling. It must now reject
+  // with a typed ExecError naming the failed command.
+  it('rejects with a typed ExecError naming the command', async () => {
+    try {
+      await execCommand('sh', ['-c', 'exit 2'])
+      expect.unreachable('execCommand should have rejected for a non-zero exit code')
+    } catch (err) {
+      if (!(err instanceof ExecError)) {
+        throw err
+      }
+      expect(err.command).toBe('sh')
+    }
   })
 })
 
@@ -42,9 +53,22 @@ describe('execCommandFull', () => {
   })
 
   it('kills the process and rejects after timeout', async () => {
-    await expect(
-      execCommandFull('sleep', ['10'], { timeoutMs: 50 }),
-    ).rejects.toThrow(/timed out/)
+    await expect(execCommandFull('sleep', ['10'], { timeoutMs: 50 })).rejects.toThrow(/timed out/)
+  }, 5000)
+
+  // Regression: issue #127 — a timeout previously rejected with a plain
+  // `Error`, breaking instanceof-based handling. It must now reject with a
+  // typed ExecError naming the command.
+  it('rejects with a typed ExecError naming the command on timeout', async () => {
+    try {
+      await execCommandFull('sleep', ['10'], { timeoutMs: 50 })
+      expect.unreachable('execCommandFull should have rejected after the timeout')
+    } catch (err) {
+      if (!(err instanceof ExecError)) {
+        throw err
+      }
+      expect(err.command).toBe('sleep')
+    }
   }, 5000)
 
   it('pipes stdin to the process', async () => {

--- a/packages/vaultkeeper/test/unit/util/exec.test.ts
+++ b/packages/vaultkeeper/test/unit/util/exec.test.ts
@@ -86,23 +86,34 @@ describe('execCommandFull', () => {
   // Regression: PR #164 review (issue #127) — the timeout timer was never
   // cleared when the process closed before it fired. Left pending, it kept
   // the event loop alive until it eventually fired and called proc.kill() on
-  // an already-exited process. A distinctive timeoutMs value (98765, far
-  // from any other timeoutMs used in this file) identifies our setTimeout
-  // call unambiguously among any others the test runner itself may issue.
+  // an already-exited process.
+  //
+  // Wraps the real setTimeout (rather than asserting a call count on the
+  // clearTimeout spy) so the assertion pins the *specific* handle our
+  // setTimeout call returned — immune to unrelated clearTimeout calls
+  // elsewhere in the process, unlike a global call-count assertion (review
+  // feedback on the first version of this test). A distinctive timeoutMs
+  // value (98765, far from any other timeoutMs used in this file) identifies
+  // our setTimeout call among any others that may fire during the test.
   it('clears the timeout timer once the process closes, before it fires', async () => {
-    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const realSetTimeout = globalThis.setTimeout
+    let ourTimeoutHandle: NodeJS.Timeout | undefined
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((callback: () => void, ms?: number) => {
+        const handle = realSetTimeout(callback, ms)
+        if (ms === 98_765) {
+          ourTimeoutHandle = handle
+        }
+        return handle
+      })
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
 
     const result = await execCommandFull('echo', ['hello'], { timeoutMs: 98_765 })
     expect(result.exitCode).toBe(0)
 
-    const ourSetTimeoutCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 98_765)
-    expect(ourSetTimeoutCalls).toHaveLength(1)
-    // Pre-fix, clearTimeout was never called at all on the 'close' path — a
-    // fixed count (rather than inspecting the specific handle, which would
-    // require an unsafe `any`-typed read of the timer-returning spy's mock
-    // results) is enough to prove the timer we scheduled was torn down.
-    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+    expect(ourTimeoutHandle).toBeDefined()
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(ourTimeoutHandle)
 
     setTimeoutSpy.mockRestore()
     clearTimeoutSpy.mockRestore()
@@ -110,7 +121,17 @@ describe('execCommandFull', () => {
 
   // Same regression, via the error path (spawn ENOENT) rather than 'close'.
   it('clears the timeout timer when spawn errors, before it fires', async () => {
-    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const realSetTimeout = globalThis.setTimeout
+    let ourTimeoutHandle: NodeJS.Timeout | undefined
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, 'setTimeout')
+      .mockImplementation((callback: () => void, ms?: number) => {
+        const handle = realSetTimeout(callback, ms)
+        if (ms === 98_766) {
+          ourTimeoutHandle = handle
+        }
+        return handle
+      })
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
 
     await expect(
@@ -119,9 +140,8 @@ describe('execCommandFull', () => {
       }),
     ).rejects.toThrow(PluginNotFoundError)
 
-    const ourSetTimeoutCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 98_766)
-    expect(ourSetTimeoutCalls).toHaveLength(1)
-    expect(clearTimeoutSpy).toHaveBeenCalledTimes(1)
+    expect(ourTimeoutHandle).toBeDefined()
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(ourTimeoutHandle)
 
     setTimeoutSpy.mockRestore()
     clearTimeoutSpy.mockRestore()

--- a/packages/vaultkeeper/test/unit/util/platform.test.ts
+++ b/packages/vaultkeeper/test/unit/util/platform.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { currentPlatform, isDarwin, isWindows, isLinux } from '../../../src/util/platform.js'
+import { SetupError } from '../../../src/errors.js'
 
 describe('currentPlatform', () => {
   it('returns the current platform without throwing', () => {
@@ -11,6 +12,34 @@ describe('currentPlatform', () => {
   it('returns a value consistent with process.platform', () => {
     const platform = currentPlatform()
     expect(platform).toBe(process.platform)
+  })
+
+  // Regression: issue #127 — an unsupported process.platform previously threw
+  // a plain `Error`, breaking instanceof-based handling. It must now throw a
+  // typed SetupError.
+  describe('on an unsupported platform', () => {
+    const original = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    afterEach(() => {
+      if (original !== undefined) {
+        Object.defineProperty(process, 'platform', original)
+      }
+    })
+
+    it('throws a typed SetupError naming the platform dependency', () => {
+      Object.defineProperty(process, 'platform', { value: 'freebsd', configurable: true })
+
+      try {
+        currentPlatform()
+        expect.unreachable('currentPlatform should have thrown for an unsupported platform')
+      } catch (err) {
+        if (!(err instanceof SetupError)) {
+          throw err
+        }
+        expect(err.dependency).toBe('platform')
+        expect(err.message).toContain('freebsd')
+      }
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

Completes the plain-`Error` audit started in #115/#126 (which covered `config.ts` and `FileBackend`). Every remaining `throw new Error(...)` (and the `reject(new Error(...))` variants found in the same modules) in product source now throws/rejects a typed error.

Every site reuses an existing `VaultError` subclass from `packages/vaultkeeper/src/errors.ts` — no new public error classes or fields were added. The one new class, `NonInteractiveApprovalError` in `@vaultkeeper/cli`, is internal-only (not exported), matching the existing `ConfigDirFlagError` pattern for CLI-only concerns that don't belong in the library's `VaultError` hierarchy.

### Site → typed-error mapping

| Site | Was | Now |
|---|---|---|
| `util/at-rest.ts` `decryptGcm` (malformed envelope, x2) | plain `Error` | `DecryptionError` (now takes a `path` param) |
| `backend/yubikey-backend.ts` `decryptGcm` (legacy format, unsupported version, malformed file, missing part, GCM auth failure — x5) | plain `Error` | `DecryptionError` |
| `util/platform.ts` `currentPlatform()` | plain `Error` | `SetupError('...', 'platform')` |
| `backend/one-password-constants.ts` `getIntegrationVersion()` | plain `Error` | `SetupError('...', 'vaultkeeper package.json')` |
| `backend/yubikey-backend.ts` `deriveKey()` (invalid HMAC response) | plain `Error` | `SetupError('...', 'ykman')` |
| `util/exec.ts` `execCommand`/`execCommandFull` (non-zero exit, timeout) | plain `Error` | `ExecError` |
| `backend/yubikey-backend.ts` `challengeResponse()` (ykman non-zero exit) | plain `Error` | `ExecError` |
| `backend/one-password-backend.ts` constructor (accessMode/serviceAccountToken/account mutual exclusivity, x2) | plain `Error` | `ConfigValidationError` |
| `backend/one-password-backend.ts` per-access worker crash/spawn failure (x2) | plain `Error` (via `reject`) | `BackendUnavailableError` |
| `cli/src/approval.ts` `promptApproval` (non-TTY) | plain `Error` | `NonInteractiveApprovalError` (new, internal-only) |
| `cli/src/commands/exec.ts` trust gate (non-TTY) | plain `Error` | `NonInteractiveApprovalError` (same class) |

## Acceptance criteria → tests

1. **Every remaining plain `throw new Error(` replaced with a typed subclass** — see mapping table above; verified by criterion 2's guard test passing.
2. **Repo-wide guard test extended to `packages/vaultkeeper/src/**` and `packages/cli/src/**`** — `packages/vaultkeeper/test/unit/no-plain-error.test.ts` and `packages/cli/test/unit/no-plain-error.test.ts` (new), which supersede the narrower `config.ts`-only guard from #115 (removed from `config.test.ts`, replaced with a pointer comment). No allowlisted exceptions were needed.
3. **Regression tests for every consumer-observable error-type change**:
   - `test/unit/util/at-rest.test.ts` (new) — `decryptGcm` throws `DecryptionError` for a malformed envelope
   - `test/unit/util/platform.test.ts` — `currentPlatform` throws `SetupError` for an unsupported platform
   - `test/unit/util/exec.test.ts` — `execCommand`/`execCommandFull` reject with `ExecError` (exit code + timeout)
   - `test/unit/backend/one-password-backend.test.ts` — constructor throws `ConfigValidationError` (x2); per-access worker crash/spawn failure rejects with `BackendUnavailableError` (x2)
   - `test/unit/backend/one-password-constants.test.ts` — `getIntegrationVersion` throws `SetupError` when no candidate `package.json` exists
   - `test/unit/backend/yubikey-backend.test.ts` — tampered ciphertext, legacy format, and unsupported version all reject with `DecryptionError`; invalid HMAC response rejects with `SetupError`; ykman command failure rejects with `ExecError`
   - `cli/test/unit/approval.test.ts` — `promptApproval` throws `NonInteractiveApprovalError`
   - `cli/test/unit/commands/exec.test.ts` — the trust gate's non-TTY path throws `NonInteractiveApprovalError` (intercepted via a `formatError` spy, since `execCommand` itself only surfaces an exit code)
4. **API report / changeset** — no public error classes or fields changed, so no `api-report`/`check:api-docs` regen was needed. Added `.changeset/plain-error-audit-completion.md` (`vaultkeeper`: patch, `@vaultkeeper/cli`: patch) since published behavior changed even though types didn't.

## Test plan

- [x] `pnpm build` (needed for the e2e backend-registration test)
- [x] `pnpm check` (typecheck + lint + api-report) — green, only pre-existing/unrelated security-plugin warnings
- [x] `pnpm test` (full workspace, including `cli-tests` e2e subprocess suite) — green
- [x] Prettier — clean

Refs #127