### PR TITLE
Fix false README parity claims and add pack-contents sentinel check

### DIFF
--- a/packages/cli-tests/test/packaging/packaging.test.ts
+++ b/packages/cli-tests/test/packaging/packaging.test.ts
@@ -15,7 +15,8 @@
 import { describe, it, expect } from 'vitest'
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
-import { readFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import * as os from 'node:os'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -193,6 +194,47 @@ async function runNpmPackDryRun(packageDir: string): Promise<NpmPackResult> {
   return first
 }
 
+interface NpmPackJsonEntry {
+  filename: string
+}
+
+function isNpmPackJsonEntry(value: unknown): value is NpmPackJsonEntry {
+  return isPlainObject(value) && typeof value.filename === 'string'
+}
+
+/**
+ * Packs the given package for real (not `--dry-run`) into a throwaway temp
+ * directory, then extracts README.md from the resulting tarball and returns
+ * its text content. `--dry-run` only reports the file list, so it cannot
+ * prove that a guaranteed section survived intact — only that a file named
+ * README.md is present.
+ */
+async function readPackedReadme(packageDir: string): Promise<string> {
+  const cwd = path.join(repoRoot, 'packages', packageDir)
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'vaultkeeper-pack-'))
+  try {
+    const { stdout } = await execFileAsync(
+      'npm',
+      ['pack', '--json', '--pack-destination', tmpDir],
+      { cwd },
+    )
+    const parsed: unknown = JSON.parse(stdout)
+    const first: unknown = Array.isArray(parsed) ? parsed[0] : undefined
+    if (!isNpmPackJsonEntry(first)) {
+      throw new Error(`Unexpected npm pack output for ${packageDir}: ${stdout}`)
+    }
+    const tarballPath = path.join(tmpDir, first.filename)
+    const { stdout: readmeContent } = await execFileAsync('tar', [
+      '-xOf',
+      tarballPath,
+      'package/README.md',
+    ])
+    return readmeContent
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true })
+  }
+}
+
 describe.each(publishablePackageDirs)('packaging: packages/%s', (packageDir) => {
   it('includes README.md in the published tarball', async () => {
     const pack = await runNpmPackDryRun(packageDir)
@@ -246,6 +288,31 @@ describe.each(publishablePackageDirs)('packaging: packages/%s', (packageDir) => 
         filePaths,
         `${packageDir}: declared path "${declaredPath}" missing from tarball`,
       ).toContain(normalized)
+    }
+  })
+})
+
+/**
+ * Regression guard for https://github.com/mike-north/vaultkeeper/issues/179:
+ * the tarball-inclusion test above only proves README.md exists in the
+ * packed `vaultkeeper` tarball, not that its guaranteed content survived — a
+ * future edit could silently strip a section (e.g. the error hierarchy or
+ * the full `VaultConfig` reference) while every existing packaging assertion
+ * kept passing. Each sentinel anchors a section that must ship intact.
+ */
+describe('packaging: packages/vaultkeeper README content', () => {
+  it('retains guaranteed sections in the packed tarball', async () => {
+    const readme = await readPackedReadme('vaultkeeper')
+
+    const sentinels = [
+      'Multiple secrets in one request', // dedicated section heading
+      'InvalidKeyMaterialError', // error hierarchy entry
+      'gracePeriodDays', // full VaultConfig field reference
+      'Doctor / preflight checks', // doctor section heading
+    ]
+
+    for (const sentinel of sentinels) {
+      expect(readme, `packed vaultkeeper README missing "${sentinel}"`).toContain(sentinel)
     }
   })
 })

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -174,8 +174,9 @@ tracked separately.
 The [`vaultkeeper`](https://www.npmjs.com/package/vaultkeeper) library package's README and shipped
 `.d.ts` cover the TypeScript API and access patterns for embedding vaultkeeper programmatically —
 including the complete error hierarchy and full `VaultConfig` reference, shipped inline in that
-package's README. The [repository README](https://github.com/mike-north/vaultkeeper#readme) mirrors
-the same content online as a supplement.
+package's README. The [repository README](https://github.com/mike-north/vaultkeeper#readme) covers
+related narrative online, but for the complete reference see the `vaultkeeper` package's own
+README linked above.
 
 ## License
 

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -483,8 +483,9 @@ read-only properties for machine-readable context.
 | `RotationInProgressError` | `rotateKey()` called while a previous rotation's grace period is still active.                           |
 
 Each class's JSDoc (carried on the package's shipped `.d.ts`) documents these same errors and
-fields inline. The [repository README](https://github.com/mike-north/vaultkeeper#readme) mirrors
-this list for online reference.
+fields inline. The [repository README](https://github.com/mike-north/vaultkeeper#readme) covers
+related narrative online, but this package's own README (above) and its shipped `.d.ts` are the
+authoritative, complete list.
 
 ## Testing against this library
 
@@ -508,8 +509,8 @@ pnpm add -D @vaultkeeper/test-helpers
 This README is self-contained: the full error hierarchy, development-mode narrative, and complete
 `VaultConfig` reference above are all shipped inside the package (no network access required). The
 package's `.d.ts` files carry the same reference on every exported type, method, and option via
-JSDoc. The [repository README](https://github.com/mike-north/vaultkeeper#readme) mirrors this
-content online as a supplement.
+JSDoc. The [repository README](https://github.com/mike-north/vaultkeeper#readme) covers related
+narrative online, but treat this package's own README as the complete, authoritative reference.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewords the three "the repository README mirrors this list/content" claims in `packages/vaultkeeper/README.md` (error hierarchy, full documentation section) and `packages/cli/README.md` (full documentation section). Re-verified against the current `main` (post-#159, post-#196): the root README is missing an entire section ("Multiple secrets in one request"), the full `VaultConfig`/`BackendConfig` field table, and 4 of 29 documented error classes (`DecryptionError`, `FetchError`, `ConfigValidationError`, `ConfigParseError`). Since the gap spans whole sections rather than a couple of missing rows, this reworks the claims to point readers to the package's own README as the authoritative reference instead of duplicating that content into a second hand-maintained file — a parity promise between two files is a standing drift liability, which is exactly what this issue is proof of.
- Confirmed no other "mirrors"/parity claims exist elsewhere (grepped both READMEs plus `@vaultkeeper/wasm`'s — its one "see the repository README" pointer references real, non-duplicated content and isn't a parity claim, so it's untouched).
- Confirmed the umbrella-convention check already holds: the root README's "Which package should I use?" section references `vaultkeeper`/`@vaultkeeper/wasm`/`@vaultkeeper/cli`, and each package README is titled with its own name and links back to `vaultkeeper` only where relevant. No violations found, no changes needed.
- Adds a `packages/vaultkeeper` README-content packaging test: packs the package for real (not `--dry-run`), extracts `README.md` from the resulting tarball, and asserts it contains sentinel strings for guaranteed content — the "Multiple secrets in one request" heading, `InvalidKeyMaterialError`, `gracePeriodDays`, and the "Doctor / preflight checks" heading. Verified this fails when a sentinel is stripped (tested locally by removing one, confirming the new test failed, then reverting).

No changeset — docs and tests only, no shipped package behavior changed.

## Test plan

- [x] `pnpm check` (typecheck + lint + api-report) — green
- [x] `pnpm test` — 175 passed, 25 skipped (Rust-conformance tests that skip without a built binary, unrelated)
- [x] `pnpm exec prettier --check` on changed files — green
- [x] Manually verified the new packaging test fails when a guaranteed README section is stripped, then passes again once restored

Refs #179