### PR TITLE
Close @vaultkeeper/wasm getting-started and API-reference docs gaps

### DIFF
--- a/.changeset/wasm-getting-started-and-api.md
+++ b/.changeset/wasm-getting-started-and-api.md
@@ -1,0 +1,11 @@
+---
+"@vaultkeeper/wasm": patch
+"vaultkeeper": patch
+---
+
+Close the `@vaultkeeper/wasm` getting-started and API-reference documentation gaps.
+
+- The WASM quick start now leads with an ESM-setup callout. `@vaultkeeper/wasm` is ESM-only (no CommonJS fallback), so a copy-paste of the snippet into a default `npm init -y` (CommonJS) project previously failed with `SyntaxError: Cannot use import statement outside a module`. The callout documents adding `"type": "module"` first, so the documented steps now succeed from a fresh project.
+- `SetupOptions.executablePath` JSDoc (and the generated API reference) now states positively that this WASM SDK records the path as a claim label and performs no trust-on-first-use (TOFU) verification — no hashing, manifest check, or throw on a changed/nonexistent path — unlike the TypeScript `vaultkeeper` library's `VaultKeeper.setup()`. Cross-references the behavioral follow-up tracked separately.
+- The `vaultkeeper` README Trust-tiers section now scopes its "requires an explicit executable-trust choice / never silently skips verification" guarantee to the TypeScript library, and notes that `@vaultkeeper/wasm` records `executablePath` as a claim label without running TOFU verification.
+- `SetupOptions.backendType` is now documented as a claim label only (recorded in the token's `bkd` claim) that does not select or route through a functional backend, mirroring the claim-label framing of `executablePath`.

--- a/docs/api/wasm.setupoptions.backendtype.md
+++ b/docs/api/wasm.setupoptions.backendtype.md
@@ -4,6 +4,8 @@
 
 ## SetupOptions.backendType property
 
+Backend identifier recorded as a claim label in the minted token's `bkd` claim. This is a label only, mirroring the claim-label nature of [SetupOptions.executablePath](./wasm.setupoptions.executablepath.md)<!-- -->: it does not select, connect to, or route through a functional backend. Setting `'keychain'`<!-- -->, for example, records the string `'keychain'` in the token without performing any keychain access. This WASM SDK's `setup()` mints the token directly from the supplied secret value and never reads from a backend.
+
 **Signature:**
 
 ```typescript

--- a/docs/api/wasm.setupoptions.executablepath.md
+++ b/docs/api/wasm.setupoptions.executablepath.md
@@ -4,7 +4,9 @@
 
 ## SetupOptions.executablePath property
 
-The calling executable's real path, bound into the minted token. Mutually exclusive with [SetupOptions.skipTrust](./wasm.setupoptions.skiptrust.md)<!-- -->. The retired `'dev'` sentinel is rejected — use `skipTrust: true` to skip binding a real identity instead.
+The calling executable's real path, recorded as a claim label in the minted token. Mutually exclusive with [SetupOptions.skipTrust](./wasm.setupoptions.skiptrust.md)<!-- -->. The retired `'dev'` sentinel is rejected — use `skipTrust: true` to skip binding a real identity instead.
+
+This value is a claim label only. Unlike the TypeScript `vaultkeeper` library's `VaultKeeper.setup()`<!-- -->, this WASM SDK performs no trust-on-first-use (TOFU) verification: the path is copied straight into the token's `exe` claim without hashing the executable, consulting a trust manifest, or throwing on a changed or nonexistent path. Passing `executablePath` here therefore documents an intended identity but does not enforce it. Making WASM `setup()` verify with the same semantics as the TypeScript library is tracked separately (see vaultkeeper issue \#165); until then, treat this field as descriptive metadata, not an enforced security boundary.
 
 **Signature:**
 

--- a/docs/api/wasm.setupoptions.md
+++ b/docs/api/wasm.setupoptions.md
@@ -52,7 +52,7 @@ string
 
 </td><td>
 
-_(Optional)_
+_(Optional)_ Backend identifier recorded as a claim label in the minted token's `bkd` claim. This is a label only, mirroring the claim-label nature of [SetupOptions.executablePath](./wasm.setupoptions.executablepath.md)<!-- -->: it does not select, connect to, or route through a functional backend. Setting `'keychain'`<!-- -->, for example, records the string `'keychain'` in the token without performing any keychain access. This WASM SDK's `setup()` mints the token directly from the supplied secret value and never reads from a backend.
 
 
 </td></tr>
@@ -71,7 +71,9 @@ string
 
 </td><td>
 
-_(Optional)_ The calling executable's real path, bound into the minted token. Mutually exclusive with [SetupOptions.skipTrust](./wasm.setupoptions.skiptrust.md)<!-- -->. The retired `'dev'` sentinel is rejected — use `skipTrust: true` to skip binding a real identity instead.
+_(Optional)_ The calling executable's real path, recorded as a claim label in the minted token. Mutually exclusive with [SetupOptions.skipTrust](./wasm.setupoptions.skiptrust.md)<!-- -->. The retired `'dev'` sentinel is rejected — use `skipTrust: true` to skip binding a real identity instead.
+
+This value is a claim label only. Unlike the TypeScript `vaultkeeper` library's `VaultKeeper.setup()`<!-- -->, this WASM SDK performs no trust-on-first-use (TOFU) verification: the path is copied straight into the token's `exe` claim without hashing the executable, consulting a trust manifest, or throwing on a changed or nonexistent path. Passing `executablePath` here therefore documents an intended identity but does not enforce it. Making WASM `setup()` verify with the same semantics as the TypeScript library is tracked separately (see vaultkeeper issue \#165); until then, treat this field as descriptive metadata, not an enforced security boundary.
 
 
 </td></tr>

--- a/packages/vaultkeeper-wasm/README.md
+++ b/packages/vaultkeeper-wasm/README.md
@@ -25,6 +25,19 @@ pnpm add @vaultkeeper/wasm
 
 ## Quick start
 
+This package is **ESM-only** — it ships an `import`-only `exports` map and no CommonJS
+build, so there is no `require()` fallback. The snippet below is ESM and requires
+`"type": "module"` in your `package.json` (or an ESM-capable loader/bundler). A default
+`npm init -y` project is CommonJS, so add that field first — otherwise Node rejects the
+`import` line with `SyntaxError: Cannot use import statement outside a module`:
+
+```jsonc
+// package.json
+{
+  "type": "module"
+}
+```
+
 ```ts
 import { createVaultKeeper } from '@vaultkeeper/wasm'
 

--- a/packages/vaultkeeper-wasm/api-report/wasm.api.md
+++ b/packages/vaultkeeper-wasm/api-report/wasm.api.md
@@ -105,7 +105,6 @@ export class SecretNotFoundError extends VaultError {
 
 // @public
 export interface SetupOptions {
-    // (undocumented)
     backendType?: string;
     executablePath?: string;
     skipTrust?: boolean;

--- a/packages/vaultkeeper-wasm/src/types.ts
+++ b/packages/vaultkeeper-wasm/src/types.ts
@@ -36,9 +36,20 @@ export interface SetupOptions {
   ttlMinutes?: number;
   useLimit?: number;
   /**
-   * The calling executable's real path, bound into the minted token. Mutually
-   * exclusive with {@link SetupOptions.skipTrust}. The retired `'dev'` sentinel
-   * is rejected — use `skipTrust: true` to skip binding a real identity instead.
+   * The calling executable's real path, recorded as a claim label in the minted
+   * token. Mutually exclusive with {@link SetupOptions.skipTrust}. The retired
+   * `'dev'` sentinel is rejected — use `skipTrust: true` to skip binding a real
+   * identity instead.
+   *
+   * This value is a claim label only. Unlike the TypeScript `vaultkeeper`
+   * library's `VaultKeeper.setup()`, this WASM SDK performs no trust-on-first-use
+   * (TOFU) verification: the path is copied straight into the token's `exe` claim
+   * without hashing the executable, consulting a trust manifest, or throwing on a
+   * changed or nonexistent path. Passing `executablePath` here therefore documents
+   * an intended identity but does not enforce it. Making WASM `setup()` verify with
+   * the same semantics as the TypeScript library is tracked separately (see
+   * vaultkeeper issue #165); until then, treat this field as descriptive metadata,
+   * not an enforced security boundary.
    */
   executablePath?: string;
   /**
@@ -47,6 +58,15 @@ export interface SetupOptions {
    * Mutually exclusive with {@link SetupOptions.executablePath}.
    */
   skipTrust?: boolean;
+  /**
+   * Backend identifier recorded as a claim label in the minted token's `bkd`
+   * claim. This is a label only, mirroring the claim-label nature of
+   * {@link SetupOptions.executablePath}: it does not select, connect to, or route
+   * through a functional backend. Setting `'keychain'`, for example, records the
+   * string `'keychain'` in the token without performing any keychain access. This
+   * WASM SDK's `setup()` mints the token directly from the supplied secret value
+   * and never reads from a backend.
+   */
   backendType?: string;
 }
 

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -123,9 +123,12 @@ longer be decrypted.
 
 ## Trust tiers
 
-Executable identity verification against a local trust-on-first-use (TOFU) manifest runs
-when `setup()` is given a real `executablePath`. **`setup()` requires an explicit executable-trust
-choice — it has no default and never silently skips verification.** Pass the caller's real path to
+In this TypeScript library, executable identity verification against a local trust-on-first-use
+(TOFU) manifest runs when `VaultKeeper.setup()` is given a real `executablePath`. **This library's
+`setup()` requires an explicit executable-trust choice — it has no default and never silently skips
+verification.** (The separate [`@vaultkeeper/wasm`](https://www.npmjs.com/package/@vaultkeeper/wasm)
+SDK also requires the explicit choice, but records `executablePath` as a claim label without running
+TOFU verification — see that package's API reference.) Pass the caller's real path to
 protect a production caller: `vault.setup('MY_API_KEY', { executablePath: '/usr/local/bin/my-tool'
 })`. To deliberately skip verification during development, pass the explicit, greppable opt-out
 `vault.setup('MY_API_KEY', { skipTrust: true })` instead — a token minted this way carries no


### PR DESCRIPTION
## Summary

Closes the three `@vaultkeeper/wasm` documentation gaps identified in the wave-5 usability study (subject A5 — the aggregate's one rough surface). Docs-only: README + JSDoc, no behavioral change. The behavioral WASM-verify fix is tracked separately.

Refs #170 (relates to #165)

## Changes

1. **ESM first-run failure (blocking).** `@vaultkeeper/wasm` is ESM-only with no CommonJS fallback, but its quick start gave copy-paste `import` code with no setup warning — pasting into a default `npm init -y` (CommonJS) project failed with `SyntaxError: Cannot use import statement outside a module`. The quick start now leads with a `"type": "module"` callout (more critical here than in the dual-build TS library, since there is no `require()` fallback).

2. **`executablePath` claim-label scoping.** The `vaultkeeper` README Trust-tiers section advertised, unscoped, that `setup()` "never silently skips verification" — false for WASM, where `executablePath` is copied into the token with no TOFU verification. That guarantee is now scoped to the TypeScript library, and `SetupOptions.executablePath` JSDoc / the generated API reference now states positively that WASM records the path as a claim label and runs no TOFU verification (cross-referencing the behavioral follow-up).

3. **`backendType` documented.** `SetupOptions.backendType` was undocumented; it is now documented as a claim label only (recorded in the `bkd` claim), not a functional backend switch — mirroring the `executablePath` claim-label framing.

4. Regenerated `docs/api/` and the WASM `api-report` from the updated JSDoc.

## Verification

- **WASM quick start runs from a fresh project** (UAT): packed the WASM tarball, `npm init -y` in a temp dir, installed it, ran the documented snippet. Confirmed it fails without `"type": "module"` (reproducing the reported bug) and succeeds once the callout's fix is applied (`recovered secret matches: true`).
- `pnpm --filter @vaultkeeper/wasm test` — 46/46 pass.
- `pnpm check` (typecheck + lint + api-report) and `pnpm check:api-docs` — green.

### `@vaultkeeper/wasm` README: Quick start

Added an ESM-setup callout before the snippet:

```diff
 ## Quick start

+This package is **ESM-only** — it ships an `import`-only `exports` map and no CommonJS
+build, so there is no `require()` fallback. The snippet below is ESM and requires
+`"type": "module"` in your `package.json` (or an ESM-capable loader/bundler). A default
+`npm init -y` project is CommonJS, so add that field first — otherwise Node rejects the
+`import` line with `SyntaxError: Cannot use import statement outside a module`:
+
+```jsonc
+// package.json
+{
+  "type": "module"
+}
+```
+
 ```ts
 import { createVaultKeeper } from '@vaultkeeper/wasm'
```