### PR TITLE
Validate disallowed algorithm before parsing key material in verify()/sign()

### DIFF
--- a/.changeset/verify-algorithm-guard-ordering.md
+++ b/.changeset/verify-algorithm-guard-ordering.md
@@ -1,0 +1,5 @@
+---
+'vaultkeeper': patch
+---
+
+Validate the signing/verification algorithm before parsing key material in `VaultKeeper.verify()` (and the internal signing path). A disallowed algorithm (e.g. `md5`) now throws `InvalidAlgorithmError` unconditionally and synchronously, as documented — even when the supplied key material is also malformed. Previously a malformed public key short-circuited to `false` and silently skipped the algorithm guard, so callers relying on `try`/`catch` for `InvalidAlgorithmError` were not protected when key material was attacker-controlled.

--- a/packages/vaultkeeper/src/access/delegated-sign.ts
+++ b/packages/vaultkeeper/src/access/delegated-sign.ts
@@ -10,7 +10,7 @@
 import * as crypto from 'node:crypto'
 import type { SignRequest, SignResult } from '../types.js'
 import { InvalidKeyMaterialError } from '../errors.js'
-import { resolveAlgorithmForKey } from './sign-util.js'
+import { assertAllowedAlgorithm, resolveAlgorithmForKey } from './sign-util.js'
 
 /**
  * Sign data using a PEM-encoded private key.
@@ -23,6 +23,12 @@ import { resolveAlgorithmForKey } from './sign-util.js'
  * @internal
  */
 export function delegatedSign(secretPem: string, request: SignRequest): SignResult {
+  // A disallowed algorithm (e.g. 'md5') is a downgrade attempt and must throw
+  // InvalidAlgorithmError unconditionally — mirroring delegatedVerify. Run this
+  // guard BEFORE parsing the key so a disallowed algorithm is not masked by an
+  // InvalidKeyMaterialError when the stored secret is also unusable (issue #180).
+  assertAllowedAlgorithm(request.algorithm)
+
   // Note: `secretPem` is a JS string and cannot be zeroed. This is consistent
   // with how `delegatedFetch` and `delegatedExec` handle `claims.val`. Node.js
   // `KeyObject` also does not expose a zeroing API.

--- a/packages/vaultkeeper/src/access/delegated-verify.ts
+++ b/packages/vaultkeeper/src/access/delegated-verify.ts
@@ -8,7 +8,7 @@
 
 import * as crypto from 'node:crypto'
 import type { VerifyRequest } from '../types.js'
-import { resolveAlgorithmForKey } from './sign-util.js'
+import { assertAllowedAlgorithm, resolveAlgorithmForKey } from './sign-util.js'
 
 /**
  * Verify a signature using a public key.
@@ -24,9 +24,16 @@ import { resolveAlgorithmForKey } from './sign-util.js'
  * @internal
  */
 export function delegatedVerify(request: VerifyRequest): boolean {
+  // A disallowed algorithm (e.g. 'md5') is a downgrade attempt and must throw
+  // InvalidAlgorithmError unconditionally — including when the public key is
+  // also malformed or attacker-controlled. This guard therefore runs BEFORE
+  // parsing the key: parsing first would short-circuit to `return false` on a
+  // bad key and silently skip the algorithm check (see issue #180).
+  assertAllowedAlgorithm(request.algorithm)
+
   // Invalid key material or malformed signatures are treated as verification
   // failures (return false) rather than thrown errors. Disallowed algorithms
-  // are the deliberate exception — see resolveAlgorithmForKey below.
+  // are the deliberate exception — already rejected above.
   let key: crypto.KeyObject
   try {
     key = crypto.createPublicKey(request.publicKey)

--- a/packages/vaultkeeper/src/access/sign-util.ts
+++ b/packages/vaultkeeper/src/access/sign-util.ts
@@ -14,6 +14,38 @@ import { InvalidAlgorithmError } from '../errors.js'
 const ALLOWED_ALGORITHMS = new Set(['sha256', 'sha384', 'sha512'])
 
 /**
+ * Assert that a caller-supplied algorithm override is in the allowlist.
+ *
+ * This check is intentionally key-independent so it can run *before* any key
+ * material is parsed. A disallowed algorithm (e.g. `'md5'`, `'sha1'`) is a
+ * downgrade attempt and must be rejected unconditionally — even when the key
+ * material is also malformed or attacker-controlled. Callers that parse key
+ * material first would otherwise short-circuit to a key-parse failure and
+ * silently skip this guard.
+ *
+ * A `undefined` override is a no-op: the default algorithm is chosen later,
+ * once the key type is known.
+ *
+ * @param override - Caller-provided algorithm override, if any.
+ * @throws {InvalidAlgorithmError} If `override` is provided and not in the
+ *   allowed algorithm set.
+ * @internal
+ */
+export function assertAllowedAlgorithm(override: string | undefined): void {
+  if (override === undefined) {
+    return
+  }
+  const alg = override.toLowerCase()
+  if (!ALLOWED_ALGORITHMS.has(alg)) {
+    throw new InvalidAlgorithmError(
+      `Unsupported algorithm '${alg}'. Allowed: ${[...ALLOWED_ALGORITHMS].join(', ')}`,
+      alg,
+      [...ALLOWED_ALGORITHMS],
+    )
+  }
+}
+
+/**
  * Resolve the algorithm parameter for `crypto.sign()` / `crypto.verify()`
  * based on the key type.
  *
@@ -35,13 +67,7 @@ export function resolveAlgorithmForKey(
   if (keyType === 'ed25519' || keyType === 'ed448') {
     return { signAlg: null, label: keyType }
   }
+  assertAllowedAlgorithm(override)
   const alg = (override ?? 'sha256').toLowerCase()
-  if (!ALLOWED_ALGORITHMS.has(alg)) {
-    throw new InvalidAlgorithmError(
-      `Unsupported algorithm '${alg}'. Allowed: ${[...ALLOWED_ALGORITHMS].join(', ')}`,
-      alg,
-      [...ALLOWED_ALGORITHMS],
-    )
-  }
   return { signAlg: alg, label: alg }
 }

--- a/packages/vaultkeeper/src/access/sign-util.ts
+++ b/packages/vaultkeeper/src/access/sign-util.ts
@@ -23,7 +23,7 @@ const ALLOWED_ALGORITHMS = new Set(['sha256', 'sha384', 'sha512'])
  * material first would otherwise short-circuit to a key-parse failure and
  * silently skip this guard.
  *
- * A `undefined` override is a no-op: the default algorithm is chosen later,
+ * An `undefined` override is a no-op: the default algorithm is chosen later,
  * once the key type is known.
  *
  * @param override - Caller-provided algorithm override, if any.

--- a/packages/vaultkeeper/test/unit/access/delegated-sign.test.ts
+++ b/packages/vaultkeeper/test/unit/access/delegated-sign.test.ts
@@ -163,6 +163,18 @@ describe('delegatedSign', () => {
         InvalidAlgorithmError,
       )
     })
+
+    // Regression test for the sign-side of https://github.com/mike-north/vaultkeeper/issues/180:
+    // delegatedSign previously parsed the private key before validating the
+    // algorithm, so a disallowed algorithm combined with unusable key material
+    // threw InvalidKeyMaterialError instead of InvalidAlgorithmError. The
+    // disallowed-algorithm guard must run first, unconditionally — mirroring
+    // delegatedVerify.
+    it('throws InvalidAlgorithmError (not InvalidKeyMaterialError) for md5 with a garbage key', () => {
+      expect(() => delegatedSign('not-a-pem', { data: 'test', algorithm: 'md5' })).toThrow(
+        InvalidAlgorithmError,
+      )
+    })
   })
 
   describe('edge cases', () => {

--- a/packages/vaultkeeper/test/unit/access/delegated-verify.test.ts
+++ b/packages/vaultkeeper/test/unit/access/delegated-verify.test.ts
@@ -13,6 +13,8 @@ let ed25519Private: string
 let ed25519Public: string
 let rsaPrivate: string
 let rsaPublic: string
+let ecPrivate: string
+let ecPublic: string
 
 beforeAll(() => {
   const ed = crypto.generateKeyPairSync('ed25519')
@@ -22,6 +24,10 @@ beforeAll(() => {
   const rsa = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
   rsaPrivate = rsa.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString()
   rsaPublic = rsa.publicKey.export({ type: 'spki', format: 'pem' }).toString()
+
+  const ec = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' })
+  ecPrivate = ec.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString()
+  ecPublic = ec.publicKey.export({ type: 'spki', format: 'pem' }).toString()
 })
 
 function signEd25519(data: string): string {
@@ -164,6 +170,76 @@ describe('delegatedVerify', () => {
       expect(
         delegatedVerify({ data, signature, publicKey: rsaPublic, algorithm: 'Sha512' }),
       ).toBe(true)
+    })
+  })
+
+  // Regression tests for https://github.com/mike-north/vaultkeeper/issues/180:
+  // The disallowed-algorithm guard previously ran AFTER key parsing, so a
+  // disallowed algorithm (e.g. 'md5') combined with malformed key material
+  // short-circuited to `return false` and silently skipped the throw. The
+  // README documents the disallowed-algorithm throw as unconditional and
+  // synchronous, so it must fire even when the key is also invalid.
+  //
+  // Matrix (from issue #180):
+  //   md5 + valid RSA   -> throws InvalidAlgorithmError
+  //   md5 + valid EC    -> throws InvalidAlgorithmError
+  //   md5 + garbage key -> throws InvalidAlgorithmError (THE FIX)
+  //   sha256 + garbage key                 -> returns false
+  //   sha256 + valid key + bad signature   -> returns false
+  describe('disallowed algorithm is rejected before key parsing (issue #180)', () => {
+    const GARBAGE_KEY = 'not-a-real-public-key-pem'
+
+    it('throws InvalidAlgorithmError for md5 with a valid RSA key', () => {
+      const signature = signRsa('payload')
+
+      expect(() =>
+        delegatedVerify({ data: 'payload', signature, publicKey: rsaPublic, algorithm: 'md5' }),
+      ).toThrow(InvalidAlgorithmError)
+    })
+
+    it('throws InvalidAlgorithmError for md5 with a valid EC key', () => {
+      const signature = crypto
+        .sign('sha256', Buffer.from('payload'), crypto.createPrivateKey(ecPrivate))
+        .toString('base64')
+
+      expect(() =>
+        delegatedVerify({ data: 'payload', signature, publicKey: ecPublic, algorithm: 'md5' }),
+      ).toThrow(InvalidAlgorithmError)
+    })
+
+    it('throws InvalidAlgorithmError for md5 with a garbage key (the fix)', () => {
+      expect(() =>
+        delegatedVerify({
+          data: 'payload',
+          signature: 'AAAA',
+          publicKey: GARBAGE_KEY,
+          algorithm: 'md5',
+        }),
+      ).toThrow(InvalidAlgorithmError)
+    })
+
+    it('returns false (does not throw) for sha256 with a garbage key', () => {
+      expect(
+        delegatedVerify({
+          data: 'payload',
+          signature: 'AAAA',
+          publicKey: GARBAGE_KEY,
+          algorithm: 'sha256',
+        }),
+      ).toBe(false)
+    })
+
+    it('returns false for sha256 with a valid key and a bad signature', () => {
+      const signature = signRsa('payload')
+
+      expect(
+        delegatedVerify({
+          data: 'different-payload',
+          signature,
+          publicKey: rsaPublic,
+          algorithm: 'sha256',
+        }),
+      ).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

`VaultKeeper.verify()` documented a disallowed algorithm (e.g. `md5`) as throwing `InvalidAlgorithmError` unconditionally and synchronously, regardless of other argument validity. In reality `verify()` parsed the public key **first**; when the key was malformed it silently returned `false` and the algorithm guard was never reached. A caller wrapping `verify()` in `try`/`catch` for `InvalidAlgorithmError` was therefore unprotected when key material was malformed or attacker-controlled.

Confirmed matrix (before this change):

| algorithm | key | before | after |
|---|---|---|---|
| `md5` | valid RSA | throws | throws |
| `md5` | valid EC | throws | throws |
| `md5` | garbage | **returns false** | **throws** (the fix) |
| `sha256` | garbage | returns false | returns false |
| `sha256` | valid + bad signature | returns false | returns false |

## Fix

Extracted a key-independent `assertAllowedAlgorithm(override)` in `sign-util.ts` and call it **before** any key-material parsing in `delegatedVerify`. A disallowed algorithm now throws `InvalidAlgorithmError` unconditionally, before `crypto.createPublicKey`. All other behavior is unchanged: valid algorithm + bad key still returns `false`; valid algorithm + bad signature still returns `false`.

Because the disallowed-algorithm string is validated independently of the key type, an explicit disallowed override now also throws for Ed25519/Ed448 keys (previously the override was silently ignored for Edwards curves). This is the intended airtight interpretation of the documented guarantee — a downgrade request is rejected regardless of key type — and no existing test relied on the old Edwards behavior.

## Parallel ordering issue in sign()

`delegatedSign` had the same ordering: it parsed the private key (throwing `InvalidKeyMaterialError` on garbage) **before** validating the algorithm, so `md5` + an unusable stored secret threw `InvalidKeyMaterialError` instead of `InvalidAlgorithmError`. Since both paths share `resolveAlgorithmForKey` and the same documented `InvalidAlgorithmError` guarantee, the same `assertAllowedAlgorithm` guard now runs first in `delegatedSign` too. (Sign **docs** are owned by a separate issue; this PR only makes the sign **code** ordering consistent and adds a regression test.)

## Tests

Spec-first regression tests asserting the error **type**:
- `delegated-verify.test.ts`: full issue-#180 matrix (md5+RSA throws, md5+EC throws, md5+garbage throws, sha256+garbage false, sha256+valid+bad-sig false).
- `delegated-sign.test.ts`: md5 + garbage key throws `InvalidAlgorithmError` (not `InvalidKeyMaterialError`).

## Verification

- `pnpm --filter vaultkeeper test` — green
- `pnpm check` (typecheck + lint + api-report) — green
- `pnpm test` (full workspace) — green

No public API change (guard is `@internal`).

Refs #180