### PR TITLE
Render unreadable config dir as typed FilesystemError; fix CLI message papercuts

### DIFF
--- a/.changeset/cli-eacces-and-message-papercuts.md
+++ b/.changeset/cli-eacces-and-message-papercuts.md
@@ -1,0 +1,10 @@
+---
+'@vaultkeeper/cli': patch
+---
+
+Route the shared config-file presence check through the typed `FilesystemError` path, and fix three CLI message papercuts.
+
+- `store`, `config show`, `delete`, and `exec` against a config directory the process cannot read (e.g. `chmod 000`) no longer leak a raw Node `EACCES: permission denied, access '.../config.json'` string. They now render the same typed `FilesystemError` with a permissions remediation that `doctor` already produced — a human message naming the file and pointing at the file's permissions, with a non-zero exit.
+- `delete`'s "secret not found" message no longer tells the user to run `store` to *create* the secret they are trying to delete. It keeps the shared diagnostic line but gives a neutral, delete-appropriate hint. `exec` (an access path) still suggests creating the secret.
+- `exec`'s required-flags validation error now includes the standard `Usage:` line, matching every sibling validation error (exit code 2).
+- `vaultkeeper approve --help` now states that `approve` is a required first step for a new caller in non-interactive/CI contexts (non-TTY stdin), where there is no prompt to grant trust — not merely an optional prompt-avoidance convenience.

--- a/packages/cli-tests/test/e2e/approve.test.ts
+++ b/packages/cli-tests/test/e2e/approve.test.ts
@@ -62,6 +62,20 @@ describe('approve command', () => {
     expect(result.stdout).toContain('Approved')
   })
 
+  // Issue #183: approve's help framed it as an optional prompt-avoidance
+  // convenience, but in a non-interactive/CI context (non-TTY stdin) it is a
+  // hard prerequisite before a new caller's first exec — there is no prompt to
+  // grant trust. The help must state it is REQUIRED for a new caller in a
+  // non-interactive/CI context.
+  it('--help states approve is required for a new caller in non-interactive/CI use', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['approve', '--help'])
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('REQUIRED')
+    expect(result.stdout).toMatch(/non-interactive|CI/)
+    expect(result.stdout).toContain('exec')
+  })
+
   // Criterion 1 + Criterion 7 (approve writes the manifest file):
   it('writes the script SHA-256 into trust-manifest.json', async () => {
     env = await createCliTestEnv()

--- a/packages/cli-tests/test/e2e/argument-validation.test.ts
+++ b/packages/cli-tests/test/e2e/argument-validation.test.ts
@@ -67,6 +67,18 @@ describe('argument validation', () => {
     expect(result.stderr).toContain('Must provide command after --')
   })
 
+  // Issue #183: exec's required-flags validation error omitted the `Usage:`
+  // line that every sibling validation error prints, so a user who forgot a
+  // flag saw only which flags were missing, not the invocation shape. It must
+  // exit 2 (usage error) AND include the Usage: line, like its siblings.
+  it('exec should exit 2 with a Usage: line when required flags are missing', async () => {
+    env = await createCliTestEnv()
+    const result = await env.run(['exec', '--', 'echo', 'hi'])
+    expect(result.exitCode).toBe(2)
+    expect(result.stderr).toContain('--secret, --env, and --caller are required')
+    expect(result.stderr).toContain('Usage: vaultkeeper exec --secret <name> --env <VAR> --caller')
+  })
+
   it('dev-mode should exit 2 without proper arguments', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['dev-mode'])

--- a/packages/cli-tests/test/e2e/config-unreadable.test.ts
+++ b/packages/cli-tests/test/e2e/config-unreadable.test.ts
@@ -1,0 +1,114 @@
+/**
+ * UATs for issue #181: `store`, `config show`, `delete`, and `exec` against a
+ * config DIRECTORY the process cannot read (chmod-000) previously aborted with
+ * a raw Node `Error: EACCES: permission denied, access '.../config.json'`
+ * (leaked from the shared `configFileExists` presence pre-check) — no error
+ * class, no fix hint. Wave-6 (#169) fixed only `doctor`.
+ *
+ * Each of the four commands must instead render the read failure through the
+ * SAME typed `FilesystemError` construction + CLI rendering `doctor` uses:
+ * a human message naming the file and pointing at permissions, a non-zero
+ * exit, and NO raw `EACCES` / `access '...'` errno string.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
+import type { CliResult, CliTestEnv } from '@vaultkeeper/cli-test-helpers'
+
+// A chmod-000 directory only yields EACCES on POSIX, and not for root (which
+// bypasses permission bits), so this repro is guarded to a non-root POSIX host
+// (matches the doctor #169 guard).
+const canTestDirPermissions =
+  process.platform !== 'win32' && !(typeof process.getuid === 'function' && process.getuid() === 0)
+
+/** Assert the shared "unreadable config" contract on a command's result. */
+function expectUnreadableConfigContract(result: CliResult, configPath: string): void {
+  // Non-zero exit — an unreadable config is a real failure, never a success.
+  expect(result.exitCode).not.toBe(0)
+
+  // The raw Node errno string never leaks to the user (neither stream).
+  expect(result.stdout).not.toContain('EACCES')
+  expect(result.stderr).not.toContain('EACCES')
+  expect(result.stderr).not.toMatch(/access '.*config\.json'/)
+
+  // A typed, human FilesystemError naming the file and pointing at permissions
+  // — the exact wording doctor produces (issue #169).
+  expect(result.stderr).toContain('FilesystemError')
+  expect(result.stderr).toContain(configPath)
+  expect(result.stderr).toContain('could not be read')
+  expect(result.stderr).toContain('permissions')
+}
+
+describe.skipIf(!canTestDirPermissions)(
+  'unreadable config dir renders a typed FilesystemError, not a raw EACCES (issue #181)',
+  () => {
+    let env: CliTestEnv | undefined
+    let lockedDir: string | undefined
+
+    afterEach(async () => {
+      // Restore traversal so the harness can remove the temp tree, even if an
+      // assertion threw before the in-test restore ran.
+      if (lockedDir !== undefined) {
+        await fs.chmod(lockedDir, 0o755).catch(() => undefined)
+        lockedDir = undefined
+      }
+      if (env !== undefined) {
+        await env.cleanup()
+        env = undefined
+      }
+    })
+
+    /**
+     * Lock the config dir (chmod 000) so reading config.json inside it fails
+     * with EACCES, run `args`, then restore traversal immediately so later
+     * assertions can't leave a locked tree.
+     */
+    async function runAgainstLockedConfig(args: string[], stdin?: string): Promise<CliResult> {
+      // 'flag' mode so `--config-dir` names the dir explicitly and no
+      // VAULTKEEPER_CONFIG_DIR is inherited.
+      env = await createCliTestEnv({ configDirMode: 'flag' })
+      lockedDir = env.configDir
+      await fs.chmod(env.configDir, 0o000)
+      // The global --config-dir flag must precede the subcommand (and, for
+      // `exec`, its `--` separator) — anything after `exec`'s `--` is the
+      // wrapped command, not a global flag.
+      const withDir = ['--config-dir', env.configDir, ...args]
+      const result =
+        stdin !== undefined ? await env.runWithStdin(withDir, stdin) : await env.run(withDir)
+      await fs.chmod(env.configDir, 0o755)
+      lockedDir = undefined
+      return result
+    }
+
+    it('store', async () => {
+      const result = await runAgainstLockedConfig(['store', '--name', 'FOO'], 'secret-value')
+      expectUnreadableConfigContract(result, `${env?.configDir ?? ''}/config.json`)
+    })
+
+    it('config show', async () => {
+      const result = await runAgainstLockedConfig(['config', 'show'])
+      expectUnreadableConfigContract(result, `${env?.configDir ?? ''}/config.json`)
+    })
+
+    it('delete', async () => {
+      const result = await runAgainstLockedConfig(['delete', '--name', 'FOO'])
+      expectUnreadableConfigContract(result, `${env?.configDir ?? ''}/config.json`)
+    })
+
+    it('exec', async () => {
+      const result = await runAgainstLockedConfig([
+        'exec',
+        '--secret',
+        'FOO',
+        '--env',
+        'FOO',
+        '--caller',
+        '/bin/echo',
+        '--',
+        '/bin/echo',
+        'hi',
+      ])
+      expectUnreadableConfigContract(result, `${env?.configDir ?? ''}/config.json`)
+    })
+  },
+)

--- a/packages/cli-tests/test/e2e/exec.test.ts
+++ b/packages/cli-tests/test/e2e/exec.test.ts
@@ -330,9 +330,14 @@ describe('exec trust gate', () => {
   // Regression: issue #118 — exec and delete previously reported the same
   // failure with different wording (exec: `Secret "x" not found in file
   // backend`; delete: the file backend's own `Secret not found in file
-  // store: x`) and neither included a recovery hint. Both commands must now
-  // render byte-for-byte identical text for the missing-secret line.
-  it('reports the identical SecretNotFoundError wording and hint as `delete` for the same missing secret (issue #118)', async () => {
+  // store: x`) and neither included a recovery hint. Both commands must render
+  // the identical typed class and diagnostic LINE.
+  //
+  // Regression: issue #183 — the shared recovery HINT must NOT be identical:
+  // telling `delete` to `store` (create) the secret it is removing is
+  // nonsensical. exec (an access path) keeps the "run store to create it"
+  // hint; delete gets a neutral, delete-appropriate hint instead.
+  it('shares the SecretNotFoundError diagnostic line with `delete` but gives a context-appropriate hint (issues #118, #183)', async () => {
     if (env === undefined) throw new Error('env not initialized')
     const caller = await writeCaller('#!/bin/sh\necho hi\n')
 
@@ -341,15 +346,26 @@ describe('exec trust gate', () => {
     )
     const deleteResult = await env.run(['delete', '--name', 'ghost-secret'])
 
+    // Shared, byte-for-byte identical diagnostic line and typed class.
     const expectedLine = 'Secret "ghost-secret" not found in the "file" backend.'
-    const expectedHint = "Run `vaultkeeper store --name 'ghost-secret'` to create it."
-
     expect(execResult.exitCode).not.toBe(0)
     expect(deleteResult.exitCode).not.toBe(0)
+    expect(execResult.stderr).toContain('SecretNotFoundError')
+    expect(deleteResult.stderr).toContain('SecretNotFoundError')
     expect(execResult.stderr).toContain(expectedLine)
-    expect(execResult.stderr).toContain(expectedHint)
     expect(deleteResult.stderr).toContain(expectedLine)
-    expect(deleteResult.stderr).toContain(expectedHint)
+
+    // exec (access): suggests creating the secret with `store`.
+    expect(execResult.stderr).toContain(
+      "Run `vaultkeeper store --name 'ghost-secret'` to create it.",
+    )
+
+    // delete (removal): must NOT suggest creating the thing being deleted.
+    expect(deleteResult.stderr).not.toContain('to create it')
+    expect(deleteResult.stderr).not.toContain('vaultkeeper store --name')
+    expect(deleteResult.stderr).toContain(
+      'may have already been deleted, or the name may be misspelled',
+    )
   })
 
   // Regression (review follow-up, issue #118): unlike store/delete's --name,

--- a/packages/cli-tests/test/e2e/store-delete.test.ts
+++ b/packages/cli-tests/test/e2e/store-delete.test.ts
@@ -41,14 +41,24 @@ describe('store and delete lifecycle', () => {
 
   // Regression: issue #118 — delete previously surfaced the file backend's
   // own not-found message ("Secret not found in file store: x") instead of
-  // the consistent, hint-bearing wording exec.ts uses for the same failure.
-  it('delete should exit non-zero with the consistent SecretNotFoundError wording and a recovery hint for a nonexistent secret (issue #118)', async () => {
+  // the consistent, typed SecretNotFoundError wording exec.ts uses for the
+  // same failure.
+  //
+  // Regression: issue #183 — the shared not-found hint told the user to run
+  // `store` to CREATE the secret, which is nonsensical on the delete path
+  // (they are trying to REMOVE it). The delete-context message must share the
+  // diagnostic sentence but never suggest creating the secret being deleted.
+  it('delete should exit non-zero with the consistent SecretNotFoundError wording and a delete-appropriate hint for a nonexistent secret (issues #118, #183)', async () => {
     env = await createCliTestEnv()
     const result = await env.run(['delete', '--name', 'never-stored', '--skip-doctor'])
     expect(result.exitCode).not.toBe(0)
     expect(result.stderr).toContain('SecretNotFoundError')
     expect(result.stderr).toContain('Secret "never-stored" not found in the "file" backend')
-    expect(result.stderr).toContain("Run `vaultkeeper store --name 'never-stored'` to create it")
+    // The delete path must NOT tell the user to `store` (create) the secret.
+    expect(result.stderr).not.toContain('to create it')
+    expect(result.stderr).not.toContain('vaultkeeper store --name')
+    // It gives a neutral, delete-appropriate explanation instead.
+    expect(result.stderr).toContain('may have already been deleted, or the name may be misspelled')
   })
 
   // Regression: issue #60 — the CLI ignored BackendConfig.path and always wrote

--- a/packages/cli/src/commands/approve.ts
+++ b/packages/cli/src/commands/approve.ts
@@ -7,9 +7,16 @@ import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
 function printApproveHelp(): void {
   process.stdout.write(
     'Usage: vaultkeeper approve --script <path>\n\n' +
-      'Record a script hash in the TOFU trust manifest so that invoking it via\n' +
-      'vaultkeeper exec does not prompt for trust. Running this on an already\n' +
-      'approved, unchanged script is idempotent.\n\n' +
+      'Record a script hash in the TOFU trust manifest, marking the script as a\n' +
+      'trusted caller for vaultkeeper exec.\n\n' +
+      'When this is required:\n' +
+      '  In a non-interactive or CI context (non-TTY stdin), approve is a REQUIRED\n' +
+      "  first step before a new caller's first exec: there is no prompt to grant\n" +
+      '  trust, so an un-approved caller fails. Pre-approve it here once (or pass\n' +
+      '  exec --yes to approve a single run). On an interactive terminal exec can\n' +
+      "  instead prompt [y/N] on first use, so approve is optional there — it's a\n" +
+      '  way to grant trust ahead of time and avoid that prompt.\n\n' +
+      'Running this on an already approved, unchanged script is idempotent.\n\n' +
       'Options:\n' +
       '  --script <path>   Path to the script to approve\n' +
       CONFIG_DIR_HELP_OPTION +

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -95,7 +95,9 @@ export async function deleteCommand(args: string[], configDir: string): Promise<
       // secret being deleted between any check and this call (issue #118
       // review), which a pre-check alone cannot.
       if (deleteErr instanceof SecretNotFoundError) {
-        throw new SecretNotFoundError(secretNotFoundMessage(values.name, vault.activeBackendType))
+        throw new SecretNotFoundError(
+          secretNotFoundMessage(values.name, vault.activeBackendType, 'delete'),
+        )
       }
       throw deleteErr
     }

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -269,6 +269,12 @@ export async function execCommand(args: string[], configDir: string): Promise<nu
 
   if (secret === undefined || envVar === undefined || caller === undefined) {
     process.stderr.write('Error: --secret, --env, and --caller are required\n')
+    // Every sibling validation error prints the Usage: line; this one omitted
+    // it (issue #183). Append it for consistency so a user who missed a flag
+    // sees the invocation shape, not just which flags were missing.
+    process.stderr.write(
+      'Usage: vaultkeeper exec --secret <name> --env <VAR> --caller <path> [options] -- <command...>\n',
+    )
     // Exit code 2: usage error (missing required flags)
     return 2
   }

--- a/packages/cli/src/config-status.ts
+++ b/packages/cli/src/config-status.ts
@@ -10,6 +10,7 @@
 
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
+import { FilesystemError } from 'vaultkeeper'
 
 /** `true` if `fs.access` failed because the config file truly does not exist. */
 function isEnoent(err: unknown): boolean {
@@ -24,18 +25,36 @@ function isEnoent(err: unknown): boolean {
  * permissions error on the file itself) is a real problem, not "no config" —
  * treating it as "no config" would silently fall back to platform defaults
  * for a config that actually exists but is broken, the same class of bug
- * `loadConfig`'s ENOENT-only fallback fixes (issue #68). Such errors rethrow
- * so the caller's own `loadConfig()` call surfaces the typed error instead.
+ * `loadConfig`'s ENOENT-only fallback fixes (issue #68).
+ *
+ * Such an error is rethrown as a typed {@link FilesystemError} on the same
+ * `config.json` read path `loadConfig` uses (`permission: 'read'`, `path`
+ * = `configDir/config.json`), so `formatError` renders it with the CLI's
+ * shared unreadable-config-file remediation — the exact wording `doctor`
+ * already produces (issue #169) — instead of leaking a raw Node
+ * `EACCES: … access '.../config.json'` string. `store`, `delete`, `exec`,
+ * and `config show` all funnel their presence check through here, so this
+ * one wrap is what makes all four honor the FilesystemError contract for an
+ * unreadable config dir (issue #181). The original errno is preserved as the
+ * cause, so `FilesystemError.code` carries `EACCES`/`EPERM`/etc. for the
+ * message to key on.
  */
 export async function configFileExists(configDir: string): Promise<boolean> {
+  const configPath = path.join(configDir, 'config.json')
   try {
-    await fs.access(path.join(configDir, 'config.json'))
+    await fs.access(configPath)
     return true
   } catch (err) {
     if (isEnoent(err)) {
       return false
     }
-    throw err
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new FilesystemError(
+      `Cannot access config file at ${configPath}: ${detail}`,
+      configPath,
+      'read',
+      err,
+    )
   }
 }
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -280,6 +280,18 @@ function formatFilesystemError(err: FilesystemError): string {
 }
 
 /**
+ * Which command is looking the secret up, so {@link secretNotFoundMessage} can
+ * pick a recovery hint that fits the caller's intent:
+ *
+ * - `'access'` — a command that needs the secret to exist (`exec`, and any
+ *   future read path). Suggesting `store` to create it is the right next step.
+ * - `'delete'` — the user is trying to *remove* the secret. Telling them to
+ *   run `store` to *create* the very thing they are deleting is nonsensical
+ *   (issue #183), so the delete hint is neutral and suggests no creation.
+ */
+export type SecretLookupContext = 'access' | 'delete'
+
+/**
  * Build the standard "secret not found" message, shared by every CLI command
  * that looks up a secret before acting on it.
  *
@@ -288,10 +300,17 @@ function formatFilesystemError(err: FilesystemError): string {
  * file backend`; `delete` surfaced the backend's own `Secret not found in
  * file store: x`), and neither pointed the user at a fix. Centralizing the
  * wording here, and having each command construct the error from this helper
- * instead of the backend's own message, guarantees they stay in sync and
- * always include a recovery hint.
+ * instead of the backend's own message, guarantees they stay in sync.
+ *
+ * The recovery hint is chosen by `context` (issue #183): the shared diagnostic
+ * sentence is identical, but `delete` must not be told to `store` (create) the
+ * secret it is trying to remove — the old shared wording did exactly that.
  */
-export function secretNotFoundMessage(name: string, backendType: string): string {
+export function secretNotFoundMessage(
+  name: string,
+  backendType: string,
+  context: SecretLookupContext = 'access',
+): string {
   // The diagnostic sentence and the recovery hint each need their own kind
   // of quoting, since they aren't the same kind of text:
   //
@@ -304,15 +323,21 @@ export function secretNotFoundMessage(name: string, backendType: string): string
   //   contain a quote, but `name` is user-supplied and, on the exec path
   //   (`--secret`), is validated only for non-emptiness — not restricted to
   //   store/delete's safe `--name` character set — so it needs the escaping.
-  // - The recovery hint is a literal shell command a user may copy and
-  //   paste, so `name` is wrapped with shellQuote() (single-quote POSIX
-  //   shell escaping) instead — JSON's escaping isn't shell-safe and an
-  //   unescaped name could contain a quote, breaking the pasted command
-  //   (review follow-up, issue #118).
-  return (
-    `Secret ${JSON.stringify(name)} not found in the ${JSON.stringify(backendType)} backend. ` +
-    `Run \`vaultkeeper store --name ${shellQuote(name)}\` to create it.`
-  )
+  const diagnostic = `Secret ${JSON.stringify(name)} not found in the ${JSON.stringify(backendType)} backend.`
+
+  if (context === 'delete') {
+    // No `store` suggestion: the user is deleting, not creating. The neutral
+    // hint names the two ordinary explanations for a delete missing its
+    // target so the message is still actionable without being contradictory.
+    return `${diagnostic} It may have already been deleted, or the name may be misspelled.`
+  }
+
+  // The access-path recovery hint is a literal shell command a user may copy
+  // and paste, so `name` is wrapped with shellQuote() (single-quote POSIX
+  // shell escaping) — JSON's escaping isn't shell-safe and an unescaped name
+  // could contain a quote, breaking the pasted command (review follow-up,
+  // issue #118).
+  return `${diagnostic} Run \`vaultkeeper store --name ${shellQuote(name)}\` to create it.`
 }
 
 /** Format an error for display on stderr. */

--- a/packages/cli/test/unit/commands/delete.test.ts
+++ b/packages/cli/test/unit/commands/delete.test.ts
@@ -115,10 +115,15 @@ describe('deleteCommand', () => {
   // SecretNotFoundError wording ("Secret not found in file store: x"),
   // different from exec's ("Secret "x" not found in file backend") and with
   // no recovery hint. delete now catches whatever SecretNotFoundError the
-  // backend's delete() throws and rethrows it with the same wording + hint
-  // exec.ts uses.
-  describe('when vault.delete() throws SecretNotFoundError (issue #118)', () => {
-    it('should return 1 and report a consistent SecretNotFoundError with a recovery hint', async () => {
+  // backend's delete() throws and rethrows it with the normalized wording.
+  //
+  // Regression: issue #183 — that normalized wording used to append exec's
+  // "Run `vaultkeeper store …` to create it" hint, which is nonsensical on
+  // the delete path (the user is removing, not creating). delete now passes
+  // the 'delete' context so the shared diagnostic line is kept but the hint
+  // is neutral and never suggests creating the secret being deleted.
+  describe('when vault.delete() throws SecretNotFoundError (issues #118, #183)', () => {
+    it('should return 1 and report a consistent SecretNotFoundError with a delete-appropriate hint', async () => {
       mockDeleteFn.mockRejectedValue(new SecretNotFoundError('Secret not found in file store: x'))
       mockInit.mockResolvedValue(existingSecretVault())
       const { deleteCommand } = await import('../../../src/commands/delete.js')
@@ -126,7 +131,10 @@ describe('deleteCommand', () => {
       expect(code).toBe(1)
       expect(stderrOutput).toContain('SecretNotFoundError')
       expect(stderrOutput).toContain('Secret "missing-secret" not found in the "file" backend')
-      expect(stderrOutput).toContain("Run `vaultkeeper store --name 'missing-secret'` to create it")
+      // Never suggest creating the secret being deleted.
+      expect(stderrOutput).not.toContain('to create it')
+      expect(stderrOutput).not.toContain('vaultkeeper store --name')
+      expect(stderrOutput).toContain('may have already been deleted, or the name may be misspelled')
     })
 
     // Review follow-up on issue #118: an upfront secretExists() pre-check
@@ -146,7 +154,8 @@ describe('deleteCommand', () => {
       const code = await deleteCommand(['--name', 'race-secret'], configDir)
       expect(code).toBe(1)
       expect(stderrOutput).toContain('Secret "race-secret" not found in the "keychain" backend')
-      expect(stderrOutput).toContain("Run `vaultkeeper store --name 'race-secret'` to create it")
+      expect(stderrOutput).toContain('may have already been deleted, or the name may be misspelled')
+      expect(stderrOutput).not.toContain('to create it')
       expect(stderrOutput).not.toContain('macOS Keychain')
     })
   })

--- a/packages/cli/test/unit/config-status.test.ts
+++ b/packages/cli/test/unit/config-status.test.ts
@@ -7,6 +7,7 @@ vi.mock('node:fs/promises', () => ({
 // Must import after mock declaration
 const { access } = await import('node:fs/promises')
 const { configFileExists, noConfigMessage } = await import('../../src/config-status.js')
+const { FilesystemError } = await import('vaultkeeper')
 
 /** Build a Node.js-shaped filesystem error with a `code` (e.g. 'ENOENT'). */
 function fsError(code: string, message: string): NodeJS.ErrnoException {
@@ -32,16 +33,31 @@ describe('configFileExists', () => {
   // ANY fs.access failure as "no config file", so a config that exists but
   // isn't readable (EACCES on a parent directory, EPERM, etc.) was silently
   // reported as absent — the same class of bug loadConfig's ENOENT-only
-  // fallback fixes for issue #68. It must now rethrow non-ENOENT errors
-  // instead of reporting "no config file".
-  it('rethrows a non-ENOENT error instead of reporting "no config file" (regression: PR #94 review)', async () => {
+  // fallback fixes for issue #68. It must not report "no config file".
+  //
+  // Issue #181: it must rethrow a non-ENOENT error as a typed FilesystemError
+  // on the `config.json` read path (`permission: 'read'`, `path` =
+  // `configDir/config.json`, `code` = the original errno), so `formatError`
+  // renders the CLI's shared unreadable-config remediation instead of leaking
+  // the raw Node `EACCES: … access '.../config.json'` string.
+  it('rethrows an EACCES failure as a typed FilesystemError on the config.json read path (issue #181)', async () => {
     vi.mocked(access).mockRejectedValue(fsError('EACCES', 'permission denied'))
-    await expect(configFileExists('/fake')).rejects.toMatchObject({ code: 'EACCES' })
+    await expect(configFileExists('/fake')).rejects.toBeInstanceOf(FilesystemError)
+    await expect(configFileExists('/fake')).rejects.toMatchObject({
+      code: 'EACCES',
+      permission: 'read',
+      path: '/fake/config.json',
+    })
   })
 
-  it('rethrows an EPERM error instead of reporting "no config file"', async () => {
+  it('rethrows an EPERM failure as a typed FilesystemError, preserving the errno (issue #181)', async () => {
     vi.mocked(access).mockRejectedValue(fsError('EPERM', 'operation not permitted'))
-    await expect(configFileExists('/fake')).rejects.toMatchObject({ code: 'EPERM' })
+    await expect(configFileExists('/fake')).rejects.toBeInstanceOf(FilesystemError)
+    await expect(configFileExists('/fake')).rejects.toMatchObject({
+      code: 'EPERM',
+      permission: 'read',
+      path: '/fake/config.json',
+    })
   })
 })
 

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -281,6 +281,39 @@ describe('formatError', () => {
       // shellQuote("weird'name") -> 'weird'\''name' (POSIX single-quote escaping)
       expect(message).toContain("vaultkeeper store --name 'weird'\\''name'")
     })
+
+    it("defaults to the access context (equivalent to passing 'access')", () => {
+      expect(secretNotFoundMessage('db-password', 'file')).toBe(
+        secretNotFoundMessage('db-password', 'file', 'access'),
+      )
+    })
+
+    // Issue #183: on the delete path, suggesting `store` to CREATE the secret
+    // the user is deleting is nonsensical. The delete context shares the
+    // diagnostic line but gives a neutral, non-creating hint.
+    describe("delete context (issue #183)", () => {
+      it('shares the diagnostic line but suggests no creation and names no store command', () => {
+        const message = secretNotFoundMessage('db-password', 'file', 'delete')
+        expect(message).toBe(
+          'Secret "db-password" not found in the "file" backend. ' +
+            'It may have already been deleted, or the name may be misspelled.',
+        )
+      })
+
+      it('never tells the user to store/create the secret being deleted', () => {
+        const message = secretNotFoundMessage('db-password', 'file', 'delete')
+        expect(message).not.toContain('to create it')
+        expect(message).not.toContain('vaultkeeper store')
+      })
+
+      it('formats as a proper SecretNotFoundError via formatError', () => {
+        const err = new SecretNotFoundError(secretNotFoundMessage('db-password', 'keychain', 'delete'))
+        expect(formatError(err, CONFIG_DIR)).toBe(
+          'SecretNotFoundError: Secret "db-password" not found in the "keychain" backend. ' +
+            'It may have already been deleted, or the name may be misspelled.',
+        )
+      })
+    })
   })
 })
 


### PR DESCRIPTION
Refs #181, Refs #183

## #181 — Raw EACCES leak from store / config show / delete / exec

Wave-6 (#169) fixed only `doctor` to render a typed `FilesystemError` for an unreadable config directory. `store`, `config show`, `delete`, and `exec` still leaked the raw Node errno because their shared presence check, `configFileExists`, rethrew the raw `fs.access` error (not a `FilesystemError`), so `formatError` fell through to its generic `Error` branch.

The fix wraps the non-`ENOENT` failure in `configFileExists` into a `FilesystemError` on the same `config.json` read path `loadConfig` uses (`permission: 'read'`, `path` = `configDir/config.json`, `code` = the original errno). All four commands funnel through this one check, so this single wrap makes all four honor the documented `FilesystemError` contract and share `doctor`'s exact remediation.

### `store` / `config show` / `delete` / `exec` against a `chmod 000` config dir

```diff
-Error: EACCES: permission denied, access '/…/config.json'
+FilesystemError: The config at `/…/config.json` could not be read — check the file's permissions and ownership, and that it exists — the current user cannot read it. Then try again.
```

Non-zero exit preserved; no raw `EACCES` / `access '...'` string on either stream. Covered by a new subprocess UAT (`config-unreadable.test.ts`) exercising all four commands.

## #183 — CLI message papercuts

### 1. `delete` no longer suggests creating the secret it is deleting

The shared not-found message told the user to `store` (create) the secret — nonsensical on the delete path. `secretNotFoundMessage` now takes a `context` (`'access'` | `'delete'`): both share the diagnostic line, but `delete` gets a neutral hint.

```diff
 SecretNotFoundError: Secret "FOO" not found in the "file" backend.
-Run `vaultkeeper store --name 'FOO'` to create it.
+It may have already been deleted, or the name may be misspelled.
```

`exec` (an access path) keeps the create hint.

### 2. `exec` required-flags error now includes `Usage:`

```diff
 Error: --secret, --env, and --caller are required
+Usage: vaultkeeper exec --secret <name> --env <VAR> --caller <path> [options] -- <command...>
```

Exit code 2 (unchanged).

### 3. `approve --help` frames approve as a required prerequisite

```diff
 Usage: vaultkeeper approve --script <path>

-Record a script hash in the TOFU trust manifest so that invoking it via
-vaultkeeper exec does not prompt for trust. Running this on an already
-approved, unchanged script is idempotent.
+Record a script hash in the TOFU trust manifest, marking the script as a
+trusted caller for vaultkeeper exec.
+
+When this is required:
+  In a non-interactive or CI context (non-TTY stdin), approve is a REQUIRED
+  first step before a new caller's first exec: there is no prompt to grant
+  trust, so an un-approved caller fails. Pre-approve it here once (or pass
+  exec --yes to approve a single run). On an interactive terminal exec can
+  instead prompt [y/N] on first use, so approve is optional there — it's a
+  way to grant trust ahead of time and avoid that prompt.
+
+Running this on an already approved, unchanged script is idempotent.
```

### 4. `trust-manifest.json` format — decision: no change needed

**Decision: leave as-is; the file is already real JSON.** The issue's premise (a "YAML-flavored custom format") is stale. Both the TS writer (`JSON.stringify(raw, null, 2)` in `packages/vaultkeeper/src/identity/manifest.ts`) and the Rust writer (`serde_json::to_string_pretty` in `crates/vaultkeeper-core/src/identity/manifest.rs`) already emit standard, cross-language-compatible JSON, and both read it back with a JSON parser. Verified on disk: `approve` produces a file that `JSON.parse` accepts. No rename and no re-serialization are warranted, and touching the shared wire format would risk the Rust/TS interop for no benefit.

## Verification

- `pnpm --filter @vaultkeeper/cli test` — 286 passed
- `pnpm --filter @vaultkeeper/cli-tests test` — 146 passed / 25 skipped
- `pnpm check` — typecheck + lint + api-report all pass (0 errors)

Changeset: `@vaultkeeper/cli` patch (manifest serialization unchanged, so no `vaultkeeper` bump).