### PR TITLE
Insert redaction replacements verbatim; lock the literal-matching contract

### DIFF
--- a/docs/api/vaultkeeper.md
+++ b/docs/api/vaultkeeper.md
@@ -450,6 +450,8 @@ Before redacting, the secret set is normalized so masking is complete and order-
 
 - \*\*Empty/whitespace-only values are dropped.\*\* An empty string matches between every character, and a whitespace-only value matches ubiquitous whitespace, so redacting either would blank the text rather than a secret. - \*\*Duplicates are removed\*\* so each distinct value is processed once. - \*\*Longer values are redacted first.\*\* If one secret is a substring or prefix of another — common for keys that share a prefix — redacting the shorter one first would leave the longer secret's remaining suffix visible (redacting `"abc"` before `"abc123"` yields `"[REDACTED]123"`<!-- -->, leaking `"123"`<!-- -->). Sorting by length descending guarantees each longer value is fully masked before any shorter substring pass runs.
 
+Both arguments are treated fully literally: the secret is matched as a plain substring (never as a regular expression), and `replacement` is inserted verbatim — `String.prototype.replaceAll`<!-- -->'s `$`<!-- -->-substitution patterns are disabled, since a replacement containing `$&` would otherwise re-expand to the matched secret and silently defeat the redaction.
+
 
 </td></tr>
 <tr><td>

--- a/docs/api/vaultkeeper.redactsecrets.md
+++ b/docs/api/vaultkeeper.redactsecrets.md
@@ -12,6 +12,8 @@ Before redacting, the secret set is normalized so masking is complete and order-
 
 - \*\*Empty/whitespace-only values are dropped.\*\* An empty string matches between every character, and a whitespace-only value matches ubiquitous whitespace, so redacting either would blank the text rather than a secret. - \*\*Duplicates are removed\*\* so each distinct value is processed once. - \*\*Longer values are redacted first.\*\* If one secret is a substring or prefix of another — common for keys that share a prefix — redacting the shorter one first would leave the longer secret's remaining suffix visible (redacting `"abc"` before `"abc123"` yields `"[REDACTED]123"`<!-- -->, leaking `"123"`<!-- -->). Sorting by length descending guarantees each longer value is fully masked before any shorter substring pass runs.
 
+Both arguments are treated fully literally: the secret is matched as a plain substring (never as a regular expression), and `replacement` is inserted verbatim — `String.prototype.replaceAll`<!-- -->'s `$`<!-- -->-substitution patterns are disabled, since a replacement containing `$&` would otherwise re-expand to the matched secret and silently defeat the redaction.
+
 **Signature:**
 
 ```typescript
@@ -80,7 +82,7 @@ string
 
 </td><td>
 
-_(Optional)_ The token to substitute for each occurrence. Defaults to [REDACTED](./vaultkeeper.redacted.md)<!-- -->.
+_(Optional)_ The token to substitute for each occurrence, inserted literally. Defaults to [REDACTED](./vaultkeeper.redacted.md)<!-- -->.
 
 
 </td></tr>

--- a/packages/vaultkeeper/src/access/redact.ts
+++ b/packages/vaultkeeper/src/access/redact.ts
@@ -35,11 +35,17 @@ export const REDACTED = '[REDACTED]'
  *   `"123"`). Sorting by length descending guarantees each longer value is
  *   fully masked before any shorter substring pass runs.
  *
+ * Both arguments are treated fully literally: the secret is matched as a
+ * plain substring (never as a regular expression), and `replacement` is
+ * inserted verbatim — `String.prototype.replaceAll`'s `$`-substitution
+ * patterns are disabled, since a replacement containing `$&` would otherwise
+ * re-expand to the matched secret and silently defeat the redaction.
+ *
  * @param text - The text to scrub.
  * @param secrets - The secret values to redact. Every non-empty, non-whitespace
  *   value has all of its occurrences replaced.
- * @param replacement - The token to substitute for each occurrence. Defaults to
- *   {@link REDACTED}.
+ * @param replacement - The token to substitute for each occurrence, inserted
+ *   literally. Defaults to {@link REDACTED}.
  * @returns `text` with every occurrence of each redactable secret replaced.
  *
  * @public
@@ -53,9 +59,12 @@ export function redactSecrets(
     .filter((secret) => secret.trim().length > 0)
     .sort((a, b) => b.length - a.length)
 
+  // '$' doubles to '$$' so replaceAll inserts the replacement verbatim
+  // instead of interpreting $&/$`/$' substitution patterns.
+  const literalReplacement = replacement.replaceAll('$', '$$$$')
   let result = text
   for (const secret of ordered) {
-    result = result.replaceAll(secret, replacement)
+    result = result.replaceAll(secret, literalReplacement)
   }
   return result
 }

--- a/packages/vaultkeeper/test/unit/access/redact.test.ts
+++ b/packages/vaultkeeper/test/unit/access/redact.test.ts
@@ -72,4 +72,24 @@ describe('redactSecrets', () => {
   it('exposes REDACTED as the default token', () => {
     expect(REDACTED).toBe('[REDACTED]')
   })
+
+  // Regression guards for the literal-matching contract (PR #195 review).
+  // replaceAll with a string pattern is spec-literal today, but redactSecrets
+  // is a public shared API — a future refactor to RegExp-based replacement
+  // would silently reintroduce metacharacter interpretation.
+  it('matches secrets containing regex metacharacters literally', () => {
+    const secret = 'a.b*c$1(x)[y]+?'
+    expect(redactSecrets(`token=${secret};`, [secret])).toBe(`token=${REDACTED};`)
+    // A near-miss that a regex interpretation of '.' or '*' would match:
+    expect(redactSecrets('token=aXbbbc11xxyy;', [secret])).toBe('token=aXbbbc11xxyy;')
+  })
+
+  // '$&' in a replacement string re-expands to the matched substring — i.e.
+  // the secret itself. The replacement must be inserted verbatim so a custom
+  // token can never accidentally preserve what it was meant to erase.
+  it('inserts the replacement literally — $-substitution patterns cannot re-expand the secret', () => {
+    expect(redactSecrets('key=hunter2', ['hunter2'], '<$&>')).toBe('key=<$&>')
+    expect(redactSecrets('key=hunter2', ['hunter2'], '$$ paid')).toBe('key=$$ paid')
+    expect(redactSecrets('key=hunter2', ['hunter2'], "$'")).toBe("key=$'")
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up from the #195 review (that PR merged while review was in flight). `String.prototype.replaceAll` interprets `$`-substitution patterns in a **string replacement**: a caller of the newly-public `redactSecrets` passing a custom replacement containing `$&` would re-expand it to the matched substring — i.e. the secret itself — silently defeating the redaction it asked for (`redactSecrets(out, [secret], '<$&>')` returned `<hunter2>`). The replacement now has `$` doubled before use, so it is always inserted verbatim, and the JSDoc documents the fully-literal contract for both arguments.

Also locks in the two literal-matching guarantees with regression tests so a future refactor (e.g. to RegExp-based replacement for perf) can't silently reintroduce interpretation on either side:
- secrets containing regex metacharacters match literally (with a near-miss negative case);
- `$&` / `$$` / `` $' `` in a replacement are inserted verbatim.

Rebased onto the merged #195's improvements (dedup, whitespace-skip, longest-first ordering) — this composes with them, touching only the replacement side. `docs/api/` regenerated for the JSDoc change. No changeset impact beyond #195's existing minor (this corrects behavior of the not-yet-released export).

## Test plan

- [x] `test/unit/access/redact.test.ts` — 12/12 (including the two new regression groups)
- [x] `pnpm build && pnpm generate:api-docs` — committed regen
- [x] Prettier clean

Refs #195, #189