### PR TITLE
Prevent test-helpers 1.0.0 major-bump cascade from peer-dependency range

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/fix-test-helpers-peer-range-cascade.md
+++ b/.changeset/fix-test-helpers-peer-range-cascade.md
@@ -1,0 +1,7 @@
+---
+"@vaultkeeper/test-helpers": patch
+---
+
+Loosen the `vaultkeeper` peerDependency range from `workspace:^` (published as `^0.6.0`) to an explicit `>=0.6.0 <1`. The caret range was minor-locked under 0.x, so a routine `vaultkeeper` minor bump (e.g. 0.6.0 → 0.7.0) would exit the range and trigger a changesets-driven major bump on `@vaultkeeper/test-helpers` — silently graduating it to 1.0.0 with no changeset declaring that intent. The new range tracks the pre-1.0 vaultkeeper line explicitly and only forces a major on `@vaultkeeper/test-helpers` once `vaultkeeper` itself reaches 1.0.0, which is the point such a cascade should actually happen.
+
+This also requires enabling changesets' `onlyUpdatePeerDependentsWhenOutOfRange` option (see `.changeset/config.json`): by default, changesets bumps a package major on *any* non-patch release of a peer dependency, regardless of whether the new version still satisfies the declared peer range. Without that option, the widened range alone would not have stopped the cascade.

--- a/packages/cli-tests/test/packaging/packaging.test.ts
+++ b/packages/cli-tests/test/packaging/packaging.test.ts
@@ -287,7 +287,7 @@ describe('bin ownership', () => {
  * declaration.
  */
 describe('peer dependency stability', () => {
-  it('test-helpers declares an explicit vaultkeeper peer range bounded below 1.0.0', async () => {
+  it('test-helpers declares an explicit vaultkeeper peer range with an upper bound below 1.0.0', async () => {
     const pkg = await readPackageJson('test-helpers')
     const range = pkg.peerDependencies?.vaultkeeper
 

--- a/packages/cli-tests/test/packaging/packaging.test.ts
+++ b/packages/cli-tests/test/packaging/packaging.test.ts
@@ -50,6 +50,7 @@ interface PackageJson {
   types?: string
   bin?: string | Record<string, string>
   exports?: ExportsValue
+  peerDependencies?: Record<string, string>
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -123,6 +124,9 @@ function isPackageJson(value: unknown): value is PackageJson {
     return false
   }
   if (value.exports !== undefined && !isExportsValue(value.exports)) {
+    return false
+  }
+  if (value.peerDependencies !== undefined && !isStringRecord(value.peerDependencies)) {
     return false
   }
   return true
@@ -267,5 +271,28 @@ describe('bin ownership', () => {
   it('declares no bin field on the vaultkeeper library package', async () => {
     const pkg = await readPackageJson('vaultkeeper')
     expect(pkg.bin).toBeUndefined()
+  })
+})
+
+/**
+ * Regression guard for https://github.com/mike-north/vaultkeeper/issues/156:
+ * `test-helpers`' `vaultkeeper` peerDependency previously used `workspace:^`,
+ * which publishes as a caret range (e.g. `^0.6.0`) that a routine 0.x
+ * `vaultkeeper` minor bump exits — and changesets forces a major bump on any
+ * peer-dependent whenever the dependency's release is non-patch, regardless
+ * of whether the published range actually still allows the new version. An
+ * explicit range with an upper bound below `1.0.0` keeps routine 0.x minors
+ * in range (so the cascade only fires deliberately, once `vaultkeeper`
+ * reaches 1.0.0). This assertion fails against the pre-fix `workspace:^`
+ * declaration.
+ */
+describe('peer dependency stability', () => {
+  it('test-helpers declares an explicit vaultkeeper peer range bounded below 1.0.0', async () => {
+    const pkg = await readPackageJson('test-helpers')
+    const range = pkg.peerDependencies?.vaultkeeper
+
+    expect(range).toBeDefined()
+    expect(range).not.toMatch(/^workspace:/)
+    expect(range).toMatch(/<\s*1(\.0\.0)?(\s|$)/)
   })
 })

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -47,7 +47,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "vaultkeeper": "workspace:^"
+    "vaultkeeper": ">=0.6.0 <1"
   },
   "devDependencies": {
     "vaultkeeper": "workspace:*",


### PR DESCRIPTION
## Summary

`packages/test-helpers/package.json` declared `peerDependencies: { "vaultkeeper": "workspace:^" }`, which publishes as the caret range `^0.6.0`. The pending changesets bump `vaultkeeper` 0.6.0 → 0.7.0 (minor), which exits that caret range under 0.x semver rules — and by default, `@changesets/cli` forces a **major** bump on any package with a peer dependency whenever that dependency's release is non-patch, regardless of whether the new version actually still satisfies the declared range (see `shouldBumpMajor` in `@changesets/assemble-release-plan`). The net effect: `@vaultkeeper/test-helpers` would silently graduate 0.2.7 → 1.0.0 with no changeset declaring a major — contradicting the pre-1.0 versioning convention from #131 ("breaking changes ship as minor bumps while pre-1.0").

## Fix (two parts — both required)

1. **Explicit peer range**: `packages/test-helpers/package.json` now declares `"vaultkeeper": ">=0.6.0 <1"` instead of `"workspace:^"`. Verified via `pnpm pack` that this string is published **verbatim** — pnpm only rewrites `workspace:` protocol dependencies, so a plain semver range like this passes through untouched to the published manifest.
2. **Changesets config flag**: `.changeset/config.json` now sets `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true`. This is necessary because **the range change alone does not stop the cascade** — changesets' default behavior ignores the peer range entirely when deciding whether to force a major bump; only with this flag does it check `semver.satisfies(newVersion, declaredRange)` before forcing major. This is a real, schema-validated (if explicitly "experimental/unsafe" named) option in `@changesets/config`.

## Other packages checked (acceptance criterion 2)

Only `@vaultkeeper/test-helpers` declares a `peerDependencies` entry pointing at `vaultkeeper`. `@vaultkeeper/cli-test-helpers` has no `peerDependencies` field at all — no cascade risk there, nothing else to fix.

## Cascade-defused evidence (acceptance criterion 3)

Ran `pnpm exec changeset version` as a dry-run experiment against the pending changesets, then fully reverted (`git checkout --`) so no version artifacts are part of this PR.

**Before the fix** (peer range `>=0.6.0 <1` alone, without the config flag): `@vaultkeeper/test-helpers` still bumped **0.2.7 → 1.0.0**, with the CHANGELOG showing only a `### Minor Changes` section (no major changeset) — reproducing the exact bug from #156.

**With both parts of the fix applied**: `@vaultkeeper/test-helpers` bumped **0.2.7 → 0.3.0** (a real minor bump, matching its own pending changesets — the existing `test-helpers-peer-dep.md` changeset plus the new patch changeset added here), and the peer range stayed `>=0.6.0 <1` (unchanged, since 0.7.0 already satisfies it). This is the correct, deliberate outcome.

## Changeset (acceptance criterion 4)

Added `.changeset/fix-test-helpers-peer-range-cascade.md` — `patch` on `@vaultkeeper/test-helpers` for the peer-range change itself (a published-manifest change). No other package needed a changeset since only `test-helpers` was touched.

## CI-facing guard (acceptance criterion 5)

Added a small structural assertion to `packages/cli-tests/test/packaging/packaging.test.ts` (`describe('peer dependency stability', ...)`) asserting `test-helpers`' `vaultkeeper` peer range is not the `workspace:` protocol and has an explicit upper bound below `1.0.0`. This fails against the pre-fix `workspace:^` declaration and passes with the fix — verified directly.

## Non-goals

Does not touch #81, does not change the pre-1.0 versioning convention, and contains no version bumps of its own (only the peer-range/config/changeset/test changes above).

Refs #156