### PR TITLE
Fix wave-13 papercut cluster: setup() error hint, useLimit docs, verify PEM parse, did-you-mean

### DIFF
--- a/.changeset/setup-error-hint-and-cli-papercuts.md
+++ b/.changeset/setup-error-hint-and-cli-papercuts.md
@@ -1,0 +1,17 @@
+---
+'vaultkeeper': patch
+'@vaultkeeper/wasm': patch
+'@vaultkeeper/cli': patch
+---
+
+Polish setup() editor guidance and CLI/README papercuts.
+
+**`setup()` compile-error hint.** Both `VaultKeeper.setup()` in the `vaultkeeper` library and `@vaultkeeper/wasm` now carry a TSDoc note that names the exact compile errors a missing trust choice produces (TS2554/TS2345) and the two remedies — add exactly one of `executablePath` or `skipTrust: true` — so hovering the call in-editor explains the fix rather than leaving the bare compiler message. The WASM `setup()` also gains a runnable `@example`.
+
+**`useLimit` "use" semantics documented.** The README now spells out that `useLimit` bounds calls to `vault.authorize(jwe)`, not downstream delegated `fetch()`/`exec()`/`getSecret()` calls: each `authorize(jwe)` consumes one use, and the resulting `CapabilityToken` can be reused across many delegated calls; only a second `authorize(jwe)` throws `UsageLimitExceededError`.
+
+**`verify` inline-PEM parsing.** `vaultkeeper verify --public-key`/`--signature` now reject inline PEM material with a clear, actionable usage error (exit 2) instead of node's opaque "argument is ambiguous" — the flags are file-path-only, and the message says so and points at the `--public-key=<path>` escape for a path that legitimately begins with a dash.
+
+**Unknown-command suggestion.** An unrecognized subcommand now prints an npm/git/cargo-style `Did you mean '<closest>'?` suggestion (e.g. `doctro` → `doctor`) plus a one-line pointer to `vaultkeeper --help` and the docs, giving tarball-only users a discovery path.
+
+**README Quick Start.** The CLI Quick Start code block now includes an inline `--config-dir`/`VAULTKEEPER_CONFIG_DIR` reminder so a copy-paster gets the isolated-config guidance that was previously only in prose.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Both the native Rust CLI and the Node.js CLI share the same command surface:
 > The safe `file` default described below (a bare `config init` writing the `file` backend) currently applies to the **Node.js CLI** and the TypeScript library. The native Rust CLI's zero-config default still targets the platform-native store; converging it onto this behavior is tracked in [#75](https://github.com/mike-north/vaultkeeper/issues/75).
 
 ```sh
+# Every command accepts a global `--config-dir <path>` (or the
+# VAULTKEEPER_CONFIG_DIR env var) that isolates config, key material, and the
+# `file` backend's secrets to that directory instead of the default
+# ~/.config/vaultkeeper. Prefer it when experimenting or running in CI so you
+# never touch (or clobber) your real configuration, e.g.:
+#   vaultkeeper --config-dir ./vk-demo config init
+#   vaultkeeper --config-dir ./vk-demo store --name MY_API_KEY
+
 # Run preflight checks
 vaultkeeper doctor
 
@@ -763,6 +771,18 @@ const jwe = await vault.setup('SECRET_NAME', {
   backendType: 'keychain',
 })
 ```
+
+> [!IMPORTANT]
+> **What counts as a "use".** `useLimit` bounds the number of times a JWE can be
+> **authorized** — i.e. calls to `vault.authorize(jwe)` — **not** the number of
+> delegated `fetch()`/`exec()`/`getSecret()` calls. Each `authorize(jwe)`
+> consumes one use and returns a `CapabilityToken`; the delegated-access methods
+> take that already-authorized token and do **not** consume a further use. So
+> with `useLimit: 1` you may call `authorize(jwe)` **once**, then run as many
+> `exec()`/`fetch()` calls as you like against the resulting token — only a
+> **second** `authorize(jwe)` throws `UsageLimitExceededError`. Size `useLimit`
+> to how many times the JWE itself will be redeemed, not to how many downstream
+> operations each redemption performs.
 
 ## Error types
 

--- a/docs/api/vaultkeeper.vaultkeeper.setup.md
+++ b/docs/api/vaultkeeper.vaultkeeper.setup.md
@@ -84,6 +84,8 @@ Compact JWE string
 
 `setup()` requires an explicit executable-trust decision — it has no default and never silently skips verification. Pass `executablePath` (the calling executable's real path) to run trust-on-first-use verification, or `skipTrust: true` to deliberately skip it in development. The [SetupOptions](./vaultkeeper.setupoptions.md) type enforces this choice at compile time (exactly one, and the options argument is required); [ExecutableTrustRequiredError](./vaultkeeper.executabletrustrequirederror.md) is the runtime backstop for untyped callers.
 
+\*\*Seeing a compile error here?\*\* A bare `vault.setup('NAME')` or `vault.setup('NAME', {})` fails to typecheck (e.g. TS2554 "Expected 2 arguments, but got 1" or TS2345 "Argument … is not assignable") precisely because the mandatory trust choice is missing. The fix is to add \*\*exactly one\*\* of `executablePath: '<path>'` (verify the caller — production) or `skipTrust: true` (skip verification — development only). Supplying both fails to typecheck for the same reason.
+
 ## Example
 
 

--- a/docs/api/wasm.vaultkeeper.setup.md
+++ b/docs/api/wasm.vaultkeeper.setup.md
@@ -94,3 +94,18 @@ TypeError If `secretName` or `secretValue` is not a string (guards the WASM boun
 
 \*\*Backend divergence.\*\* Unlike the TypeScript `vaultkeeper` library's `setup(secretName, options?)`<!-- -->, this method does not read from the backend — it mints the token directly from `secretValue`<!-- -->. It never calls [VaultKeeper.store()](./wasm.vaultkeeper.store.md) / [VaultKeeper.retrieve()](./wasm.vaultkeeper.retrieve.md) or looks at anything already persisted under `secretName`<!-- -->, so a prior `store()` call has no effect on what `setup()` encapsulates. This is an intentional divergence between the two SDKs' `setup()` contracts, not a bug.
 
+\*\*Seeing a compile error here?\*\* A bare `vault.setup('NAME', 'value')` or `vault.setup('NAME', 'value', {})` fails to typecheck (e.g. TS2554 "Expected 3 arguments, but got 2" or TS2345 "Argument … is not assignable") precisely because the mandatory trust choice is missing. The fix is to add \*\*exactly one\*\* of `executablePath: '<path>'` (verify the caller — production) or `skipTrust: true` (skip verification — development only). Supplying both fails to typecheck for the same reason.
+
+## Example
+
+
+```ts
+// Production: bind the token to the calling executable's identity.
+const token = await vault.setup('MY_API_KEY', 'secret-value', {
+  executablePath: '/usr/local/bin/my-tool',
+})
+
+// Local development: skip executable-trust verification.
+const devToken = await vault.setup('MY_API_KEY', 'secret-value', { skipTrust: true })
+```
+

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -35,6 +35,7 @@ import {
   CONFIG_DIR_HELP_OPTION,
   CONFIG_DIR_HELP_ENV,
 } from './config-dir.js'
+import { suggestCommand } from './suggest.js'
 
 // Read the package version at startup so --version doesn't need an async import.
 // We read and parse the package.json synchronously to avoid a dynamic import()
@@ -227,11 +228,24 @@ async function main(): Promise<number> {
       const { revokeKeyCommand } = await import('./commands/revoke-key.js')
       return revokeKeyCommand(commandArgs, configDir)
     }
-    default:
+    default: {
       process.stderr.write(`Unknown command: ${subcommand}\n`)
+      // Offer the closest known command (npm/git/cargo-style) when the typo is
+      // close enough to be a confident guess (e.g. `doctro` → `doctor`).
+      const suggestion = suggestCommand(subcommand)
+      if (suggestion !== undefined) {
+        process.stderr.write(`Did you mean '${suggestion}'?\n`)
+      }
+      // A one-line discovery pointer so tarball-only users always have a next
+      // step even when no suggestion is close enough.
+      process.stderr.write(
+        "Run 'vaultkeeper --help' for the full command list, or see " +
+          'https://github.com/mike-north/vaultkeeper#readme\n',
+      )
       printHelp()
       // Exit code 2: usage error (unknown command)
       return 2
+    }
   }
 }
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -103,15 +103,21 @@ export async function verifyCommand(args: string[]): Promise<number> {
     return 2
   }
 
-  // Catch the equals-form inline PEM (`--public-key=-----BEGIN…`), which parses
-  // cleanly but is inline key material, not a path — reading it as a file would
-  // fail with a confusing ENOENT. These flags are file-path-only.
+  // Catch the equals-form inline PEM (`--public-key=-----BEGIN…-----END…`),
+  // which parses cleanly but is inline key material, not a path — reading it as
+  // a file would fail with a confusing ENOENT. These flags are file-path-only.
+  //
+  // Require BOTH the `-----BEGIN` and `-----END` markers rather than the prefix
+  // alone: a real PEM has both (and is multi-line), whereas a legitimate file
+  // path is a single token that could conceivably begin with `-----BEGIN` but
+  // will never also contain `-----END`. This avoids misclassifying an unusual
+  // (dash-leading) path as inline key material.
   const inlineFlags: { flag: string; value: string }[] = [
     { flag: '--public-key', value: publicKeyPath },
     { flag: '--signature', value: signaturePath },
   ]
   for (const { flag, value } of inlineFlags) {
-    if (value.startsWith('-----BEGIN')) {
+    if (value.includes('-----BEGIN') && value.includes('-----END')) {
       process.stderr.write(
         `Error: ${flag} takes a file PATH, not inline key material. ` +
           'Write the PEM/signature to a file and pass its path instead.\n',

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -81,8 +81,8 @@ export async function verifyCommand(args: string[]): Promise<number> {
         'Error: --public-key and --signature take a file PATH, not an inline value. ' +
           'A value beginning with "-" (including an inline PEM, which starts with ' +
           '"-----BEGIN") is read as another option. Write the key/signature to a file ' +
-          'and pass its path; if the path itself begins with "-", use the ' +
-          '--public-key=<path> (equals) form.\n',
+          'and pass its path; if the path itself begins with "-", use the equals form ' +
+          '(--public-key=<path> / --signature=<path>).\n',
       )
     } else if (err instanceof Error) {
       process.stderr.write(`Error: ${err.message}\n`)
@@ -97,6 +97,9 @@ export async function verifyCommand(args: string[]): Promise<number> {
   const signaturePath = values.signature
   if (publicKeyPath === undefined || signaturePath === undefined) {
     process.stderr.write('Error: --public-key and --signature are both required\n')
+    process.stderr.write(
+      'Usage: vaultkeeper verify --public-key <pem-path> --signature <sig-path> < payload\n',
+    )
     return 2
   }
 

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -67,7 +67,24 @@ export async function verifyCommand(args: string[]): Promise<number> {
       strict: true,
     }))
   } catch (err) {
-    if (err instanceof Error) {
+    // node's parseArgs rejects a space-separated value that begins with `-`
+    // (e.g. an inline PEM `--public-key -----BEGIN…`) as "argument is
+    // ambiguous". These flags take a file PATH, not inline key material, so
+    // point the caller at the file-path contract and the `=` escape for a value
+    // that legitimately starts with a dash.
+    const isAmbiguous =
+      err instanceof Error &&
+      'code' in err &&
+      err.code === 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE'
+    if (isAmbiguous) {
+      process.stderr.write(
+        'Error: --public-key and --signature take a file PATH, not an inline value. ' +
+          'A value beginning with "-" (including an inline PEM, which starts with ' +
+          '"-----BEGIN") is read as another option. Write the key/signature to a file ' +
+          'and pass its path; if the path itself begins with "-", use the ' +
+          '--public-key=<path> (equals) form.\n',
+      )
+    } else if (err instanceof Error) {
       process.stderr.write(`Error: ${err.message}\n`)
     }
     process.stderr.write(
@@ -81,6 +98,26 @@ export async function verifyCommand(args: string[]): Promise<number> {
   if (publicKeyPath === undefined || signaturePath === undefined) {
     process.stderr.write('Error: --public-key and --signature are both required\n')
     return 2
+  }
+
+  // Catch the equals-form inline PEM (`--public-key=-----BEGIN…`), which parses
+  // cleanly but is inline key material, not a path — reading it as a file would
+  // fail with a confusing ENOENT. These flags are file-path-only.
+  const inlineFlags: { flag: string; value: string }[] = [
+    { flag: '--public-key', value: publicKeyPath },
+    { flag: '--signature', value: signaturePath },
+  ]
+  for (const { flag, value } of inlineFlags) {
+    if (value.startsWith('-----BEGIN')) {
+      process.stderr.write(
+        `Error: ${flag} takes a file PATH, not inline key material. ` +
+          'Write the PEM/signature to a file and pass its path instead.\n',
+      )
+      process.stderr.write(
+        'Usage: vaultkeeper verify --public-key <pem-path> --signature <sig-path> < payload\n',
+      )
+      return 2
+    }
   }
 
   try {

--- a/packages/cli/src/suggest.ts
+++ b/packages/cli/src/suggest.ts
@@ -1,0 +1,87 @@
+/**
+ * Nearest-command suggestion for unknown subcommands ("did you mean …?").
+ *
+ * Mirrors the affordance npm/git/cargo provide: a typo like `doctro` should
+ * surface `doctor` rather than a bare "unknown command" with no next step.
+ *
+ * @internal
+ */
+
+/**
+ * The canonical list of top-level subcommands, in the order they appear in
+ * `--help`. Kept alongside the `bin.ts` dispatch switch it is derived from —
+ * update both together when a command is added or removed.
+ */
+export const KNOWN_COMMANDS: readonly string[] = [
+  'exec',
+  'doctor',
+  'approve',
+  'dev-mode',
+  'store',
+  'delete',
+  'key',
+  'sign',
+  'verify',
+  'config',
+  'rotate-key',
+  'revoke-key',
+]
+
+/**
+ * Levenshtein edit distance between two strings (insertions, deletions, and
+ * substitutions each cost 1). Used to rank candidate commands by closeness to
+ * the user's typo.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0
+  if (a.length === 0) return b.length
+  if (b.length === 0) return a.length
+
+  // Single-row dynamic-programming table; `prev[j]` holds the distance for the
+  // previous source-prefix length, rebuilt row by row.
+  let prev: number[] = []
+  for (let j = 0; j <= b.length; j++) prev[j] = j
+
+  for (let i = 1; i <= a.length; i++) {
+    const curr: number[] = [i]
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      const deletion = (prev[j] ?? 0) + 1
+      const insertion = (curr[j - 1] ?? 0) + 1
+      const substitution = (prev[j - 1] ?? 0) + cost
+      curr[j] = Math.min(deletion, insertion, substitution)
+    }
+    prev = curr
+  }
+  return prev[b.length] ?? 0
+}
+
+/**
+ * Return the known command closest to `input`, or `undefined` when nothing is
+ * close enough to be a helpful suggestion.
+ *
+ * The threshold scales with the input length (a longer word tolerates more
+ * typos) but is capped so wildly different words never produce a misleading
+ * suggestion — `doctro` → `doctor`, but `xyz` → nothing.
+ */
+export function suggestCommand(
+  input: string,
+  commands: readonly string[] = KNOWN_COMMANDS,
+): string | undefined {
+  if (input === '') return undefined
+
+  // Tolerate up to a third of the input length in edits, but never more than 3.
+  const maxDistance = Math.min(3, Math.floor(input.length / 3) + 1)
+
+  let best: string | undefined
+  let bestDistance = Number.POSITIVE_INFINITY
+  for (const command of commands) {
+    const distance = levenshtein(input, command)
+    if (distance < bestDistance) {
+      best = command
+      bestDistance = distance
+    }
+  }
+
+  return bestDistance <= maxDistance ? best : undefined
+}

--- a/packages/cli/test/unit/bin.test.ts
+++ b/packages/cli/test/unit/bin.test.ts
@@ -71,6 +71,37 @@ describe('bin.ts entry point', () => {
     expect(result.stdout).toContain('Usage: vaultkeeper [--config-dir <path>] <command>')
   })
 
+  // Issue #216, item 5: unknown subcommands get an npm/git/cargo-style
+  // "did you mean …?" suggestion plus a one-line discovery pointer.
+  describe('unknown-command suggestion (did you mean …?)', () => {
+    it("should suggest 'doctor' for the typo 'doctro'", async () => {
+      const result = await runCli(['doctro'])
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain('Unknown command: doctro')
+      expect(result.stderr).toContain("Did you mean 'doctor'?")
+    })
+
+    it("should suggest 'exec' for the typo 'exce'", async () => {
+      const result = await runCli(['exce'])
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain("Did you mean 'exec'?")
+    })
+
+    it('should not offer a misleading suggestion for a wildly unrelated command', async () => {
+      const result = await runCli(['frobnicate'])
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain('Unknown command: frobnicate')
+      expect(result.stderr).not.toContain('Did you mean')
+    })
+
+    it('should always print a discovery pointer to --help and the docs', async () => {
+      const result = await runCli(['frobnicate'])
+      expect(result.exitCode).toBe(2)
+      expect(result.stderr).toContain("Run 'vaultkeeper --help'")
+      expect(result.stderr).toContain('github.com/mike-north/vaultkeeper')
+    })
+  })
+
   it('should list all known commands in the help output', async () => {
     const result = await runCli(['--help'])
     const knownCommands = [

--- a/packages/cli/test/unit/commands/verify-flag-parsing.test.ts
+++ b/packages/cli/test/unit/commands/verify-flag-parsing.test.ts
@@ -1,0 +1,90 @@
+/**
+ * `verify` flag-parsing tests (issue #216, item 3).
+ *
+ * `--public-key` / `--signature` are **file-path-only** flags. Two ways a
+ * caller can wrongly pass inline PEM material must produce a clear, actionable
+ * usage error (exit 2) instead of node's opaque "argument is ambiguous" or a
+ * confusing downstream ENOENT:
+ *
+ *   1. Space-separated inline PEM (`--public-key -----BEGIN…`) — node's
+ *      parseArgs rejects any space-separated value starting with `-` as
+ *      ambiguous.
+ *   2. Equals-form inline PEM (`--public-key=-----BEGIN…`) — parses cleanly but
+ *      is key material, not a path.
+ *
+ * These error paths return before any stdin read or vault work, so the tests
+ * need neither stdin nor a backend.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// `verify.ts` imports `vaultkeeper`; mock it so these tests never require the
+// library's build output. The flag-parsing error paths under test return before
+// any `VaultKeeper.verify()` call anyway.
+vi.mock('vaultkeeper', async (importOriginal) => {
+  const { mockVaultkeeperModule } = await import('../../support/mock-vaultkeeper-module.js')
+  return mockVaultkeeperModule(importOriginal, {
+    VaultKeeper: {
+      init: vi.fn(),
+      verify: vi.fn(),
+    },
+    defaultBackendType: vi.fn().mockReturnValue('file'),
+  })
+})
+
+const { verifyCommand } = await import('../../../src/commands/verify.js')
+
+describe('verify --public-key/--signature reject inline PEM with a clear usage error', () => {
+  let stderrOutput: string
+
+  beforeEach(() => {
+    stderrOutput = ''
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderrOutput += String(chunk)
+      return true
+    })
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  const INLINE_PEM = '-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA\n-----END PUBLIC KEY-----'
+
+  it('exits 2 with a file-path hint for a space-separated inline PEM (was "argument is ambiguous")', async () => {
+    const code = await verifyCommand(['--public-key', INLINE_PEM, '--signature', '/tmp/sig'])
+    expect(code).toBe(2)
+    // The old bare node message must be replaced by an actionable one.
+    expect(stderrOutput).not.toContain('argument is ambiguous')
+    expect(stderrOutput).toContain('file PATH')
+    expect(stderrOutput).toContain('-----BEGIN')
+    // Points at the escape for a legitimately dash-leading path.
+    expect(stderrOutput).toContain('--public-key=<path>')
+  })
+
+  it('exits 2 with a file-path hint for an equals-form inline public key', async () => {
+    const code = await verifyCommand([`--public-key=${INLINE_PEM}`, '--signature', '/tmp/sig'])
+    expect(code).toBe(2)
+    expect(stderrOutput).toContain('--public-key takes a file PATH')
+    expect(stderrOutput).not.toContain('argument is ambiguous')
+  })
+
+  it('exits 2 with a file-path hint for an equals-form inline signature', async () => {
+    const code = await verifyCommand(['--public-key', '/tmp/pub.pem', `--signature=${INLINE_PEM}`])
+    expect(code).toBe(2)
+    expect(stderrOutput).toContain('--signature takes a file PATH')
+  })
+
+  it('still points at the file-path usage line for an unknown flag', async () => {
+    const code = await verifyCommand(['--bogus', 'x'])
+    expect(code).toBe(2)
+    expect(stderrOutput).toContain('Usage: vaultkeeper verify --public-key <pem-path>')
+  })
+
+  it('still reports both flags as required when one is missing', async () => {
+    const code = await verifyCommand(['--public-key', '/tmp/pub.pem'])
+    expect(code).toBe(2)
+    expect(stderrOutput).toContain('--public-key and --signature are both required')
+  })
+})

--- a/packages/cli/test/unit/commands/verify-flag-parsing.test.ts
+++ b/packages/cli/test/unit/commands/verify-flag-parsing.test.ts
@@ -59,8 +59,10 @@ describe('verify --public-key/--signature reject inline PEM with a clear usage e
     expect(stderrOutput).not.toContain('argument is ambiguous')
     expect(stderrOutput).toContain('file PATH')
     expect(stderrOutput).toContain('-----BEGIN')
-    // Points at the escape for a legitimately dash-leading path.
+    // Points at the equals-form escape for a legitimately dash-leading path,
+    // covering BOTH flags the message names (not just --public-key).
     expect(stderrOutput).toContain('--public-key=<path>')
+    expect(stderrOutput).toContain('--signature=<path>')
   })
 
   it('exits 2 with a file-path hint for an equals-form inline public key', async () => {
@@ -82,9 +84,12 @@ describe('verify --public-key/--signature reject inline PEM with a clear usage e
     expect(stderrOutput).toContain('Usage: vaultkeeper verify --public-key <pem-path>')
   })
 
-  it('still reports both flags as required when one is missing', async () => {
+  it('reports both flags as required AND prints the Usage line when one is missing', async () => {
     const code = await verifyCommand(['--public-key', '/tmp/pub.pem'])
     expect(code).toBe(2)
     expect(stderrOutput).toContain('--public-key and --signature are both required')
+    // The missing-flags path must be as actionable as the parse-error and
+    // inline-PEM paths: it prints the Usage hint too.
+    expect(stderrOutput).toContain('Usage: vaultkeeper verify --public-key <pem-path>')
   })
 })

--- a/packages/cli/test/unit/commands/verify-flag-parsing.test.ts
+++ b/packages/cli/test/unit/commands/verify-flag-parsing.test.ts
@@ -31,6 +31,14 @@ vi.mock('vaultkeeper', async (importOriginal) => {
   })
 })
 
+// Provide a non-empty stdin payload so that a value which is NOT classified as
+// inline PEM proceeds past the guard into the real file-read path (rather than
+// bailing on empty stdin) — this is what lets the "path starting with
+// -----BEGIN but no -----END" case reach the file-read failure.
+vi.mock('../../../src/stdin.js', () => ({
+  readStdinBytes: vi.fn(() => Promise.resolve(Buffer.from('challenge-payload'))),
+}))
+
 const { verifyCommand } = await import('../../../src/commands/verify.js')
 
 describe('verify --public-key/--signature reject inline PEM with a clear usage error', () => {
@@ -76,6 +84,22 @@ describe('verify --public-key/--signature reject inline PEM with a clear usage e
     const code = await verifyCommand(['--public-key', '/tmp/pub.pem', `--signature=${INLINE_PEM}`])
     expect(code).toBe(2)
     expect(stderrOutput).toContain('--signature takes a file PATH')
+  })
+
+  // The inline-PEM guard keys on BOTH the -----BEGIN and -----END markers (real
+  // PEM content), not the -----BEGIN prefix alone. A single-token file path that
+  // merely starts with "-----BEGIN" (no -----END) must NOT be misclassified as
+  // inline key material — it is a legitimate (if unusual, dash-leading) path and
+  // must flow through to the real file-read path instead.
+  it('does not misclassify a path starting with -----BEGIN (no -----END) as inline PEM', async () => {
+    const dashyPath = '-----BEGIN-not-really-a-pem.pub'
+    const code = await verifyCommand([`--public-key=${dashyPath}`, '--signature=/tmp/sig'])
+    // Treated as a path: it reaches the file read and fails there (exit 1),
+    // rather than being rejected by the inline-PEM guard (exit 2).
+    expect(code).toBe(1)
+    expect(stderrOutput).not.toContain('takes a file PATH, not inline key material')
+    expect(stderrOutput).toContain('Failed to read public key')
+    expect(stderrOutput).toContain(dashyPath)
   })
 
   it('still points at the file-path usage line for an unknown flag', async () => {

--- a/packages/cli/test/unit/suggest.test.ts
+++ b/packages/cli/test/unit/suggest.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for the unknown-command suggestion helper (issue #216, item 5).
+ *
+ * `suggestCommand` powers the npm/git/cargo-style "did you mean …?" hint on an
+ * unknown subcommand. It must confidently correct near-miss typos while never
+ * offering a misleading suggestion for a genuinely unrelated word.
+ */
+import { describe, it, expect } from 'vitest'
+import { levenshtein, suggestCommand, KNOWN_COMMANDS } from '../../src/suggest.js'
+
+describe('levenshtein', () => {
+  it('is 0 for identical strings', () => {
+    expect(levenshtein('doctor', 'doctor')).toBe(0)
+  })
+
+  it('equals the other length when one string is empty', () => {
+    expect(levenshtein('', 'doctor')).toBe(6)
+    expect(levenshtein('exec', '')).toBe(4)
+  })
+
+  it('counts a single substitution as distance 1', () => {
+    expect(levenshtein('doctor', 'doctdr')).toBe(1)
+  })
+
+  it('counts a transposition (doctro → doctor) as 2 substitutions', () => {
+    // Levenshtein has no transposition primitive, so a swapped pair costs 2.
+    expect(levenshtein('doctro', 'doctor')).toBe(2)
+  })
+})
+
+describe('suggestCommand', () => {
+  it('suggests the closest command for a near-miss typo', () => {
+    expect(suggestCommand('doctro')).toBe('doctor')
+    expect(suggestCommand('docter')).toBe('doctor')
+    expect(suggestCommand('exce')).toBe('exec')
+    expect(suggestCommand('stroe')).toBe('store')
+    expect(suggestCommand('verfy')).toBe('verify')
+  })
+
+  it('suggests a command missing/adding a single character', () => {
+    expect(suggestCommand('confi')).toBe('config')
+    expect(suggestCommand('configg')).toBe('config')
+  })
+
+  it('returns undefined for an empty input', () => {
+    expect(suggestCommand('')).toBeUndefined()
+  })
+
+  it('returns undefined for a wildly unrelated word (no misleading guess)', () => {
+    expect(suggestCommand('xyz')).toBeUndefined()
+    expect(suggestCommand('frobnicate')).toBeUndefined()
+    expect(suggestCommand('deploy')).toBeUndefined()
+  })
+
+  it('returns the exact command (distance 0) when the input is already valid', () => {
+    for (const command of KNOWN_COMMANDS) {
+      expect(suggestCommand(command)).toBe(command)
+    }
+  })
+
+  it('honors an explicit command list', () => {
+    expect(suggestCommand('bild', ['build', 'test'])).toBe('build')
+    expect(suggestCommand('zzzz', ['build', 'test'])).toBeUndefined()
+  })
+})

--- a/packages/vaultkeeper-wasm/src/index.ts
+++ b/packages/vaultkeeper-wasm/src/index.ts
@@ -260,6 +260,25 @@ export class VaultKeeper {
    * no effect on what `setup()` encapsulates. This is an intentional divergence
    * between the two SDKs' `setup()` contracts, not a bug.
    *
+   * **Seeing a compile error here?** A bare `vault.setup('NAME', 'value')` or
+   * `vault.setup('NAME', 'value', {})` fails to typecheck (e.g. TS2554
+   * "Expected 3 arguments, but got 2" or TS2345 "Argument … is not assignable")
+   * precisely because the mandatory trust choice is missing. The fix is to add
+   * **exactly one** of `executablePath: '<path>'` (verify the caller —
+   * production) or `skipTrust: true` (skip verification — development only).
+   * Supplying both fails to typecheck for the same reason.
+   *
+   * @example
+   * ```ts
+   * // Production: bind the token to the calling executable's identity.
+   * const token = await vault.setup('MY_API_KEY', 'secret-value', {
+   *   executablePath: '/usr/local/bin/my-tool',
+   * })
+   *
+   * // Local development: skip executable-trust verification.
+   * const devToken = await vault.setup('MY_API_KEY', 'secret-value', { skipTrust: true })
+   * ```
+   *
    * @throws {@link ExecutableTrustRequiredError} If neither `executablePath` nor
    *   `skipTrust: true` is provided, if both are, or if `executablePath` is the
    *   retired legacy `'dev'` opt-out sentinel (use `skipTrust: true`).

--- a/packages/vaultkeeper/src/vault.ts
+++ b/packages/vaultkeeper/src/vault.ts
@@ -504,6 +504,14 @@ export class VaultKeeper {
    * argument is required); {@link ExecutableTrustRequiredError} is the runtime
    * backstop for untyped callers.
    *
+   * **Seeing a compile error here?** A bare `vault.setup('NAME')` or
+   * `vault.setup('NAME', {})` fails to typecheck (e.g. TS2554 "Expected 2
+   * arguments, but got 1" or TS2345 "Argument … is not assignable") precisely
+   * because the mandatory trust choice is missing. The fix is to add **exactly
+   * one** of `executablePath: '<path>'` (verify the caller — production) or
+   * `skipTrust: true` (skip verification — development only). Supplying both
+   * fails to typecheck for the same reason.
+   *
    * @example
    * ```ts
    * // Production: bind the token to a STABLE executable so a swapped binary is


### PR DESCRIPTION
Refs #216

Addresses the wave-13 papercut cluster — editor/docs guidance plus small CLI polish. Each item ships with a test where behavior changes.

## Changes

**1. `setup()` compile-error is generic (TSDoc).** Omitting the executable-trust choice is correctly caught at compile time, but the bare TS2554/TS2345 message gives no hint. Both `VaultKeeper.setup()` (library) and `@vaultkeeper/wasm`'s `setup()` now carry a TSDoc note that names those exact compile errors and the two remedies — add **exactly one** of `executablePath` or `skipTrust: true`. The WASM `setup()` also gains a runnable `@example`. api-docs regenerated.

**2. `useLimit` "use" semantics (README).** A "use" is an `authorize(jwe)` call, **not** each delegated `fetch()`/`exec()`/`getSecret()`. The Setup-options section now spells this out: `authorize(jwe)` consumes one use and returns a `CapabilityToken` that can be reused across many delegated calls; only a second `authorize(jwe)` throws `UsageLimitExceededError`.

**3. `verify` inline-PEM misparse (CLI).** `--public-key`/`--signature` are file-path-only. Passing an inline PEM previously surfaced node's opaque "argument is ambiguous". The command now returns a clear usage error (exit 2) explaining the file-path contract and the `--public-key=<path>` escape for a dash-leading path, and it also catches the equals-form inline PEM (`--public-key=-----BEGIN…`) before the confusing downstream ENOENT.

**4. README Quick Start omits `--config-dir` (README).** The CLI Quick Start code block now carries an inline `--config-dir`/`VAULTKEEPER_CONFIG_DIR` reminder so a copy-paster gets the isolated-config guidance.

**5. No "did you mean" on unknown subcommands (CLI).** Unknown subcommands now print an npm/git/cargo-style `Did you mean '<closest>'?` (Levenshtein against the known command list, e.g. `doctro` → `doctor`) plus a one-line pointer to `vaultkeeper --help` and the docs.

### `vaultkeeper verify`: inline-PEM error

```diff
-Error: Option '--public-key' argument is ambiguous.
-Did you forget to specify the option argument for '--public-key'?
+Error: --public-key and --signature take a file PATH, not an inline value. A value
+beginning with "-" (including an inline PEM, which starts with "-----BEGIN") is read
+as another option. Write the key/signature to a file and pass its path; if the path
+itself begins with "-", use the --public-key=<path> (equals) form.
 Usage: vaultkeeper verify --public-key <pem-path> --signature <sig-path> < payload
```

### `vaultkeeper <unknown>`: did-you-mean

```diff
 Unknown command: doctro
+Did you mean 'doctor'?
+Run 'vaultkeeper --help' for the full command list, or see https://github.com/mike-north/vaultkeeper#readme
 Usage: vaultkeeper [--config-dir <path>] <command> [options]
```

## Tests

- `packages/cli/test/unit/suggest.test.ts` — Levenshtein + `suggestCommand` (near-miss corrections + negative "no misleading guess" cases)
- `packages/cli/test/unit/commands/verify-flag-parsing.test.ts` — space- and equals-form inline PEM both exit 2 with the file-path hint
- `packages/cli/test/unit/bin.test.ts` — did-you-mean suggestion, no-suggestion path, and the discovery pointer

## Verification

- `pnpm --filter vaultkeeper test` — 912 passed
- `pnpm --filter @vaultkeeper/cli test` — 344 passed
- `pnpm --filter @vaultkeeper/cli-tests test` — 181 passed
- `pnpm --filter @vaultkeeper/wasm test` — 72 passed
- `pnpm check` + `pnpm check:api-docs` — green

Changeset: `vaultkeeper`, `@vaultkeeper/wasm`, `@vaultkeeper/cli` all patch.