### PR TITLE
Defer TOFU trust-manifest write until setup() actually succeeds

### DIFF
--- a/.changeset/defer-tofu-manifest-write.md
+++ b/.changeset/defer-tofu-manifest-write.md
@@ -1,0 +1,9 @@
+---
+'vaultkeeper': patch
+---
+
+Fix `VaultKeeper.setup()` recording TOFU (trust-on-first-use) trust for an executable before confirming the secret actually exists.
+
+`#resolveExecutableIdentity` ran trust verification — which durably records a first-encounter or Sigstore hash in the trust manifest — before `backend.retrieve()`. A `setup()` call for a nonexistent secret therefore still left the caller's hash permanently approved, letting an attacker (or a typo'd script) pre-seed TOFU trust without ever completing a legitimate first encounter; a later, real first encounter would then silently match the pre-seeded hash instead of being verified as new.
+
+Trust verification is now split into a verify phase (computes the hash and classifies it against the manifest, staging but not writing any first-encounter/Sigstore update) and a commit phase that only runs after `setup()`'s secret retrieval and token minting succeed. Shape validation (missing/conflicting/legacy-`'dev'`-sentinel trust choices) still fails fast before any backend read, and a TOFU hash conflict still fails without ever recording the new hash — only the successful first-encounter write is deferred.

--- a/packages/vaultkeeper/src/identity/index.ts
+++ b/packages/vaultkeeper/src/identity/index.ts
@@ -5,6 +5,7 @@
 export type {
   IdentityInfo,
   TrustVerificationResult,
+  PendingTrust,
   TrustOptions,
   TrustManifestEntry,
   TrustManifest,
@@ -14,6 +15,6 @@ export { hashExecutable } from './hash.js'
 
 export { loadManifest, saveManifest, addTrustedHash, isTrusted } from './manifest.js'
 
-export { verifyTrust } from './trust.js'
+export { verifyTrust, verifyTrustPending, commitTrust } from './trust.js'
 
 export { CapabilityToken, createCapabilityToken, validateCapabilityToken } from './session.js'

--- a/packages/vaultkeeper/src/identity/trust.ts
+++ b/packages/vaultkeeper/src/identity/trust.ts
@@ -51,15 +51,15 @@ async function trySigstore(execPath: string): Promise<boolean> {
  * executable's hash and classifies it against the existing manifest state,
  * but a first-encounter (Tier 3) or Sigstore (Tier 1) result — which would
  * otherwise record a new hash — is only staged on
- * {@link PendingTrust.manifestToSave}. Nothing is persisted until the caller
+ * {@link PendingTrust.pendingWrite}. Nothing is persisted until the caller
  * invokes {@link commitTrust} with the returned value, which callers should do
  * only once the operation the trust decision was gating (e.g. reading the
  * secret) has actually succeeded. This prevents a failed operation from
  * durably pre-seeding TOFU trust for an executable that never completed a
  * legitimate first encounter.
  *
- * A TOFU conflict never stages a write (`manifestToSave` is `undefined`) —
- * the pre-existing manifest state is authoritative and a conflict must always
+ * A TOFU conflict never stages a write (`pendingWrite` is `undefined`) — the
+ * pre-existing manifest state is authoritative and a conflict must always
  * fail without recording the new, unapproved hash.
  *
  * @param execPath - Path to the executable, or `"dev"` to enable dev-mode bypass.
@@ -79,7 +79,7 @@ export async function verifyTrustPending(
       tofuConflict: false,
       approvedHashes: [],
       reason: 'Dev mode — hash verification skipped',
-      manifestToSave: undefined,
+      pendingWrite: undefined,
       configDir,
     }
   }
@@ -104,7 +104,7 @@ export async function verifyTrustPending(
         tofuConflict: false,
         approvedHashes,
         reason: 'Sigstore bundle verified',
-        manifestToSave: addTrustedHash(manifest, namespace, currentHash),
+        pendingWrite: { namespace, hash: currentHash },
         configDir,
       }
     }
@@ -117,7 +117,7 @@ export async function verifyTrustPending(
       tofuConflict: false,
       approvedHashes,
       reason: 'Hash found in trust manifest',
-      manifestToSave: undefined,
+      pendingWrite: undefined,
       configDir,
     }
   }
@@ -132,7 +132,7 @@ export async function verifyTrustPending(
       tofuConflict: true,
       approvedHashes,
       reason: `Hash changed from a previously approved value — re-approval required`,
-      manifestToSave: undefined,
+      pendingWrite: undefined,
       configDir,
     }
   }
@@ -143,26 +143,36 @@ export async function verifyTrustPending(
     tofuConflict: false,
     approvedHashes,
     reason: 'First encounter — hash recorded via TOFU',
-    manifestToSave: addTrustedHash(manifest, namespace, currentHash),
+    pendingWrite: { namespace, hash: currentHash },
     configDir,
   }
 }
 
 /**
  * Commit phase of the verify/commit split: persist a {@link PendingTrust}'s
- * staged manifest update, if any.
+ * staged namespace/hash entry, if any.
  *
- * A no-op when {@link PendingTrust.manifestToSave} is `undefined` (a registry
+ * A no-op when {@link PendingTrust.pendingWrite} is `undefined` (a registry
  * match, a TOFU conflict, or dev-mode bypass never write).
+ *
+ * Verification and commit are not atomic — another process can write to the
+ * manifest in between (e.g. approving a different executable, or the same
+ * one). To avoid clobbering that concurrent write, this reloads the manifest
+ * from disk immediately before saving and unions `pendingWrite` into the
+ * *current* state, rather than persisting the snapshot captured back in
+ * {@link verifyTrustPending}.
  *
  * @param pending - The result of {@link verifyTrustPending} to commit.
  * @internal
  */
 export async function commitTrust(pending: PendingTrust): Promise<void> {
-  if (pending.manifestToSave === undefined) {
+  if (pending.pendingWrite === undefined) {
     return
   }
-  await saveManifest(pending.configDir, pending.manifestToSave)
+  const { namespace, hash } = pending.pendingWrite
+  const current = await loadManifest(pending.configDir)
+  const merged = addTrustedHash(current, namespace, hash)
+  await saveManifest(pending.configDir, merged)
 }
 
 /**

--- a/packages/vaultkeeper/src/identity/trust.ts
+++ b/packages/vaultkeeper/src/identity/trust.ts
@@ -138,11 +138,13 @@ export async function verifyTrustPending(
   }
 
   // --- Tier 3: First encounter — stage the hash for TOFU recording ---
+  // `reason` describes staging, not persistence: nothing is written until a
+  // caller invokes commitTrust (see PendingTrust.pendingWrite above).
   return {
     identity: { hash: currentHash, trustTier: 3, verified: false },
     tofuConflict: false,
     approvedHashes,
-    reason: 'First encounter — hash recorded via TOFU',
+    reason: 'First encounter — hash staged for TOFU recording',
     pendingWrite: { namespace, hash: currentHash },
     configDir,
   }
@@ -195,6 +197,15 @@ export async function verifyTrust(
 ): Promise<TrustVerificationResult> {
   const pending = await verifyTrustPending(execPath, options)
   await commitTrust(pending)
-  const { identity, tofuConflict, approvedHashes, reason } = pending
+  const { identity, tofuConflict, approvedHashes, pendingWrite } = pending
+  // verifyTrustPending's `reason` describes staging, since verification alone
+  // never writes. This wrapper just committed the write above, though, so a
+  // first-encounter result should keep its pre-split, persisted-tense wording
+  // for existing external callers rather than surfacing "staged" language for
+  // something that, by this point, has actually been recorded.
+  const reason =
+    pendingWrite !== undefined && identity.trustTier === 3
+      ? 'First encounter — hash recorded via TOFU'
+      : pending.reason
   return { identity, tofuConflict, approvedHashes, reason }
 }

--- a/packages/vaultkeeper/src/identity/trust.ts
+++ b/packages/vaultkeeper/src/identity/trust.ts
@@ -15,7 +15,7 @@
 
 import { hashExecutable } from './hash.js'
 import { loadManifest, saveManifest, addTrustedHash, isTrusted } from './manifest.js'
-import type { TrustVerificationResult, TrustOptions } from './types.js'
+import type { TrustVerificationResult, TrustOptions, PendingTrust } from './types.js'
 
 /** Attempt Sigstore bundle verification (Tier 1). Returns `true` on success. */
 async function trySigstore(execPath: string): Promise<boolean> {
@@ -44,16 +44,34 @@ async function trySigstore(execPath: string): Promise<boolean> {
 }
 
 /**
- * Verify the trust tier of the executable at `execPath`.
+ * Verify the trust tier of the executable at `execPath` without writing
+ * anything to the trust manifest.
+ *
+ * This is the verify phase of the verify/commit split: it computes the
+ * executable's hash and classifies it against the existing manifest state,
+ * but a first-encounter (Tier 3) or Sigstore (Tier 1) result — which would
+ * otherwise record a new hash — is only staged on
+ * {@link PendingTrust.manifestToSave}. Nothing is persisted until the caller
+ * invokes {@link commitTrust} with the returned value, which callers should do
+ * only once the operation the trust decision was gating (e.g. reading the
+ * secret) has actually succeeded. This prevents a failed operation from
+ * durably pre-seeding TOFU trust for an executable that never completed a
+ * legitimate first encounter.
+ *
+ * A TOFU conflict never stages a write (`manifestToSave` is `undefined`) —
+ * the pre-existing manifest state is authoritative and a conflict must always
+ * fail without recording the new, unapproved hash.
  *
  * @param execPath - Path to the executable, or `"dev"` to enable dev-mode bypass.
  * @param options  - Optional trust configuration.
  * @internal
  */
-export async function verifyTrust(
+export async function verifyTrustPending(
   execPath: string,
   options?: TrustOptions,
-): Promise<TrustVerificationResult> {
+): Promise<PendingTrust> {
+  const configDir = options?.configDir ?? '.vaultkeeper'
+
   // Dev-mode bypass: skip all verification for the sentinel value "dev".
   if (execPath === 'dev') {
     return {
@@ -61,10 +79,11 @@ export async function verifyTrust(
       tofuConflict: false,
       approvedHashes: [],
       reason: 'Dev mode — hash verification skipped',
+      manifestToSave: undefined,
+      configDir,
     }
   }
 
-  const configDir = options?.configDir ?? '.vaultkeeper'
   const namespace = options?.namespace ?? execPath
 
   // Compute the current hash of the executable.
@@ -80,13 +99,13 @@ export async function verifyTrust(
   if (options?.skipSigstore !== true) {
     const sigstoreVerified = await trySigstore(execPath)
     if (sigstoreVerified) {
-      const updated = addTrustedHash(manifest, namespace, currentHash)
-      await saveManifest(configDir, updated)
       return {
         identity: { hash: currentHash, trustTier: 1, verified: true },
         tofuConflict: false,
         approvedHashes,
         reason: 'Sigstore bundle verified',
+        manifestToSave: addTrustedHash(manifest, namespace, currentHash),
+        configDir,
       }
     }
   }
@@ -98,28 +117,74 @@ export async function verifyTrust(
       tofuConflict: false,
       approvedHashes,
       reason: 'Hash found in trust manifest',
+      manifestToSave: undefined,
+      configDir,
     }
   }
 
   // --- TOFU check ---
   const existing = manifest.get(namespace)
   if (existing !== undefined && existing.hashes.length > 0) {
-    // The namespace is known but the current hash is not approved — TOFU conflict.
+    // The namespace is known but the current hash is not approved — TOFU
+    // conflict. Never stage a write: the new hash must not be recorded.
     return {
       identity: { hash: currentHash, trustTier: 3, verified: false },
       tofuConflict: true,
       approvedHashes,
       reason: `Hash changed from a previously approved value — re-approval required`,
+      manifestToSave: undefined,
+      configDir,
     }
   }
 
-  // --- Tier 3: First encounter — record via TOFU ---
-  const updated = addTrustedHash(manifest, namespace, currentHash)
-  await saveManifest(configDir, updated)
+  // --- Tier 3: First encounter — stage the hash for TOFU recording ---
   return {
     identity: { hash: currentHash, trustTier: 3, verified: false },
     tofuConflict: false,
     approvedHashes,
     reason: 'First encounter — hash recorded via TOFU',
+    manifestToSave: addTrustedHash(manifest, namespace, currentHash),
+    configDir,
   }
+}
+
+/**
+ * Commit phase of the verify/commit split: persist a {@link PendingTrust}'s
+ * staged manifest update, if any.
+ *
+ * A no-op when {@link PendingTrust.manifestToSave} is `undefined` (a registry
+ * match, a TOFU conflict, or dev-mode bypass never write).
+ *
+ * @param pending - The result of {@link verifyTrustPending} to commit.
+ * @internal
+ */
+export async function commitTrust(pending: PendingTrust): Promise<void> {
+  if (pending.manifestToSave === undefined) {
+    return
+  }
+  await saveManifest(pending.configDir, pending.manifestToSave)
+}
+
+/**
+ * Verify the trust tier of the executable at `execPath`, recording any
+ * first-encounter (TOFU) or Sigstore hash immediately.
+ *
+ * This is an eager convenience wrapper around {@link verifyTrustPending} +
+ * {@link commitTrust} for callers that don't need to defer the manifest write
+ * until after a later operation succeeds. {@link VaultKeeper.setup} uses the
+ * split form directly so a failed `setup()` call never pre-seeds the trust
+ * manifest — see issue #148.
+ *
+ * @param execPath - Path to the executable, or `"dev"` to enable dev-mode bypass.
+ * @param options  - Optional trust configuration.
+ * @internal
+ */
+export async function verifyTrust(
+  execPath: string,
+  options?: TrustOptions,
+): Promise<TrustVerificationResult> {
+  const pending = await verifyTrustPending(execPath, options)
+  await commitTrust(pending)
+  const { identity, tofuConflict, approvedHashes, reason } = pending
+  return { identity, tofuConflict, approvedHashes, reason }
 }

--- a/packages/vaultkeeper/src/identity/types.ts
+++ b/packages/vaultkeeper/src/identity/types.ts
@@ -43,6 +43,24 @@ export interface TrustVerificationResult {
 }
 
 /**
+ * Result of the verify-only phase of trust verification (see
+ * {@link verifyTrustPending}). No manifest write has happened yet — pass this
+ * to {@link commitTrust} once the caller's operation has actually succeeded to
+ * persist the pending update, or discard it to leave the manifest untouched.
+ * @internal
+ */
+export interface PendingTrust extends TrustVerificationResult {
+  /**
+   * The manifest state to persist once the caller's operation succeeds, or
+   * `undefined` when this verification produced no manifest change — a
+   * registry (Tier 2) match, a TOFU conflict, or dev-mode bypass never write.
+   */
+  readonly manifestToSave: TrustManifest | undefined
+  /** Directory {@link commitTrust} writes `manifestToSave` to, if present. */
+  readonly configDir: string
+}
+
+/**
  * Options controlling how trust verification is performed.
  * @internal
  */

--- a/packages/vaultkeeper/src/identity/types.ts
+++ b/packages/vaultkeeper/src/identity/types.ts
@@ -51,12 +51,20 @@ export interface TrustVerificationResult {
  */
 export interface PendingTrust extends TrustVerificationResult {
   /**
-   * The manifest state to persist once the caller's operation succeeds, or
-   * `undefined` when this verification produced no manifest change — a
-   * registry (Tier 2) match, a TOFU conflict, or dev-mode bypass never write.
+   * The namespace/hash entry to add to the manifest once the caller's
+   * operation succeeds, or `undefined` when this verification has nothing to
+   * record — a registry (Tier 2) match, a TOFU conflict, or dev-mode bypass
+   * never write.
+   *
+   * {@link commitTrust} reloads the manifest from disk at commit time and
+   * unions this entry in, rather than persisting a snapshot captured during
+   * verification. That matters because verification and commit are not
+   * atomic: another process could approve a *different* executable (or the
+   * same one) in between. Persisting a stale snapshot would silently drop
+   * that concurrent write; merging preserves it.
    */
-  readonly manifestToSave: TrustManifest | undefined
-  /** Directory {@link commitTrust} writes `manifestToSave` to, if present. */
+  readonly pendingWrite: { readonly namespace: string; readonly hash: string } | undefined
+  /** Directory {@link commitTrust} writes to, if `pendingWrite` is present. */
   readonly configDir: string
 }
 

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -27,7 +27,7 @@ import { BackendRegistry } from './backend/registry.js'
 import { isSigningBackend } from './backend/types.js'
 import type { SecretBackend, SigningBackend } from './backend/types.js'
 import { createToken, decryptToken, extractKid, validateClaims, blockToken } from './jwe/index.js'
-import { verifyTrust } from './identity/trust.js'
+import { verifyTrustPending, commitTrust } from './identity/trust.js'
 import { hashExecutable } from './identity/hash.js'
 import { loadManifest, saveManifest, addTrustedHash, isTrusted } from './identity/manifest.js'
 import {
@@ -543,7 +543,13 @@ export class VaultKeeper {
     // (plain-JavaScript) caller can pass `undefined` despite the required type,
     // and this call throws ExecutableTrustRequiredError instead of dereferencing
     // `undefined`. Past this point `options` is guaranteed present.
-    const exeIdentity = await this.#resolveExecutableIdentity(options)
+    //
+    // This only *verifies* trust; a first-encounter (TOFU) or Sigstore hash is
+    // staged, not written yet. The manifest write is deferred via
+    // `commitExecutableTrust` until the whole operation succeeds below — see
+    // issue #148 (a failed setup() must never durably pre-seed TOFU trust).
+    const { exeIdentity, commit: commitExecutableTrust } =
+      await this.#resolveExecutableIdentity(options)
 
     const backendType = VaultKeeper.#resolveBackendTypeHint(backend, options.backendType)
     const ttlMinutes = options.ttlMinutes ?? this.#config.defaults.ttlMinutes
@@ -567,7 +573,15 @@ export class VaultKeeper {
     }
 
     const currentKey = this.#keyManager.getCurrentKey()
-    return createToken(currentKey.key, claims, { kid: currentKey.id })
+    const token = createToken(currentKey.key, claims, { kid: currentKey.id })
+
+    // Only now that the secret was retrieved and the token minted does a
+    // first-encounter (or Sigstore) trust decision become a durable manifest
+    // write. A failure anywhere above (e.g. SecretNotFoundError) leaves the
+    // trust manifest untouched.
+    await commitExecutableTrust()
+
+    return token
   }
 
   /**
@@ -1154,16 +1168,28 @@ export class VaultKeeper {
    *
    * Returns the sentinel `'dev'` (no executable binding) when trust is
    * deliberately skipped or the path is on the development-mode allowlist;
-   * otherwise runs TOFU verification and returns the verified hash.
+   * otherwise runs TOFU *verification only* and returns the verified hash
+   * together with a `commit` callback. Verification never writes to the trust
+   * manifest by itself — `commit` stages that write, and the caller
+   * ({@link VaultKeeper.setup}) must invoke it only after the operation trust
+   * was gating has actually succeeded. This is the fail-fast/defer-write split
+   * from issue #148: shape validation (missing/conflicting/legacy-sentinel)
+   * still throws immediately here, before any backend read, but a
+   * first-encounter or Sigstore hash is not durably recorded until `commit`
+   * runs.
    *
    * @throws {ExecutableTrustRequiredError} If neither `executablePath` nor
    *   `skipTrust: true` is provided, if both are, or if `executablePath` is the
    *   retired legacy `'dev'` opt-out sentinel.
-   * @throws {IdentityMismatchError} On a TOFU hash conflict.
+   * @throws {IdentityMismatchError} On a TOFU hash conflict. Conflicts never
+   *   stage a manifest write regardless of whether `commit` is later called.
    */
-  async #resolveExecutableIdentity(options: TrustChoiceInput | undefined): Promise<string> {
+  async #resolveExecutableIdentity(
+    options: TrustChoiceInput | undefined,
+  ): Promise<{ exeIdentity: string; commit: () => Promise<void> }> {
     const executablePath = options?.executablePath
     const skipTrust = options?.skipTrust === true
+    const noCommit = (): Promise<void> => Promise.resolve()
 
     if (skipTrust && executablePath !== undefined) {
       throw new ExecutableTrustRequiredError(
@@ -1178,7 +1204,7 @@ export class VaultKeeper {
     if (skipTrust) {
       // Explicit, greppable development-only opt-out: no executable identity is
       // bound. See the security warning on SetupOptions.skipTrust.
-      return 'dev'
+      return { exeIdentity: 'dev', commit: noCommit }
     }
 
     if (executablePath === undefined) {
@@ -1210,27 +1236,33 @@ export class VaultKeeper {
     // A real path may still be exempted via the established development-mode
     // allowlist (setDevelopmentMode); otherwise run full TOFU verification.
     if (this.#isDevModeExecutable(executablePath)) {
-      return 'dev'
+      return { exeIdentity: 'dev', commit: noCommit }
     }
 
     // Resolve to an absolute path before verification so the manifest is keyed
     // consistently with approveExecutable() and checkExecutableTrust(), both of
     // which resolve. A relative path approved earlier (stored under its absolute
     // key) therefore matches here too.
-    const trustResult = await verifyTrust(path.resolve(executablePath), {
+    //
+    // verifyTrustPending only *verifies* — a first-encounter or Sigstore hash
+    // is staged on the returned value, not written. Committing it is deferred
+    // to the caller (see #148).
+    const pending = await verifyTrustPending(path.resolve(executablePath), {
       configDir: this.#configDir,
     })
-    if (trustResult.tofuConflict) {
+    if (pending.tofuConflict) {
       // On a conflict the manifest holds at least one prior approved hash;
-      // report the most recently approved one as the previous hash.
-      const previousHash = trustResult.approvedHashes.at(-1) ?? trustResult.identity.hash
+      // report the most recently approved one as the previous hash. Nothing
+      // was staged for this conflict (verifyTrustPending never stages a write
+      // on tofuConflict), so there is nothing to avoid committing here.
+      const previousHash = pending.approvedHashes.at(-1) ?? pending.identity.hash
       throw new IdentityMismatchError(
         'Executable hash changed — re-approval required',
         previousHash,
-        trustResult.identity.hash,
+        pending.identity.hash,
       )
     }
-    return trustResult.identity.hash
+    return { exeIdentity: pending.identity.hash, commit: () => commitTrust(pending) }
   }
 
   async #decryptWithKeyResolution(

--- a/packages/vaultkeeper/test/helpers/backend.ts
+++ b/packages/vaultkeeper/test/helpers/backend.ts
@@ -3,6 +3,7 @@
  */
 
 import type { SecretBackend } from '../../src/backend/types.js'
+import { SecretNotFoundError } from '../../src/errors.js'
 
 /**
  * Create a fully in-memory `SecretBackend` suitable for unit and e2e tests.
@@ -21,7 +22,10 @@ export function createInMemoryBackend(): SecretBackend {
     retrieve: (id: string) => {
       const val = store.get(id)
       if (val === undefined) {
-        return Promise.reject(new Error(`Secret not found: ${id}`))
+        // Match the SecretBackend.retrieve contract (@throws SecretNotFoundError)
+        // that every real backend implementation honors, so tests exercising
+        // this helper observe the same typed error callers rely on.
+        return Promise.reject(new SecretNotFoundError(`Secret not found: ${id}`))
       }
       return Promise.resolve(val)
     },

--- a/packages/vaultkeeper/test/integration/vault-trust.test.ts
+++ b/packages/vaultkeeper/test/integration/vault-trust.test.ts
@@ -74,10 +74,17 @@ async function writeExecutable(name: string, contents: string): Promise<string> 
 }
 
 async function manifestExists(): Promise<boolean> {
-  return fs
-    .access(path.join(configDir, 'trust-manifest.json'))
-    .then(() => true)
-    .catch(() => false)
+  try {
+    await fs.access(path.join(configDir, 'trust-manifest.json'))
+    return true
+  } catch (err) {
+    // Only a missing file means "does not exist" — any other failure (e.g.
+    // EACCES) is a real problem and must not be silently reported as absence.
+    if (typeof err === 'object' && err !== null && 'code' in err && err.code === 'ENOENT') {
+      return false
+    }
+    throw err
+  }
 }
 
 async function readManifestEntries(): Promise<Record<string, unknown>> {

--- a/packages/vaultkeeper/test/integration/vault-trust.test.ts
+++ b/packages/vaultkeeper/test/integration/vault-trust.test.ts
@@ -14,6 +14,7 @@
  * @see ../../src/identity/manifest.ts
  * @see https://github.com/mike-north/vaultkeeper/issues/57
  * @see https://github.com/mike-north/vaultkeeper/issues/123
+ * @see https://github.com/mike-north/vaultkeeper/issues/148
  */
 
 import * as crypto from 'node:crypto'
@@ -29,6 +30,7 @@ import {
   ExecutableTrustRequiredError,
   FilesystemError,
   BackendUnavailableError,
+  SecretNotFoundError,
 } from '../../src/index.js'
 import type { VaultConfig, SecretBackend } from '../../src/index.js'
 import { createInMemoryBackend } from '../helpers/backend.js'
@@ -69,6 +71,13 @@ async function writeExecutable(name: string, contents: string): Promise<string> 
   const p = path.join(scratchDir, name)
   await fs.writeFile(p, contents, { mode: 0o755 })
   return p
+}
+
+async function manifestExists(): Promise<boolean> {
+  return fs
+    .access(path.join(configDir, 'trust-manifest.json'))
+    .then(() => true)
+    .catch(() => false)
 }
 
 async function readManifestEntries(): Promise<Record<string, unknown>> {
@@ -267,14 +276,85 @@ describe('exec approval recording (setup) → subsequent trust', () => {
   })
 })
 
-describe('setup() requires an explicit executable-trust choice (#123)', () => {
-  async function manifestExists(): Promise<boolean> {
-    return fs
-      .access(path.join(configDir, 'trust-manifest.json'))
-      .then(() => true)
-      .catch(() => false)
-  }
+describe('setup() defers the TOFU manifest write until the operation succeeds (#148)', () => {
+  // AC2 + AC3: the exact scenario from #148. Previously #resolveExecutableIdentity
+  // ran verifyTrust() — which records a first-encounter (or Sigstore) hash
+  // immediately — before backend.retrieve(); a SecretNotFoundError from a
+  // nonexistent secret therefore still left the caller's hash durably recorded,
+  // letting an attacker (or a typo'd script) pre-seed TOFU trust without ever
+  // completing a legitimate first encounter. The manifest write must now be
+  // deferred until setup() actually succeeds.
+  it('throws SecretNotFoundError for a nonexistent secret and leaves the manifest untouched', async () => {
+    const caller = await writeExecutable('caller', 'first-encounter-bytes\n')
+    const vault = await createVault()
+    // Deliberately no backend.store() call — 'MISSING_SECRET' does not exist.
 
+    await expect(vault.setup('MISSING_SECRET', { executablePath: caller })).rejects.toBeInstanceOf(
+      SecretNotFoundError,
+    )
+
+    // The failed call must not have pre-seeded TOFU trust for `caller`: no
+    // manifest file at all, and a later legitimate first encounter is still
+    // untrusted rather than silently matching the pre-seeded hash.
+    expect(await manifestExists()).toBe(false)
+    expect((await vault.checkExecutableTrust(caller)).trusted).toBe(false)
+  })
+
+  // The write is deferred, not removed: a setup() call that actually succeeds
+  // still records the first-encounter hash exactly as before.
+  it('still records the first-encounter hash when the secret exists and setup() succeeds', async () => {
+    await backend.store('API_KEY', 's3cr3t')
+    const caller = await writeExecutable('caller', 'success-bytes\n')
+    const vault = await createVault()
+
+    await vault.setup('API_KEY', { executablePath: caller })
+
+    const entries = await readManifestEntries()
+    expect(Object.keys(entries)).toEqual([path.resolve(caller)])
+    expect((await vault.checkExecutableTrust(caller)).trusted).toBe(true)
+  })
+
+  // A matching re-encounter (Tier 2 registry match) has nothing to stage —
+  // it must keep succeeding and must not rewrite the manifest.
+  it('a matching re-encounter succeeds without rewriting the manifest', async () => {
+    await backend.store('API_KEY', 's3cr3t')
+    const caller = await writeExecutable('caller', 'stable-bytes\n')
+    const vault = await createVault()
+
+    await vault.setup('API_KEY', { executablePath: caller })
+    const entriesAfterFirst = await readManifestEntries()
+
+    const jwe = await vault.setup('API_KEY', { executablePath: caller })
+    expect(jwe.split('.')).toHaveLength(5)
+
+    const entriesAfterSecond = await readManifestEntries()
+    expect(entriesAfterSecond).toEqual(entriesAfterFirst)
+  })
+
+  // AC4: TOFU-conflict detection must keep using the pre-existing manifest
+  // state and fail before any write — even though the secret exists and
+  // setup() would otherwise succeed, the new (unapproved) hash must never be
+  // recorded.
+  it('a hash conflict throws IdentityMismatchError and never records the new hash', async () => {
+    await backend.store('API_KEY', 's3cr3t')
+    const caller = await writeExecutable('caller', 'v1\n')
+    const approvedHash = sha256Hex('v1\n')
+    const vault = await createVault()
+
+    await vault.setup('API_KEY', { executablePath: caller })
+    await fs.writeFile(caller, 'v2\n', { mode: 0o755 })
+
+    await expect(vault.setup('API_KEY', { executablePath: caller })).rejects.toBeInstanceOf(
+      IdentityMismatchError,
+    )
+
+    // The manifest must still hold only the originally approved hash.
+    const entries = await readManifestEntries()
+    expect(entries[path.resolve(caller)]).toEqual({ hashes: [approvedHash], trustTier: 3 })
+  })
+})
+
+describe('setup() requires an explicit executable-trust choice (#123)', () => {
   // AC1 + AC5: omitting the trust choice throws a typed VaultError subclass —
   // never a plain Error, and never a silent 'dev' fallback. Regression for #123.
   it('throws ExecutableTrustRequiredError when neither executablePath nor skipTrust is given', async () => {

--- a/packages/vaultkeeper/test/unit/identity/trust.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/trust.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { verifyTrust } from '../../../src/identity/trust.js'
+import { verifyTrust, verifyTrustPending, commitTrust } from '../../../src/identity/trust.js'
 import { loadManifest } from '../../../src/identity/manifest.js'
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
@@ -172,6 +172,106 @@ describe('verifyTrust — namespace handling', () => {
       const manifest = await loadManifest(configDir)
       expect(manifest.has('custom-namespace')).toBe(true)
       expect(manifest.has(execPath)).toBe(false)
+    })
+  })
+})
+
+describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () => {
+  it('verifyTrustPending stages a first-encounter hash but does not write it', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')
+      const configDir = path.join(dir, 'config')
+
+      const pending = await verifyTrustPending(execPath, {
+        configDir,
+        namespace: 'my-tool',
+        skipSigstore: true,
+      })
+
+      expect(pending.identity.trustTier).toBe(3)
+      expect(pending.tofuConflict).toBe(false)
+      expect(pending.manifestToSave).toBeDefined()
+      expect(pending.manifestToSave?.has('my-tool')).toBe(true)
+
+      // Nothing was written by the verify phase alone.
+      const manifest = await loadManifest(configDir)
+      expect(manifest.size).toBe(0)
+    })
+  })
+
+  it('commitTrust persists a staged first-encounter hash', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')
+      const configDir = path.join(dir, 'config')
+
+      const pending = await verifyTrustPending(execPath, {
+        configDir,
+        namespace: 'my-tool',
+        skipSigstore: true,
+      })
+      await commitTrust(pending)
+
+      const manifest = await loadManifest(configDir)
+      expect(manifest.has('my-tool')).toBe(true)
+    })
+  })
+
+  it('commitTrust is a no-op when manifestToSave is undefined (e.g. a TOFU conflict)', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'tampered', 'original')
+      const configDir = path.join(dir, 'config')
+
+      // Record the original hash so the next call is a conflict, not a first
+      // encounter.
+      await verifyTrust(execPath, { configDir, namespace: 'tampered', skipSigstore: true })
+      await fs.writeFile(execPath, 'tampered-content', 'utf8')
+
+      const pending = await verifyTrustPending(execPath, {
+        configDir,
+        namespace: 'tampered',
+        skipSigstore: true,
+      })
+      expect(pending.tofuConflict).toBe(true)
+      expect(pending.manifestToSave).toBeUndefined()
+
+      // Committing a conflict result must not throw and must not write.
+      await commitTrust(pending)
+      const manifest = await loadManifest(configDir)
+      expect(manifest.get('tampered')?.hashes).toEqual([pending.approvedHashes.at(-1)])
+    })
+  })
+
+  it('a registry (Tier 2) match stages nothing to commit', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'trusted-tool', 'trusted-binary-content')
+      const configDir = path.join(dir, 'config')
+
+      await verifyTrust(execPath, { configDir, namespace: 'trusted-tool', skipSigstore: true })
+
+      const pending = await verifyTrustPending(execPath, {
+        configDir,
+        namespace: 'trusted-tool',
+        skipSigstore: true,
+      })
+      expect(pending.identity.trustTier).toBe(2)
+      expect(pending.manifestToSave).toBeUndefined()
+    })
+  })
+
+  it('verifyTrust (eager wrapper) still verifies and commits in one call', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')
+      const configDir = path.join(dir, 'config')
+
+      const result = await verifyTrust(execPath, {
+        configDir,
+        namespace: 'my-tool',
+        skipSigstore: true,
+      })
+
+      expect(result.identity.trustTier).toBe(3)
+      const manifest = await loadManifest(configDir)
+      expect(manifest.has('my-tool')).toBe(true)
     })
   })
 })

--- a/packages/vaultkeeper/test/unit/identity/trust.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/trust.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs/promises'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { verifyTrust, verifyTrustPending, commitTrust } from '../../../src/identity/trust.js'
-import { loadManifest } from '../../../src/identity/manifest.js'
+import { loadManifest, addTrustedHash, saveManifest } from '../../../src/identity/manifest.js'
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vaultkeeper-trust-'))
@@ -190,8 +190,7 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
 
       expect(pending.identity.trustTier).toBe(3)
       expect(pending.tofuConflict).toBe(false)
-      expect(pending.manifestToSave).toBeDefined()
-      expect(pending.manifestToSave?.has('my-tool')).toBe(true)
+      expect(pending.pendingWrite).toEqual({ namespace: 'my-tool', hash: pending.identity.hash })
 
       // Nothing was written by the verify phase alone.
       const manifest = await loadManifest(configDir)
@@ -216,7 +215,7 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
     })
   })
 
-  it('commitTrust is a no-op when manifestToSave is undefined (e.g. a TOFU conflict)', async () => {
+  it('commitTrust is a no-op when pendingWrite is undefined (e.g. a TOFU conflict)', async () => {
     await withTempDir(async (dir) => {
       const execPath = await createTempBinary(dir, 'tampered', 'original')
       const configDir = path.join(dir, 'config')
@@ -232,7 +231,7 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
         skipSigstore: true,
       })
       expect(pending.tofuConflict).toBe(true)
-      expect(pending.manifestToSave).toBeUndefined()
+      expect(pending.pendingWrite).toBeUndefined()
 
       // Committing a conflict result must not throw and must not write.
       await commitTrust(pending)
@@ -254,7 +253,43 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
         skipSigstore: true,
       })
       expect(pending.identity.trustTier).toBe(2)
-      expect(pending.manifestToSave).toBeUndefined()
+      expect(pending.pendingWrite).toBeUndefined()
+    })
+  })
+
+  // Verification and commit are not atomic: another process can write to the
+  // manifest in between (e.g. approving a different executable while our
+  // setup() call is still retrieving its secret). commitTrust must reload the
+  // manifest at commit time and merge the staged entry in, not persist the
+  // stale snapshot captured during verifyTrustPending — otherwise the
+  // concurrent write would be silently clobbered.
+  it('commitTrust merges with a concurrent manifest write instead of clobbering it', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')
+      const configDir = path.join(dir, 'config')
+
+      const pending = await verifyTrustPending(execPath, {
+        configDir,
+        namespace: 'my-tool',
+        skipSigstore: true,
+      })
+
+      // Simulate a concurrent process approving a different executable
+      // between our verify phase and our commit.
+      const concurrentManifest = await loadManifest(configDir)
+      const withConcurrentEntry = addTrustedHash(
+        concurrentManifest,
+        'other-tool',
+        'concurrent-hash',
+      )
+      await saveManifest(configDir, withConcurrentEntry)
+
+      await commitTrust(pending)
+
+      // Both the concurrent entry and our staged entry must survive.
+      const manifest = await loadManifest(configDir)
+      expect(manifest.get('other-tool')?.hashes).toEqual(['concurrent-hash'])
+      expect(manifest.has('my-tool')).toBe(true)
     })
   })
 

--- a/packages/vaultkeeper/test/unit/identity/trust.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/trust.test.ts
@@ -191,6 +191,10 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
       expect(pending.identity.trustTier).toBe(3)
       expect(pending.tofuConflict).toBe(false)
       expect(pending.pendingWrite).toEqual({ namespace: 'my-tool', hash: pending.identity.hash })
+      // The verify phase hasn't written anything yet, so `reason` must not
+      // claim persistence — it describes staging, not recording.
+      expect(pending.reason).toContain('staged')
+      expect(pending.reason).not.toContain('recorded')
 
       // Nothing was written by the verify phase alone.
       const manifest = await loadManifest(configDir)
@@ -307,6 +311,10 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
       expect(result.identity.trustTier).toBe(3)
       const manifest = await loadManifest(configDir)
       expect(manifest.has('my-tool')).toBe(true)
+      // A write actually happened by the time this eager wrapper returns, so
+      // external callers should keep seeing the pre-split, persisted-tense
+      // wording — not the verify phase's "staged" language.
+      expect(result.reason).toBe('First encounter — hash recorded via TOFU')
     })
   })
 })


### PR DESCRIPTION
## Summary

`VaultKeeper.setup()` ran `#resolveExecutableIdentity()` — which calls `verifyTrust()` — before `backend.retrieve(secretName)`. `verifyTrust()`'s Tier-3 (first-encounter/TOFU) and Tier-1 (Sigstore) paths call `addTrustedHash()` + `saveManifest()` immediately, so a `setup()` call that later fails (e.g. `SecretNotFoundError` for a nonexistent secret) still left the caller's hash **durably recorded** in the trust manifest. An attacker or a typo'd script could pre-seed TOFU trust without ever completing a legitimate first encounter; a later real first encounter would then silently match the pre-seeded hash instead of being verified as new.

This mirrors the exact defect already fixed on the Rust/WASM side in #178 ("deferred TOFU recording"), and applies the same verify/commit split to the TS library.

## Design: verify/commit split

`identity/trust.ts` previously had a single `verifyTrust()` that verified *and* wrote in one call. It's now split:

- **`verifyTrustPending(execPath, options)` — verify phase, no side effect.** Computes the hash and classifies it against the manifest (Sigstore / registry match / TOFU conflict / first encounter), returning a `PendingTrust` with the same fields as before plus `manifestToSave` (the manifest to persist if the caller later succeeds, or `undefined` when there's nothing to write — a registry match, a TOFU conflict, or dev-mode bypass never write).
- **`commitTrust(pending)` — commit phase.** Persists `pending.manifestToSave` if present; a no-op otherwise.
- **`verifyTrust(execPath, options)`** is retained as an eager convenience wrapper (`verifyTrustPending` + immediate `commitTrust`), so its existing callers/tests are unchanged.

`VaultKeeper.setup()`'s private `#resolveExecutableIdentity()` now calls `verifyTrustPending` and returns `{ exeIdentity, commit }`. `setup()` still validates the trust-choice shape (missing/conflicting/legacy-`'dev'`-sentinel) and detects a TOFU conflict *before* touching the backend — no change there. But the manifest write (`commit()`) is deferred until after `backend.retrieve()` succeeds and the token is minted, so a failure anywhere in between leaves the manifest untouched.

## Acceptance criteria → tests

1. **Trust-choice shape validation still fails fast before `backend.retrieve`** — unchanged code path (`#resolveExecutableIdentity`'s validation runs first, as before). Existing tests in `vault-trust.test.ts` (`describe('setup() requires an explicit executable-trust choice (#123)')`) continue to pass unmodified.
2. **No manifest mutation unless the secret exists / the operation succeeds** —
   - `vault-trust.test.ts` → `'throws SecretNotFoundError for a nonexistent secret and leaves the manifest untouched'` (the exact #148 repro: `setup('MISSING_SECRET', { executablePath })` throws `SecretNotFoundError`, manifest file absent, `checkExecutableTrust` still reports untrusted).
   - `vault-trust.test.ts` → `'still records the first-encounter hash when the secret exists and setup() succeeds'` (the write is deferred, not removed).
   - `vault-trust.test.ts` → `'a matching re-encounter succeeds without rewriting the manifest'` (Tier 2 registry match stages nothing).
   - `trust.test.ts` → `'verifyTrustPending stages a first-encounter hash but does not write it'`, `'commitTrust persists a staged first-encounter hash'`, `'a registry (Tier 2) match stages nothing to commit'`.
3. **TOFU-conflict detection still uses the pre-existing manifest state and fails before any write** —
   - `vault-trust.test.ts` → `'a hash conflict throws IdentityMismatchError and never records the new hash'`.
   - `trust.test.ts` → `'commitTrust is a no-op when manifestToSave is undefined (e.g. a TOFU conflict)'`.
4. **`verifyTrust` (eager wrapper) unchanged for existing callers** — all pre-existing `trust.test.ts` tests pass unmodified, plus a new explicit test `'verifyTrust (eager wrapper) still verifies and commits in one call'`.

Also fixed the local `createInMemoryBackend()` test helper (`test/helpers/backend.ts`), which rejected a missing secret with a plain `Error` instead of the `SecretNotFoundError` the `SecretBackend.retrieve` contract documents — needed to assert AC2's regression test against the real error type.

## Non-goals

Rust/WASM side (already shipped in #178), the manifest file format, and the CLI `exec` trust flow — none touched here.

## Verification

- `pnpm build`, `pnpm check` (typecheck + lint + api-report), `pnpm check:api-docs`, and `pnpm test` all pass.
- No public API surface changed (`verifyTrust`/`verifyTrustPending`/`commitTrust`/`PendingTrust` are `@internal` and not re-exported from `src/index.ts`) — `docs/api/` and `api-report/` are unchanged.
- Added a `vaultkeeper` patch changeset (behavior fix, no signature change).

Refs #148