### PR TITLE
Guard WASM SDK string args against non-string input (Refs #192)

### DIFF
--- a/.changeset/wasm-non-string-input-guards.md
+++ b/.changeset/wasm-non-string-input-guards.md
@@ -1,0 +1,12 @@
+---
+'@vaultkeeper/wasm': patch
+---
+
+Guard the WASM SDK's string arguments so a non-string input surfaces a typed, catchable error instead of crashing the process.
+
+`VaultKeeper` forwarded its arguments straight into WebAssembly with no JS-side type check, so a non-string — a number, a plain object, or (a common mistake) an un-awaited `setup()` Promise — reached wasm-bindgen's string marshaling and aborted the process with an opaque `VaultError: memory access out of bounds` fault. A malformed token *string* by contrast already yielded a clean `InvalidTokenError`.
+
+Every wrapper method that forwards a string into WASM now validates the JS type at the boundary, before the value crosses into WebAssembly:
+
+- `authorize(jwe)` throws `InvalidTokenError` on a non-string `jwe` (joining the malformed-token-string case under one catchable type).
+- `setup(secretName, secretValue)`, `store(id, secret)`, `retrieve(id)`, and `delete(id)` throw `TypeError` on a non-string argument, naming the offending method and parameter.

--- a/docs/api/wasm.vaultkeeper.authorize.md
+++ b/docs/api/wasm.vaultkeeper.authorize.md
@@ -52,3 +52,7 @@ string
 
 [AuthorizeResult](./wasm.authorizeresult.md)
 
+## Exceptions
+
+[InvalidTokenError](./wasm.invalidtokenerror.md) If `jwe` is not a string (e.g. a number, object, or an un-awaited `setup()` Promise) or is a malformed token string. The non-string guard runs before the value crosses into WASM, turning what would otherwise be an opaque native memory fault into this typed error.
+

--- a/docs/api/wasm.vaultkeeper.delete.md
+++ b/docs/api/wasm.vaultkeeper.delete.md
@@ -50,3 +50,7 @@ string
 
 Promise&lt;void&gt;
 
+## Exceptions
+
+TypeError If `id` is not a string (guards the WASM boundary against a native memory fault).
+

--- a/docs/api/wasm.vaultkeeper.retrieve.md
+++ b/docs/api/wasm.vaultkeeper.retrieve.md
@@ -50,3 +50,7 @@ string
 
 Promise&lt;string&gt;
 
+## Exceptions
+
+TypeError If `id` is not a string (guards the WASM boundary against a native memory fault).
+

--- a/docs/api/wasm.vaultkeeper.setup.md
+++ b/docs/api/wasm.vaultkeeper.setup.md
@@ -86,6 +86,8 @@ Promise&lt;string&gt;
 
 [IdentityMismatchError](./wasm.identitymismatcherror.md) If `executablePath`<!-- -->'s current hash no longer matches a previously approved value (TOFU conflict).
 
+TypeError If `secretName` or `secretValue` is not a string (guards the WASM boundary against a native memory fault).
+
 ## Remarks
 
 \*\*Explicit executable-trust choice required.\*\* Like the TypeScript `vaultkeeper` library's `setup()`<!-- -->, this method no longer defaults to skipping the executable-identity binding. The caller must make an unambiguous decision via [SetupOptions](./wasm.setupoptions.md)<!-- -->: provide exactly one of [SetupOptions.executablePath](./wasm.setupoptions.executablepath.md) (verify and bind the calling executable's identity into the token) or [SetupOptions.skipTrust](./wasm.setupoptions.skiptrust.md) (`true` — a development-only opt-out). Supplying neither — or both — or the retired `'dev'` sentinel as `executablePath` throws [ExecutableTrustRequiredError](./wasm.executabletrustrequirederror.md) rather than silently minting an unbound `'dev'` token. Inspect the error's `reason` (`'missing-choice'` \| `'conflicting-choice'` \| `'legacy-dev-sentinel'`<!-- -->) to distinguish the cases.

--- a/docs/api/wasm.vaultkeeper.store.md
+++ b/docs/api/wasm.vaultkeeper.store.md
@@ -64,3 +64,7 @@ string
 
 Promise&lt;void&gt;
 
+## Exceptions
+
+TypeError If `id` or `secret` is not a string (guards the WASM boundary against a native memory fault).
+

--- a/packages/vaultkeeper-wasm/src/index.ts
+++ b/packages/vaultkeeper-wasm/src/index.ts
@@ -75,7 +75,7 @@ import type {
 } from './types.js'
 
 import { createNodeHost } from './node-host.js'
-import { mapWasmError } from './errors.js'
+import { InvalidTokenError, mapWasmError } from './errors.js'
 
 // The WASM module types
 type WasmBindings = typeof import('../wasm/vaultkeeper_wasm.js')
@@ -104,6 +104,54 @@ async function callAsync<T>(fn: () => Promise<T>): Promise<T> {
     return await fn()
   } catch (thrown) {
     throw mapWasmError(thrown)
+  }
+}
+
+/**
+ * Describe a runtime value's type for a type-guard error message. Distinguishes
+ * the cases that actually reach these guards from untyped JS callers — `null`,
+ * arrays, and Promises (an un-awaited `setup()` call is a common mistake) — from
+ * a bare `typeof`, which would report all three unhelpfully as `'object'`.
+ */
+function describeType(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'an array'
+  if (value instanceof Promise) return 'a Promise (did you forget to await?)'
+  return `a ${typeof value}`
+}
+
+/**
+ * Reject a non-string argument before it crosses the WASM boundary. The
+ * generated wasm-bindgen glue reads a JS string's bytes directly
+ * (`passStringToWasm0`); handing it a number, object, or un-awaited Promise
+ * corrupts that read and crashes the process with an opaque native
+ * `'memory access out of bounds'` fault instead of a catchable error (issue
+ * #192). Guarding the JS type here turns that into a clear `TypeError`.
+ *
+ * `value` is typed `unknown` rather than `string` on purpose: these wrapper
+ * methods are reachable from untyped JavaScript, where the declared `string`
+ * parameter type is not enforced at runtime, so the check is genuinely
+ * load-bearing (and not an unnecessary condition on an already-`string` value).
+ */
+function ensureStringArg(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new TypeError(`${label} must be a string, but received ${describeType(value)}`)
+  }
+}
+
+/**
+ * `authorize()`-specific analogue of {@link ensureStringArg}. Because the
+ * argument is a JWE token, a non-string is surfaced as {@link InvalidTokenError}
+ * — the same typed error a malformed token *string* already produces — so that
+ * every bad-token input to `authorize()` is catchable under one type. Prevents
+ * the same native `'memory access out of bounds'` fault described above (issue
+ * #192).
+ */
+function ensureJweString(value: unknown): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new InvalidTokenError(
+      `authorize() requires the JWE token as a string, but received ${describeType(value)}`,
+    )
   }
 }
 
@@ -199,8 +247,12 @@ export class VaultKeeper {
    *   retired legacy `'dev'` opt-out sentinel (use `skipTrust: true`).
    * @throws {@link IdentityMismatchError} If `executablePath`'s current hash no
    *   longer matches a previously approved value (TOFU conflict).
+   * @throws TypeError If `secretName` or `secretValue` is not a string (guards
+   *   the WASM boundary against a native memory fault).
    */
   async setup(secretName: string, secretValue: string, options?: SetupOptions): Promise<string> {
+    ensureStringArg(secretName, 'setup() secretName')
+    ensureStringArg(secretValue, 'setup() secretValue')
     return callAsync(() => this.#inner.setup(secretName, secretValue, options ?? {}))
   }
 
@@ -209,8 +261,15 @@ export class VaultKeeper {
    *
    * The returned `claims` never contain the raw secret value. Read the secret
    * through the one-time {@link SecretAccessor} on `result.secret`.
+   *
+   * @throws {@link InvalidTokenError} If `jwe` is not a string (e.g. a number,
+   *   object, or an un-awaited `setup()` Promise) or is a malformed token
+   *   string. The non-string guard runs before the value crosses into WASM,
+   *   turning what would otherwise be an opaque native memory fault into this
+   *   typed error.
    */
   authorize(jwe: string): AuthorizeResult {
+    ensureJweString(jwe)
     const auth = callSync(() => this.#inner.authorize(jwe))
     // The claims/response getters deserialize on the WASM side and can throw,
     // so route them through callSync too — every throw from authorize() must
@@ -246,18 +305,37 @@ export class VaultKeeper {
     return callSync(() => this.#inner.config())
   }
 
-  /** Store a secret via the file backend. */
+  /**
+   * Store a secret via the file backend.
+   *
+   * @throws TypeError If `id` or `secret` is not a string (guards the WASM
+   *   boundary against a native memory fault).
+   */
   async store(id: string, secret: string): Promise<void> {
+    ensureStringArg(id, 'store() id')
+    ensureStringArg(secret, 'store() secret')
     await callAsync(() => this.#inner.store(id, secret))
   }
 
-  /** Retrieve a secret via the file backend. */
+  /**
+   * Retrieve a secret via the file backend.
+   *
+   * @throws TypeError If `id` is not a string (guards the WASM boundary against
+   *   a native memory fault).
+   */
   async retrieve(id: string): Promise<string> {
+    ensureStringArg(id, 'retrieve() id')
     return callAsync(() => this.#inner.retrieve(id))
   }
 
-  /** Delete a secret via the file backend. */
+  /**
+   * Delete a secret via the file backend.
+   *
+   * @throws TypeError If `id` is not a string (guards the WASM boundary against
+   *   a native memory fault).
+   */
   async delete(id: string): Promise<void> {
+    ensureStringArg(id, 'delete() id')
     await callAsync(() => this.#inner.delete(id))
   }
 

--- a/packages/vaultkeeper-wasm/src/index.ts
+++ b/packages/vaultkeeper-wasm/src/index.ts
@@ -111,13 +111,18 @@ async function callAsync<T>(fn: () => Promise<T>): Promise<T> {
  * Describe a runtime value's type for a type-guard error message. Distinguishes
  * the cases that actually reach these guards from untyped JS callers — `null`,
  * arrays, and Promises (an un-awaited `setup()` call is a common mistake) — from
- * a bare `typeof`, which would report all three unhelpfully as `'object'`.
+ * a bare `typeof`, which would report all three unhelpfully as `'object'`. The
+ * article is chosen to read cleanly: `undefined` takes none ("received
+ * undefined"), `object` takes "an", every other `typeof` takes "a".
  */
 function describeType(value: unknown): string {
   if (value === null) return 'null'
   if (Array.isArray(value)) return 'an array'
   if (value instanceof Promise) return 'a Promise (did you forget to await?)'
-  return `a ${typeof value}`
+  const type = typeof value
+  if (type === 'undefined') return 'undefined'
+  if (type === 'object') return 'an object'
+  return `a ${type}`
 }
 
 /**

--- a/packages/vaultkeeper-wasm/src/test/sdk.test.ts
+++ b/packages/vaultkeeper-wasm/src/test/sdk.test.ts
@@ -1037,3 +1037,141 @@ describe('@vaultkeeper/wasm filesystem error typing (issue #138)', () => {
     })
   })
 })
+
+/**
+ * Regression tests for issue #192: the wrapper forwarded its arguments straight
+ * into WASM with no JS-side type guard, so a non-string (a number, a plain
+ * object, or — a common mistake — an un-awaited `setup()` Promise) reached
+ * wasm-bindgen's `passStringToWasm0` and crashed the process with an opaque
+ * `VaultError: memory access out of bounds` fault. A malformed token *string*
+ * by contrast already yielded a clean `InvalidTokenError`. Each guarded method
+ * must now reject a non-string with a typed, catchable error *before* the value
+ * crosses the WASM boundary.
+ *
+ * The `@ts-expect-error` directives are load-bearing: the parameters are typed
+ * `string`, so passing a non-string is a deliberate type violation that models
+ * an untyped-JavaScript caller. If a signature were ever widened to accept the
+ * bad type, the directive would fail the build — flagging that these runtime
+ * guards need re-examining.
+ */
+describe('@vaultkeeper/wasm non-string input guards (issue #192)', () => {
+  it('authorize(number) throws a typed InvalidTokenError, not a native fault', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      assert.throws(
+        // @ts-expect-error deliberately passing a non-string to exercise the runtime guard (issue #192)
+        () => vault.authorize(42),
+        (err: unknown) => err instanceof InvalidTokenError && err instanceof VaultError,
+      )
+      vault.dispose()
+    })
+  })
+
+  it('authorize(object) throws a typed InvalidTokenError, not a native fault', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      assert.throws(
+        // @ts-expect-error deliberately passing a non-string to exercise the runtime guard (issue #192)
+        () => vault.authorize({}),
+        (err: unknown) => err instanceof InvalidTokenError && err instanceof VaultError,
+      )
+      vault.dispose()
+    })
+  })
+
+  it('authorize(Promise) — the un-awaited setup() mistake — throws InvalidTokenError, not a native fault', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      // The exact shape of the reported bug: `vault.authorize(vault.setup(...))`
+      // without an intervening `await`. The pending Promise must be rejected by
+      // the guard, never handed to WASM.
+      const unawaitedSetup = vault.setup('oops', 'value', { skipTrust: true })
+      assert.throws(
+        // @ts-expect-error deliberately passing a Promise to exercise the runtime guard (issue #192)
+        () => vault.authorize(unawaitedSetup),
+        (err: unknown) => err instanceof InvalidTokenError && err instanceof VaultError,
+      )
+      // Drain the Promise so it does not surface as an unhandled rejection.
+      await unawaitedSetup
+      vault.dispose()
+    })
+  })
+
+  it('authorize(valid string) is unchanged — a real token still authorizes', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      const token = await vault.setup('guard-key', 'guard-value', { skipTrust: true })
+      const result = vault.authorize(token)
+      assert.equal(
+        result.secret.read((s) => s),
+        'guard-value',
+      )
+      vault.dispose()
+    })
+  })
+
+  it('setup(nonstring secretName) rejects with a TypeError before touching WASM', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      await assert.rejects(
+        // @ts-expect-error deliberately passing a non-string to exercise the runtime guard (issue #192)
+        () => vault.setup(42, 'value', { skipTrust: true }),
+        (err: unknown) => err instanceof TypeError,
+      )
+      vault.dispose()
+    })
+  })
+
+  it('setup(nonstring secretValue) rejects with a TypeError before touching WASM', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      await assert.rejects(
+        // @ts-expect-error deliberately passing a non-string to exercise the runtime guard (issue #192)
+        () => vault.setup('name', {}, { skipTrust: true }),
+        (err: unknown) => err instanceof TypeError,
+      )
+      vault.dispose()
+    })
+  })
+
+  it('store(nonstring id) and store(nonstring secret) reject with a TypeError', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      await assert.rejects(
+        // @ts-expect-error deliberately passing a non-string to exercise the runtime guard (issue #192)
+        () => vault.store(42, 'value'),
+        (err: unknown) => err instanceof TypeError,
+      )
+      await assert.rejects(
+        // @ts-expect-error deliberately passing a non-string to exercise the runtime guard (issue #192)
+        () => vault.store('id', {}),
+        (err: unknown) => err instanceof TypeError,
+      )
+      vault.dispose()
+    })
+  })
+
+  it('retrieve(nonstring id) rejects with a TypeError before touching WASM', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      await assert.rejects(
+        // @ts-expect-error deliberately passing a non-string to exercise the runtime guard (issue #192)
+        () => vault.retrieve(42),
+        (err: unknown) => err instanceof TypeError,
+      )
+      vault.dispose()
+    })
+  })
+
+  it('delete(nonstring id) rejects with a TypeError before touching WASM', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      await assert.rejects(
+        // @ts-expect-error deliberately passing a non-string to exercise the runtime guard (issue #192)
+        () => vault.delete(42),
+        (err: unknown) => err instanceof TypeError,
+      )
+      vault.dispose()
+    })
+  })
+})

--- a/packages/vaultkeeper-wasm/src/test/sdk.test.ts
+++ b/packages/vaultkeeper-wasm/src/test/sdk.test.ts
@@ -1174,4 +1174,28 @@ describe('@vaultkeeper/wasm non-string input guards (issue #192)', () => {
       vault.dispose()
     })
   })
+
+  // The guard message names the offending value's type; the article must read
+  // cleanly ("an object" / "undefined", not "a object" / "a undefined").
+  it('guard error messages pick the right article for each value type', async () => {
+    await withTempDir(async (dir) => {
+      const vault = await createTestVault(dir)
+      await assert.rejects(
+        // @ts-expect-error deliberately passing an object to check the guard message (issue #192)
+        () => vault.retrieve({}),
+        (err: unknown) => err instanceof TypeError && err.message.includes('received an object'),
+      )
+      await assert.rejects(
+        // @ts-expect-error deliberately passing undefined to check the guard message (issue #192)
+        () => vault.retrieve(undefined),
+        (err: unknown) => err instanceof TypeError && err.message.endsWith('received undefined'),
+      )
+      await assert.rejects(
+        // @ts-expect-error deliberately passing a number to check the guard message (issue #192)
+        () => vault.retrieve(42),
+        (err: unknown) => err instanceof TypeError && err.message.includes('received a number'),
+      )
+      vault.dispose()
+    })
+  })
 })


### PR DESCRIPTION
## Problem

Refs #192.

`VaultKeeper.authorize()` (and the other `@vaultkeeper/wasm` wrapper methods) forwarded their arguments straight across the WASM boundary with no JS-side type guard. Any non-string input — a number, a plain object, or (a common mistake) an un-awaited `setup()` Promise — reached wasm-bindgen's `passStringToWasm0`, corrupted its byte read, and crashed the process with an opaque `VaultError: memory access out of bounds` fault. A malformed token *string* by contrast already yielded a clean `InvalidTokenError`.

## Fix (wrapper-only)

Each wrapper method that forwards a string into WASM now validates the JS type at the boundary, **before** the value crosses into WebAssembly. Two small module-level guards (`ensureStringArg`, `ensureJweString`) share one `typeof x === 'string'` check, differing only in the typed error they raise:

| Method | Guarded string args | Error on non-string |
|---|---|---|
| `authorize(jwe)` | `jwe` | `InvalidTokenError` |
| `setup(secretName, secretValue, options)` | `secretName`, `secretValue` | `TypeError` |
| `store(id, secret)` | `id`, `secret` | `TypeError` |
| `retrieve(id)` | `id` | `TypeError` |
| `delete(id)` | `id` | `TypeError` |

**Why `authorize` differs:** its argument *is* a JWE token, so a non-string is surfaced as `InvalidTokenError` — the same typed error a malformed token string already produces — keeping all bad-token input to `authorize()` catchable under one type. The other methods take a secret name / id / value (not a token); there is no domain-error subtype for "argument isn't a string", so the JS-standard `TypeError` is the semantically-exact signal, naming the offending method and parameter.

The generic guard's error message distinguishes `null`, arrays, and `Promise` (the un-awaited-`setup()` case) from a bare `typeof`.

## Audit

All string-forwarding wrapper methods were checked against the generated wasm-bindgen glue (`passStringToWasm0` call sites): `authorize`, `setup` (two string args), `store` (two), `retrieve`, `delete`. `options` objects are passed by reference (never marshaled as a raw string) and need no guard.

## The `.wasm` artifact is untouched

This is a wrapper-level input-validation fix. No Rust change, no `wasm-pack` rebuild — `git status` shows no change under `packages/vaultkeeper-wasm/wasm/`.

## Tests

New `node:test` regression suite (`non-string input guards (issue #192)`): `authorize(number|object|Promise)` → typed `InvalidTokenError` (not a native fault); `authorize(valid string)` unchanged; `setup`/`store`/`retrieve`/`delete` non-string args → `TypeError`. The deliberate wrong-type calls use `@ts-expect-error` (parameters are typed `string`), so widening a signature to accept the bad type would fail the build and flag that these runtime guards need re-examining.

## Verification

- `pnpm --filter @vaultkeeper/wasm test` — 70 passed (9 new)
- `pnpm check` (typecheck + lint + format + api-report) — green
- `pnpm check:api-docs` — `docs/api/` up to date (regenerated for the new `@throws` JSDoc)
- `pnpm test` (full vitest workspace) — 151 passed
