### PR TITLE
Fix injected-backend activeBackendType throw and SecretAccessor.read return value

### DIFF
--- a/.changeset/injected-backend-and-accessor-read.md
+++ b/.changeset/injected-backend-and-accessor-read.md
@@ -4,5 +4,5 @@
 
 Fix two library rough edges surfaced by the direct-integration path.
 
-- `VaultKeeper.activeBackendType` no longer throws `BackendUnavailableError` when a backend was injected via `init({ backend })`. It now reports the injected backend's declared `type` (or the stable `'custom'` sentinel if it declares an empty type). The config-driven path is unchanged.
+- `VaultKeeper.activeBackendType` no longer throws `BackendUnavailableError` when a backend was injected via `init({ backend })`. It now reports the injected backend's declared `type` (or the stable `'custom'` sentinel if it declares an empty type). `setup()` derives the token's `bkd` claim from the same rule, so an injected backend with an empty type mints a valid token (`bkd: "custom"`) instead of one rejected by claim validation. The config-driven path is unchanged.
 - `SecretAccessor.read()` now passes the callback's return value through: `read<T>(cb: (buf: Buffer) => T): T`, so `const value = accessor.read((buf) => buf.toString('utf8'))` yields the derived value instead of `undefined`. The buffer is still zeroed after the callback returns, so returning the raw buffer only ever yields zeroed bytes — derive a value inside the callback.

--- a/.changeset/injected-backend-and-accessor-read.md
+++ b/.changeset/injected-backend-and-accessor-read.md
@@ -1,0 +1,8 @@
+---
+'vaultkeeper': minor
+---
+
+Fix two library rough edges surfaced by the direct-integration path.
+
+- `VaultKeeper.activeBackendType` no longer throws `BackendUnavailableError` when a backend was injected via `init({ backend })`. It now reports the injected backend's declared `type` (or the stable `'custom'` sentinel if it declares an empty type). The config-driven path is unchanged.
+- `SecretAccessor.read()` now passes the callback's return value through: `read<T>(cb: (buf: Buffer) => T): T`, so `const value = accessor.read((buf) => buf.toString('utf8'))` yields the derived value instead of `undefined`. The buffer is still zeroed after the callback returns, so returning the raw buffer only ever yields zeroed bytes — derive a value inside the callback.

--- a/README.md
+++ b/README.md
@@ -192,12 +192,12 @@ const { result } = await vault.exec(token, {
   env: { MY_API_TOKEN: '{{secret}}' },
 })
 
-// 5c. Controlled direct access — buffer is zeroed after the callback returns
+// 5c. Controlled direct access — buffer is zeroed after the callback returns.
+// read() passes the callback's return value through, so you can derive a value
+// (e.g. a header string or a hash) inside the callback and capture it. Never
+// return the raw `buf` itself — it is zeroed before read() returns.
 const accessor = vault.getSecret(token)
-accessor.read((buf) => {
-  // Use buf here. Do not store a reference beyond this callback.
-  doSomethingWith(buf.toString('utf8'))
-})
+const authHeader = accessor.read((buf) => `Bearer ${buf.toString('utf8')}`)
 ```
 
 ## Storing secrets

--- a/docs/api/vaultkeeper.md
+++ b/docs/api/vaultkeeper.md
@@ -601,7 +601,7 @@ A [PreflightCheck](./vaultkeeper.preflightcheck.md) scoped by whether its depend
 
 Callback-based secret accessor with auto-zeroing.
 
-The accessor is backed by a revocable Proxy. Calling `read()` passes a `Buffer` containing the secret to the callback, then zeroes the buffer after the callback returns. The accessor can only be read once; a second call throws.
+The accessor is backed by a Proxy and is single-use via an internal consumed flag. Calling `read()` passes a `Buffer` containing the secret to the callback, then zeroes the buffer after the callback returns and passes the callback's return value through. The accessor can only be read once; a second call throws.
 
 
 </td></tr>

--- a/docs/api/vaultkeeper.secretaccessor.md
+++ b/docs/api/vaultkeeper.secretaccessor.md
@@ -6,7 +6,7 @@
 
 Callback-based secret accessor with auto-zeroing.
 
-The accessor is backed by a revocable Proxy. Calling `read()` passes a `Buffer` containing the secret to the callback, then zeroes the buffer after the callback returns. The accessor can only be read once; a second call throws.
+The accessor is backed by a Proxy and is single-use via an internal consumed flag. Calling `read()` passes a `Buffer` containing the secret to the callback, then zeroes the buffer after the callback returns and passes the callback's return value through. The accessor can only be read once; a second call throws.
 
 **Signature:**
 

--- a/docs/api/vaultkeeper.secretaccessor.md
+++ b/docs/api/vaultkeeper.secretaccessor.md
@@ -38,6 +38,8 @@ Read the secret value via a callback.
 
 The `buf` argument is a temporary `Buffer` containing the secret encoded as UTF-8. The buffer is zeroed immediately after the callback returns, so callers must not store a reference to it beyond the callback scope.
 
+The callback's return value is passed through, so a caller-derived result (for example `buf.toString()` or a hash) flows out of `read()`<!-- -->: `const digest = accessor.read((buf) => sha256(buf))`<!-- -->. To preserve the zero-copy, auto-zeroing contract, derive a new value inside the callback — never return the raw `buf` itself, which is zeroed before `read()` returns.
+
 
 </td></tr>
 </tbody></table>

--- a/docs/api/vaultkeeper.secretaccessor.read.md
+++ b/docs/api/vaultkeeper.secretaccessor.read.md
@@ -8,10 +8,12 @@ Read the secret value via a callback.
 
 The `buf` argument is a temporary `Buffer` containing the secret encoded as UTF-8. The buffer is zeroed immediately after the callback returns, so callers must not store a reference to it beyond the callback scope.
 
+The callback's return value is passed through, so a caller-derived result (for example `buf.toString()` or a hash) flows out of `read()`<!-- -->: `const digest = accessor.read((buf) => sha256(buf))`<!-- -->. To preserve the zero-copy, auto-zeroing contract, derive a new value inside the callback — never return the raw `buf` itself, which is zeroed before `read()` returns.
+
 **Signature:**
 
 ```typescript
-read(callback: (buf: Buffer) => void): void;
+read<T>(callback: (buf: Buffer) => T): T;
 ```
 
 ## Parameters
@@ -39,12 +41,12 @@ callback
 
 </td><td>
 
-(buf: Buffer) =&gt; void
+(buf: Buffer) =&gt; T
 
 
 </td><td>
 
-Function that receives the secret buffer.
+Function that receives the secret buffer and returns a caller-derived value.
 
 
 </td></tr>
@@ -52,7 +54,9 @@ Function that receives the secret buffer.
 
 **Returns:**
 
-void
+T
+
+Whatever the callback returns.
 
 ## Exceptions
 

--- a/docs/api/vaultkeeper.vaultkeeper.activebackendtype.md
+++ b/docs/api/vaultkeeper.vaultkeeper.activebackendtype.md
@@ -16,5 +16,7 @@ get activeBackendType(): string;
 
 This is a pure, side-effect-free view of the resolved configuration: it reads the type of the first enabled backend without instantiating the backend or requiring it to be registered or healthy. Reading it therefore never throws for an unavailable or unregistered backend — unlike a secret operation — so it is safe to call purely to introspect an instance.
 
+When a backend was injected via `init({ backend })`<!-- -->, config-based resolution is bypassed entirely and this reports the injected instance's declared `type` (see [SecretBackend](./vaultkeeper.secretbackend.md)<!-- -->) — or the stable sentinel `'custom'` if it declares an empty type. It never throws in the injected path.
+
 Use it to confirm which backend an instance resolved to, especially when no config file exists and the safe zero-config default applies (see [defaultBackendType()](./vaultkeeper.defaultbackendtype.md)<!-- -->). With no config this reads `file` on every platform, so secret operations never silently target the real OS credential store; opt into the native store (see [platformNativeBackendType()](./vaultkeeper.platformnativebackendtype.md)<!-- -->) via explicit config to change this.
 

--- a/packages/vaultkeeper/api-report/vaultkeeper.api.md
+++ b/packages/vaultkeeper/api-report/vaultkeeper.api.md
@@ -273,7 +273,7 @@ export interface ScopedPreflightCheck extends PreflightCheck {
 
 // @public
 export interface SecretAccessor {
-    read(callback: (buf: Buffer_2) => void): void;
+    read<T>(callback: (buf: Buffer_2) => T): T;
 }
 
 // @public

--- a/packages/vaultkeeper/src/access/controlled-direct.ts
+++ b/packages/vaultkeeper/src/access/controlled-direct.ts
@@ -5,6 +5,7 @@
  * - Exposes a single `.read()` method
  * - Passes a Buffer containing the secret to the callback
  * - Zeros the buffer after the callback returns
+ * - Passes the callback's return value back through to the caller
  * - Prevents double-read (throws a descriptive Error on second call)
  * - Redacts itself from Node.js inspect output
  */

--- a/packages/vaultkeeper/src/access/controlled-direct.ts
+++ b/packages/vaultkeeper/src/access/controlled-direct.ts
@@ -29,11 +29,11 @@ interface SecretAccessorInternal extends SecretAccessor {
  * - ownKeys trap includes all own keys (matches non-extensible contract)
  */
 class SecretAccessorTarget implements SecretAccessorInternal {
-  readonly read: (callback: (buf: Buffer) => void) => void
+  readonly read: <T>(callback: (buf: Buffer) => T) => T
   readonly [INSPECT_CUSTOM]: () => string
 
   constructor(
-    readImpl: (callback: (buf: Buffer) => void) => void,
+    readImpl: <T>(callback: (buf: Buffer) => T) => T,
     inspectImpl: () => string,
   ) {
     this.read = readImpl
@@ -56,8 +56,11 @@ class SecretAccessorTarget implements SecretAccessorInternal {
 export function createSecretAccessor(secretValue: string): SecretAccessor {
   let consumed = false
 
-  // Close over the actual read logic.
-  function readImpl(callback: (buf: Buffer) => void): void {
+  // Close over the actual read logic. The callback's return value is passed
+  // through so callers can derive a value (string, hash, ...) from the secret;
+  // the buffer is still zeroed in `finally` before the value is returned, so
+  // returning the raw buffer would only ever yield zeroed bytes.
+  function readImpl<T>(callback: (buf: Buffer) => T): T {
     if (consumed) {
       throw new AccessorConsumedError('SecretAccessor has already been consumed — call getSecret() again to obtain a new accessor')
     }
@@ -65,7 +68,7 @@ export function createSecretAccessor(secretValue: string): SecretAccessor {
 
     const buf = Buffer.from(secretValue, 'utf8')
     try {
-      callback(buf)
+      return callback(buf)
     } finally {
       buf.fill(0)
     }

--- a/packages/vaultkeeper/src/types.ts
+++ b/packages/vaultkeeper/src/types.ts
@@ -220,10 +220,18 @@ export interface SecretAccessor {
    * as UTF-8. The buffer is zeroed immediately after the callback returns, so
    * callers must not store a reference to it beyond the callback scope.
    *
-   * @param callback - Function that receives the secret buffer.
+   * The callback's return value is passed through, so a caller-derived result
+   * (for example `buf.toString()` or a hash) flows out of `read()`:
+   * `const digest = accessor.read((buf) => sha256(buf))`. To preserve the
+   * zero-copy, auto-zeroing contract, derive a new value inside the callback —
+   * never return the raw `buf` itself, which is zeroed before `read()` returns.
+   *
+   * @param callback - Function that receives the secret buffer and returns a
+   *   caller-derived value.
+   * @returns Whatever the callback returns.
    * @throws {Error} If the accessor has already been consumed.
    */
-  read(callback: (buf: Buffer) => void): void
+  read<T>(callback: (buf: Buffer) => T): T
 }
 
 /**

--- a/packages/vaultkeeper/src/types.ts
+++ b/packages/vaultkeeper/src/types.ts
@@ -207,10 +207,11 @@ export interface ExecResult {
 /**
  * Callback-based secret accessor with auto-zeroing.
  *
- * The accessor is backed by a revocable Proxy. Calling `read()` passes a
- * `Buffer` containing the secret to the callback, then zeroes the buffer after
- * the callback returns. The accessor can only be read once; a second call
- * throws.
+ * The accessor is backed by a Proxy and is single-use via an internal
+ * consumed flag. Calling `read()` passes a `Buffer` containing the secret to
+ * the callback, then zeroes the buffer after the callback returns and passes
+ * the callback's return value through. The accessor can only be read once; a
+ * second call throws.
  */
 export interface SecretAccessor {
   /**

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -245,6 +245,14 @@ export class VaultKeeper {
    */
   readonly #persistKeys: boolean
   #backend: SecretBackend | undefined
+  /**
+   * Whether {@link #backend} was injected via `init({ backend })` rather than
+   * lazily resolved from `#config.backends`. Distinguishes the two so that
+   * {@link activeBackendType} reports the injected instance directly instead of
+   * consulting the (empty) config backend list. Stays correct after a lazy
+   * resolution populates {@link #backend} in the config-driven path.
+   */
+  readonly #backendInjected: boolean
 
   private constructor(
     config: VaultConfig,
@@ -258,6 +266,7 @@ export class VaultKeeper {
     this.#configDir = configDir
     this.#persistKeys = persistKeys
     this.#backend = backend
+    this.#backendInjected = backend !== undefined
   }
 
   /**
@@ -332,6 +341,12 @@ export class VaultKeeper {
    * never throws for an unavailable or unregistered backend — unlike a secret
    * operation — so it is safe to call purely to introspect an instance.
    *
+   * When a backend was injected via `init({ backend })`, config-based
+   * resolution is bypassed entirely and this reports the injected instance's
+   * declared `type` (see {@link SecretBackend}) — or the stable sentinel
+   * `'custom'` if it declares an empty type. It never throws in the injected
+   * path.
+   *
    * Use it to confirm which backend an instance resolved to, especially when
    * no config file exists and the safe zero-config default applies (see
    * {@link defaultBackendType}). With no config this reads `file` on every
@@ -341,10 +356,17 @@ export class VaultKeeper {
    *
    * @throws A {@link BackendUnavailableError} only when the configuration has
    * no enabled backend at all (a configuration error, not a backend fault).
+   * This can only happen in the config-driven path; an injected backend never
+   * throws here.
    *
    * @public
    */
   get activeBackendType(): string {
+    if (this.#backendInjected && this.#backend !== undefined) {
+      // An injected backend wins over config resolution (see init()); report
+      // its declared type, falling back to a stable sentinel if it declares none.
+      return this.#backend.type === '' ? 'custom' : this.#backend.type
+    }
     const firstEnabled = this.#config.backends.find((b) => b.enabled)
     if (firstEnabled === undefined) {
       throw new BackendUnavailableError(

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -888,16 +888,19 @@ export class VaultKeeper {
   /**
    * Resolve the backend-type hint used both for introspection
    * ({@link activeBackendType}) and for the `bkd` claim minted by
-   * {@link setup}. An explicit `override` always wins; otherwise the backend's
-   * declared `type` is used (trimmed). A backend that declares an empty or
-   * whitespace-only type — permitted for injected backends — falls back to the
-   * stable `'custom'` sentinel. Centralizing this keeps the two paths in sync
-   * so an injected empty-type backend never mints a token with an empty `bkd`
+   * {@link setup}. A non-blank `override` wins (trimmed); an empty or
+   * whitespace-only override is treated the same as no override, since
+   * honoring it would mint a token with a blank `bkd` claim. Otherwise the
+   * backend's declared `type` is used (trimmed), and a backend that declares
+   * an empty or whitespace-only type — permitted for injected backends —
+   * falls back to the stable `'custom'` sentinel. Centralizing this keeps
+   * both paths in sync so no route ever mints a token with an empty `bkd`
    * claim (which {@link validateClaims} rejects, making the token unusable).
    */
   static #resolveBackendTypeHint(backend: SecretBackend, override?: string): string {
-    if (override !== undefined) {
-      return override
+    const trimmedOverride = override?.trim()
+    if (trimmedOverride !== undefined && trimmedOverride !== '') {
+      return trimmedOverride
     }
     const declared = backend.type.trim()
     return declared === '' ? 'custom' : declared

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -365,7 +365,7 @@ export class VaultKeeper {
     if (this.#backendInjected && this.#backend !== undefined) {
       // An injected backend wins over config resolution (see init()); report
       // its declared type, falling back to a stable sentinel if it declares none.
-      return this.#backend.type === '' ? 'custom' : this.#backend.type
+      return VaultKeeper.#resolveBackendTypeHint(this.#backend)
     }
     const firstEnabled = this.#config.backends.find((b) => b.enabled)
     if (firstEnabled === undefined) {
@@ -462,7 +462,7 @@ export class VaultKeeper {
   async setup(secretName: string, options?: SetupOptions): Promise<string> {
     VaultKeeper.#validateSecretName(secretName)
     const backend = this.#requireBackend()
-    const backendType = options?.backendType ?? backend.type
+    const backendType = VaultKeeper.#resolveBackendTypeHint(backend, options?.backendType)
     const ttlMinutes = options?.ttlMinutes ?? this.#config.defaults.ttlMinutes
     const trustTier = options?.trustTier ?? this.#config.defaults.trustTier
     const useLimit = options?.useLimit ?? null
@@ -883,6 +883,24 @@ export class VaultKeeper {
     }
 
     return BackendRegistry.create(firstEnabled.type, firstEnabled, this.#configDir)
+  }
+
+  /**
+   * Resolve the backend-type hint used both for introspection
+   * ({@link activeBackendType}) and for the `bkd` claim minted by
+   * {@link setup}. An explicit `override` always wins; otherwise the backend's
+   * declared `type` is used (trimmed). A backend that declares an empty or
+   * whitespace-only type — permitted for injected backends — falls back to the
+   * stable `'custom'` sentinel. Centralizing this keeps the two paths in sync
+   * so an injected empty-type backend never mints a token with an empty `bkd`
+   * claim (which {@link validateClaims} rejects, making the token unusable).
+   */
+  static #resolveBackendTypeHint(backend: SecretBackend, override?: string): string {
+    if (override !== undefined) {
+      return override
+    }
+    const declared = backend.type.trim()
+    return declared === '' ? 'custom' : declared
   }
 
   #requireBackend(): SecretBackend {

--- a/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
+++ b/packages/vaultkeeper/test/e2e/consumer-typecheck.test.ts
@@ -113,6 +113,19 @@ const consumerSource = [
   `  })`,
   `}`,
   ``,
+  // Issue #168: read() passes the callback's return value through, so the
+  // consumer can capture a caller-derived value. This annotation fails to
+  // compile if read()'s return type regresses to `void` (TS2322).
+  `function useAccessorReturn(accessor: SecretAccessor): string {`,
+  `  return accessor.read((buf) => buf.toString('utf8'))`,
+  `}`,
+  ``,
+  // The generic return type must be inferred from the callback, not widened to
+  // a fixed type — deriving a number flows out as a number.
+  `function useAccessorReturnNumber(accessor: SecretAccessor): number {`,
+  `  return accessor.read((buf) => buf.length)`,
+  `}`,
+  ``,
   `function useSignRequest(req: SignRequest): string | Buffer {`,
   `  return req.data`,
   `}`,
@@ -130,7 +143,7 @@ const consumerSource = [
   `  await env.cleanup()`,
   `}`,
   ``,
-  `export { useAccessor, useSignRequest, useVerifyRequest, useTestVault, useCliTestEnv }`,
+  `export { useAccessor, useAccessorReturn, useAccessorReturnNumber, useSignRequest, useVerifyRequest, useTestVault, useCliTestEnv }`,
 ].join('\n')
 
 // `process.env.CI` is read once at module load, matching how

--- a/packages/vaultkeeper/test/unit/access/controlled-direct.test.ts
+++ b/packages/vaultkeeper/test/unit/access/controlled-direct.test.ts
@@ -53,6 +53,35 @@ describe('createSecretAccessor', () => {
     })
   })
 
+  // Regression for #168: read() must pass the callback's return value through,
+  // so the natural idiom `const v = accessor.read(buf => buf.toString())` yields
+  // the derived value instead of silently returning undefined.
+  describe('read() return value (issue #168)', () => {
+    it('returns the value the callback returns', () => {
+      const accessor = createSecretAccessor('hunter2')
+      const value = accessor.read((buf) => buf.toString('utf8'))
+      expect(value).toBe('hunter2')
+    })
+
+    it('supports deriving a non-string value (e.g. a length) from the secret', () => {
+      const accessor = createSecretAccessor('hunter2')
+      const length = accessor.read((buf) => buf.length)
+      expect(length).toBe(7)
+    })
+
+    it('still zeros the buffer after returning a derived value', () => {
+      const accessor = createSecretAccessor('secret')
+      let capturedBuf: Buffer | undefined
+      const value = accessor.read((buf) => {
+        capturedBuf = buf
+        return buf.toString('utf8')
+      })
+      expect(value).toBe('secret')
+      // The zero-copy/auto-zeroing contract is preserved even on the value path.
+      expect(capturedBuf?.every((b) => b === 0)).toBe(true)
+    })
+  })
+
   describe('double-read prevention', () => {
     it('throws a descriptive domain error (not TypeError) on second call to read()', () => {
       const accessor = createSecretAccessor('secret')

--- a/packages/vaultkeeper/test/unit/vault.test.ts
+++ b/packages/vaultkeeper/test/unit/vault.test.ts
@@ -5,6 +5,7 @@ import { BackendRegistry } from '../../src/backend/registry.js'
 import type { SecretBackend } from '../../src/backend/types.js'
 import { clearBlocklist } from '../../src/jwe/claims.js'
 import { UsageLimitExceededError } from '../../src/errors.js'
+import * as jweTokenModule from '../../src/jwe/token.js'
 import * as delegatedFetchModule from '../../src/access/delegated-fetch.js'
 import * as delegatedExecModule from '../../src/access/delegated-exec.js'
 import * as delegatedSignModule from '../../src/access/delegated-sign.js'
@@ -211,6 +212,44 @@ describe('VaultKeeper', () => {
         captured = buf.toString('utf-8')
       })
       expect(captured).toBe('injected-value')
+    })
+
+    // Regression for #167 follow-up (thread 3590033605): an injected backend
+    // that declares an empty type must still mint a USABLE token. setup()
+    // derives the `bkd` claim from the same centralized hint as
+    // activeBackendType, so the empty type falls back to 'custom' — a non-empty
+    // bkd that validateClaims accepts. Before the fix, bkd was '' and
+    // authorize() threw "Invalid token: bkd must not be empty".
+    it('mints a valid token (bkd="custom") for an injected empty-type backend (issue #167)', async () => {
+      const backend: SecretBackend = {
+        type: '', // empty declared type — the documented injected edge case
+        displayName: 'Anonymous Backend',
+        isAvailable: () => Promise.resolve(true),
+        store: () => Promise.resolve(),
+        retrieve: () => Promise.resolve('injected-value'),
+        delete: () => Promise.resolve(),
+        exists: () => Promise.resolve(true),
+      }
+      const vault = await VaultKeeper.init({ backend, skipDoctor: true })
+
+      // Spy (call-through) to capture the claims actually minted, without
+      // replacing the real token so authorize() still validates end-to-end.
+      const createTokenSpy = vi.spyOn(jweTokenModule, 'createToken')
+
+      // No options.backendType: setup() must derive a non-empty bkd on its own.
+      const jwe = await vault.setup('injected-secret', { skipTrust: true })
+
+      expect(createTokenSpy).toHaveBeenCalledOnce()
+      expect(createTokenSpy.mock.calls[0]?.[1].bkd).toBe('custom')
+
+      // The token round-trips: authorize() accepts it (pre-fix it threw on the
+      // empty bkd) and the secret is recoverable.
+      const { token } = await vault.authorize(jwe)
+      const accessor = vault.getSecret(token)
+      const secret = accessor.read((buf) => buf.toString('utf8'))
+      expect(secret).toBe('injected-value')
+
+      createTokenSpy.mockRestore()
     })
 
     it('uses a minimal built-in default config when config is omitted', async () => {

--- a/packages/vaultkeeper/test/unit/vault.test.ts
+++ b/packages/vaultkeeper/test/unit/vault.test.ts
@@ -146,6 +146,38 @@ describe('VaultKeeper', () => {
       })
       expect(vault.activeBackendType).toBe('unregistered-backend')
     })
+
+    // Regression for #167: with a backend injected via init({ backend }), the
+    // config-driven enabled-backend list is empty, so the getter must report
+    // the injected instance's declared `type` instead of throwing
+    // BackendUnavailableError('none-enabled').
+    it('returns the injected backend type instead of throwing (issue #167)', async () => {
+      const backend = createStatefulMockBackend() // declares type 'test'
+      const vault = await VaultKeeper.init({ backend, skipDoctor: true })
+
+      // The bug: this getter threw BackendUnavailableError before the fix.
+      expect(vault.activeBackendType).toBe('test')
+
+      // Store/retrieve still work against the same injected instance.
+      await vault.store('S', 'v')
+      expect(await backend.retrieve('S')).toBe('v')
+    })
+
+    // Edge case for #167 AC #1: an injected backend that declares an empty
+    // type falls back to the stable 'custom' sentinel rather than returning ''.
+    it('falls back to the "custom" sentinel for an injected backend with an empty type (issue #167)', async () => {
+      const backend: SecretBackend = {
+        type: '',
+        displayName: 'Anonymous Backend',
+        isAvailable: () => Promise.resolve(true),
+        store: () => Promise.resolve(),
+        retrieve: () => Promise.resolve(''),
+        delete: () => Promise.resolve(),
+        exists: () => Promise.resolve(false),
+      }
+      const vault = await VaultKeeper.init({ backend, skipDoctor: true })
+      expect(vault.activeBackendType).toBe('custom')
+    })
   })
 
   describe('init with backend option', () => {

--- a/packages/vaultkeeper/test/unit/vault.test.ts
+++ b/packages/vaultkeeper/test/unit/vault.test.ts
@@ -252,6 +252,42 @@ describe('VaultKeeper', () => {
       createTokenSpy.mockRestore()
     })
 
+    // Regression for the review thread on #resolveBackendTypeHint (comment
+    // 3590126933): a blank options.backendType override must not be treated
+    // as authoritative — honoring it would mint a token with a blank `bkd`
+    // claim that validateClaims later rejects (an unusable token). A blank
+    // override falls through to the same declared-type/'custom' derivation
+    // as no override at all. Before the fix, bkd was '  ' here.
+    it('ignores a whitespace-only options.backendType override instead of minting a blank bkd claim', async () => {
+      const backend: SecretBackend = {
+        type: 'file',
+        displayName: 'File Backend',
+        isAvailable: () => Promise.resolve(true),
+        store: () => Promise.resolve(),
+        retrieve: () => Promise.resolve('injected-value'),
+        delete: () => Promise.resolve(),
+        exists: () => Promise.resolve(true),
+      }
+      const vault = await VaultKeeper.init({ backend, skipDoctor: true })
+
+      const createTokenSpy = vi.spyOn(jweTokenModule, 'createToken')
+
+      const jwe = await vault.setup('injected-secret', {
+        skipTrust: true,
+        backendType: '  ',
+      })
+
+      expect(createTokenSpy).toHaveBeenCalledOnce()
+      expect(createTokenSpy.mock.calls[0]?.[1].bkd).toBe('file')
+
+      // The token stays usable end-to-end.
+      const { token } = await vault.authorize(jwe)
+      const accessor = vault.getSecret(token)
+      expect(accessor.read((buf) => buf.toString('utf8'))).toBe('injected-value')
+
+      createTokenSpy.mockRestore()
+    })
+
     it('uses a minimal built-in default config when config is omitted', async () => {
       const backend = createMockBackend({ 'my-secret': 'hunter2' })
       // No `config` or `configDir`-loadable file is supplied — this only


### PR DESCRIPTION
Fixes two library rough edges surfaced on the direct-integration path.

## #167 — `activeBackendType` throws for an injected backend (P1)

With a backend injected via `init({ backend })`, `init()`/`store()`/`setup()` all work, but reading `vault.activeBackendType` threw `BackendUnavailableError('none-enabled')` — the getter resolved from the config's enabled-backend list, which is empty in inject mode.

Fix: when a backend was injected, the getter reports the injected instance's declared `type` (or the stable `'custom'` sentinel if it declares an empty type) and never throws. A new `#backendInjected` flag distinguishes the injected path from a lazily-resolved config backend, so the config-driven path is unchanged.

Regression tests (`test/unit/vault.test.ts`): inject a backend → `activeBackendType` returns its type and store/retrieve still work; empty-type backend → `'custom'`.

## #168 — `SecretAccessor.read()` returned void (P3, API decision)

**Decision: took the preferred option (1) — make `read` return the callback's value.**

`read(callback)` returned `void`, so `const v = accessor.read((buf) => buf.toString())` silently yielded `undefined` — a subtle trap on a security-sensitive API. `read` is now:

```ts
read<T>(callback: (buf: Buffer) => T): T
```

The buffer is still zeroed in the `finally` before the value is returned, so the zero-copy/auto-zeroing contract holds: a caller-derived value (string, hash, header) flows out, but returning the raw `buf` only ever yields zeroed bytes. The signature stays synchronous, matching the existing shape (the study's `await accessor.read(...)` repro also works — awaiting a plain value yields it).

Type coverage lands in the repo's enforced type gate (`test/e2e/consumer-typecheck.test.ts`, real `tsc` across the pinned version matrix), not a new `tsd` dep — the project has no `tsd` and verifies public types via that consumer harness. Runtime coverage in `test/unit/access/controlled-direct.test.ts` (value passthrough, non-string derivation, buffer still zeroed on the value path). README controlled-direct example updated.

### `SecretAccessor.read()`: signature

```diff
-  read(callback: (buf: Buffer) => void): void
+  read<T>(callback: (buf: Buffer) => T): T
```

## Verification

- `pnpm --filter vaultkeeper test` — 773 passing
- `pnpm check` — typecheck + lint + api-report clean (pre-existing security warnings only)
- `pnpm check:api-docs` — `docs/api/` up to date
- `api-report/` and `docs/api/` regenerated and committed

Changeset: `vaultkeeper` minor (signature/behavior change).

Refs #167, Refs #168