### PR TITLE
Document the argument-validation TypeError carve-out in the wasm error contract

### DIFF
--- a/packages/vaultkeeper-wasm/src/errors.ts
+++ b/packages/vaultkeeper-wasm/src/errors.ts
@@ -3,8 +3,17 @@
  *
  * Mirrors the `VaultError` hierarchy of the pure-TypeScript `vaultkeeper`
  * library so that consumers of `@vaultkeeper/wasm` can rely on the same
- * ecosystem-wide contract: every error thrown by the SDK is an instance of
- * {@link VaultError}.
+ * ecosystem-wide contract: every *operational* error thrown by the SDK is an
+ * instance of {@link VaultError}.
+ *
+ * One deliberate exception: passing a wrongly-typed argument (e.g. a
+ * non-string secret name) throws a built-in `TypeError` — Node's own
+ * convention for programmer errors — rather than a `VaultError` subclass.
+ * `authorize()` is the special case that throws `InvalidTokenError` for a
+ * non-string token, since a malformed token is an operational condition its
+ * callers already handle. A `catch (e) { if (e instanceof VaultError) ... }`
+ * handler therefore covers every runtime failure, but not caller-side type
+ * mistakes, which indicate a bug to fix rather than a condition to handle.
  *
  * The Rust/WASM core throws values tagged with a stable `vaultErrorCode`;
  * {@link mapWasmError} reconstructs the matching typed instance at the bridge


### PR DESCRIPTION
## Summary

Follow-up from the #194 review (merged before the item was resolved). The guards it added throw built-in `TypeError` for wrongly-typed arguments on `setup()`/`store()`/`retrieve()`/`delete()`, while `errors.ts`'s module doc still promised "every error thrown by the SDK is an instance of `VaultError`" — a blanket `instanceof VaultError` handler misses them, making the documented contract silently false.

Of the two resolutions offered in review, the merge settled on keeping `TypeError` (Node's own convention for programmer errors), so this lands the matching doc amendment: the module doc now scopes the promise to *operational* errors, states the argument-validation exception explicitly, and explains why `authorize()` differs (`InvalidTokenError` — a malformed token is an operational condition its callers already handle).

Doc-only; no behavior change, no changeset (matches the #155 precedent for non-published-behavior changes — though note this JSDoc ships in the tarball's `.d.ts`, the *behavior* is unchanged). 71/71 wasm tests pass.

Refs #194, #192