### PR TITLE
Fix flaky real-clock race in claims.test.ts future-expiry test

### DIFF
--- a/packages/vaultkeeper/test/unit/jwe/claims.test.ts
+++ b/packages/vaultkeeper/test/unit/jwe/claims.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { validateClaims, blockToken, isBlocked, clearBlocklist } from '../../../src/jwe/claims.js'
 import type { VaultClaims } from '../../../src/types.js'
 import {
@@ -102,11 +102,26 @@ describe('validateClaims', () => {
       }).not.toThrow()
     })
 
-    it('accepts future expiry one second from now', () => {
-      const now = Math.floor(Date.now() / 1000)
-      expect(() => {
-        validateClaims(makeValidClaims({ exp: now + 1 }))
-      }).not.toThrow()
+    describe('future expiry (fixed clock)', () => {
+      // Regression test for #208: this test previously read Date.now() once to
+      // build a claim expiring 1 second in the future, then let validateClaims()
+      // read Date.now() again independently. If the real clock crossed a second
+      // boundary between those two reads, the claim would appear expired,
+      // flaking CI. Fake timers pin the clock so both reads see the same instant.
+      beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2024-01-15T10:00:00.000Z'))
+      })
+      afterEach(() => {
+        vi.useRealTimers()
+      })
+
+      it('accepts future expiry one second from now', () => {
+        const now = Math.floor(Date.now() / 1000)
+        expect(() => {
+          validateClaims(makeValidClaims({ exp: now + 1 }))
+        }).not.toThrow()
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

- `jwe/claims.test.ts`'s `accepts future expiry one second from now` read `Date.now()` once to build a claim expiring 1 second out, then let `validateClaims()` read `Date.now()` again independently. If the real clock crossed a second boundary between those two reads, the claim appeared expired, flaking CI (per issue's observed failure: `Token expired at 1784161356, now 1784161356`).
- Converted the test to use `vi.useFakeTimers()` / `vi.setSystemTime()` (fixed date) with `vi.useRealTimers()` in `afterEach`, scoped to a nested `describe` block, matching the fake-timer convention already used elsewhere in the suite (e.g. `test/unit/keys/storage.test.ts`).
- Audited the rest of the file for the same flake shape (a small real-clock margin that shrinks between claim construction and validation). No other test has it:
  - `throws TokenExpiredError when exp is in the past` / `exp equals now` / `TokenExpiredError has canRefresh=false` all use a large (3600s) **past**-dated margin — as real time advances the claim only gets *more* expired, so these can't flip results.
  - `throws VaultError when iat is after exp` fails on the `iat > exp` check before the clock-based expiry check is ever reached, so it's clock-independent.
  - Nothing left behind requiring conversion.

No changeset included — this is a test-only change with no user-facing effect.

## Test plan

- [x] `pnpm --filter vaultkeeper exec vitest run test/unit/jwe/claims.test.ts` run 5x in a row — 30/30 tests pass every time, confirming determinism
- [x] `pnpm check` — typecheck, lint, api-report all green
- [x] `pnpm test` — full suite green (181 passed, 25 skipped as expected — conformance tests skip without the Rust binary)
- [x] `pnpm exec prettier --check` on the changed file — clean

Refs #208