### PR TITLE
Extend 1Password per-access worker with a store/delete write path

### DIFF
--- a/.changeset/one-password-worker-write-path.md
+++ b/.changeset/one-password-worker-write-path.md
@@ -1,0 +1,5 @@
+---
+'vaultkeeper': minor
+---
+
+Extend the 1Password per-access worker with a `store`/`delete` write path so `--require-presence-per-use` covers writes, not just reads. Previously the per-access worker was read-only, so `OnePasswordBackend` reported `presenceEnforcedOperations: ['read']` and a flagged `store`/`delete` failed closed with `NotCapableError` — correct, but limited. Now every keyed operation (`retrieve`, `store`, `delete`) spawns its own fresh worker process forcing a distinct biometric approval, `presenceEnforcedOperations` reports `['read', 'store', 'delete']`, and the earlier `NotCapableError` refusal is replaced by the same fresh-action guarantee reads already had. The secret value for `store` is delivered to the worker over stdin — never argv — so it never appears in a process listing, shell history, or log. A declined presence action throws `PresenceDeclinedError`; a timed-out one throws `PresenceTimeoutError`.

--- a/docs/manual-tests/presence-per-use.md
+++ b/docs/manual-tests/presence-per-use.md
@@ -49,20 +49,31 @@ enabled; config sets `{ "type": "1password", "enabled": true, "options": { "acce
 4. Cancel the biometric prompt → expect the read to fail (surfaced as an
    authorization/decline failure from the 1Password worker).
 
-5. Confirm writes fail closed: `vaultkeeper store --name S --require-presence-per-use`
-   (and the same for `delete`) → expect an immediate `NotCapableError` (exit 1)
-   with a message that presence-per-use is enforced for `read` only on this
-   backend. No biometric prompt should appear, and nothing should be written.
+5. Confirm writes now force a fresh action too (issue #211 closed the earlier
+   fail-closed gap): `vaultkeeper store --name S --require-presence-per-use`
+   → expect a fresh Touch ID / system biometric prompt (a distinct worker
+   process from the read prompt), and the store succeeds only after approval.
+   Repeat for `vaultkeeper delete --name S --require-presence-per-use` → expect
+   its own fresh prompt.
+6. Cancel the biometric prompt during a flagged `store`/`delete` → expect the
+   command to fail (exit 1) as a declined presence action (`PresenceDeclinedError`),
+   not a generic authorization failure — and confirm nothing was written/deleted.
+7. Withhold the prompt past the wait window during a flagged `store`/`delete` →
+   expect `PresenceTimeoutError` (exit 1), distinct from `PresenceDeclinedError`.
+8. Confirm the secret value never appears in a process listing during a flagged
+   `store`: while the command is running, run `ps aux | grep vaultkeeper` (or
+   equivalent) in another terminal and confirm the value is absent — it travels
+   to the worker over stdin, never as a spawn argument.
 
 > **Cached-OS-unlock caveat.** 1Password `per-access` creates a fresh SDK client
-> per read, but the OS may satisfy the biometric from a cached Touch ID / Windows
-> Hello unlock without re-prompting. If step 3 does **not** re-prompt, that is the
-> OS caching the unlock, not a vaultkeeper defect — the guarantee for 1Password is
-> "fresh SDK client plus whatever the OS enforces at that moment." For a hard
-> per-tap guarantee, use a touch device. `store`/`delete` route through the cached
-> session client, so presence is enforced for reads only; a flagged write is
-> **refused** (`NotCapableError`), never silently allowed — verified by step 5 and
-> by the automated `operation-aware, fail-closed enforcement` test.
+> per operation, but the OS may satisfy the biometric from a cached Touch ID /
+> Windows Hello unlock without re-prompting. If step 3 does **not** re-prompt,
+> that is the OS caching the unlock, not a vaultkeeper defect — the guarantee for
+> 1Password is "fresh SDK client plus whatever the OS enforces at that moment."
+> For a hard per-tap guarantee, use a touch device. `store` and `delete` now
+> route through the same per-access worker as reads (issue #211), each forcing
+> its own fresh action — verified by steps 5–8 and by the automated
+> `store — per-access mode` / `delete — per-access mode` unit test suites.
 
 ## gpg smartcard (touch-to-sign) — if/when a backend ships
 

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -433,28 +433,28 @@ consecutive required-presence operations each demand their own distinct fresh ac
 
 ### Per-backend truth basis
 
-| Backend                                    | `presencePerUse`                                                                                         | Basis                                                                                                                                                                                                       |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `file`, `keychain`, `dpapi`, `secret-tool` | always `false`                                                                                           | Encryption-only or a cached/unattended unlock — no distinct per-use human action.                                                                                                                           |
-| `yubikey`                                  | `true` only when the configured slot enforces touch-per-operation (`options.touchPolicy: "required"`)    | Every challenge-response forces a physical tap. Verify the slot's real policy with `ykman otp info`. Derived from configuration, never from the backend type.                                               |
-| `1password`                                | `true` only in `per-access` mode (`options.accessMode: "per-access"`), and only for the `read` operation | A fresh worker/SDK client triggers a per-read biometric approval instead of reusing the cached session client. Writes route through the cached session, so it enforces presence for reads only (see below). |
+| Backend                                    | `presencePerUse`                                                                                              | Basis                                                                                                                                                                                                                                         |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `file`, `keychain`, `dpapi`, `secret-tool` | always `false`                                                                                                | Encryption-only or a cached/unattended unlock — no distinct per-use human action.                                                                                                                                                             |
+| `yubikey`                                  | `true` only when the configured slot enforces touch-per-operation (`options.touchPolicy: "required"`)         | Every challenge-response forces a physical tap. Verify the slot's real policy with `ykman otp info`. Derived from configuration, never from the backend type.                                                                                 |
+| `1password`                                | `true` only in `per-access` mode (`options.accessMode: "per-access"`), covering `read`, `store`, and `delete` | A fresh worker/SDK client is spawned per operation — reads, stores, and deletes each trigger their own biometric approval instead of reusing the cached session client. `exists`/`list` remain read-only probes on the cached session client. |
 
 > **Operation coverage (enforced, not advisory).** 1Password `per-access` forces a fresh biometric
-> for **reads** (the secret read behind `setup`/`exec`) but routes `store`/`delete` through the cached
-> session client. Enforcement is therefore **operation-aware and fail-closed**: a
-> `--require-presence-per-use` / `requirePresencePerUse` `store` or `delete` on 1Password is **refused
-> with `NotCapableError`** before any credential is touched — it never passes without a fresh action.
-> Only presence-gated **reads** proceed. A touch device (YubiKey with a touch slot) enforces presence
-> for every operation and has no such restriction. This is expressed generically via
-> `BackendCapabilities.presenceEnforcedOperations` (omitted = all operations), not a per-type special
-> case.
+> for **every keyed operation** — `read` (the secret read behind `setup`/`exec`), `store`, and
+> `delete` each spawn their own worker process and their own fresh approval (issue #211 closed the
+> earlier gap where `store`/`delete` rode the cached session client). A touch device (YubiKey with a
+> touch slot) enforces presence for every operation the same way and has no restriction to model. This
+> coverage is expressed generically via `BackendCapabilities.presenceEnforcedOperations` (omitted =
+> all operations), not a per-type special case — a backend that only covers _some_ operations (were
+> one added later) would still refuse an uncovered `--require-presence-per-use` request with
+> `NotCapableError` rather than silently pass it through a cached session.
 
 > **Cached-OS-unlock caveat.** A "fresh process / SDK client" is **not** the same as a guaranteed
-> fresh hardware action. 1Password `per-access` re-creates the client per read, but the OS may still
-> satisfy the biometric from a cached Touch ID / Windows Hello unlock without re-prompting — so its
-> guarantee is "fresh SDK client plus whatever the OS enforces at that moment." The strongest per-use
-> guarantee comes from a dedicated touch device (YubiKey / gpg smartcard), where the tap is intrinsic
-> to the cryptographic operation.
+> fresh hardware action. 1Password `per-access` re-creates the client per operation, but the OS may
+> still satisfy the biometric from a cached Touch ID / Windows Hello unlock without re-prompting — so
+> its guarantee is "fresh SDK client plus whatever the OS enforces at that moment." The strongest
+> per-use guarantee comes from a dedicated touch device (YubiKey / gpg smartcard), where the tap is
+> intrinsic to the cryptographic operation.
 
 Real-hardware confirmation for each backend is documented as a manual verification test in
 [`docs/manual-tests/presence-per-use.md`](../../docs/manual-tests/presence-per-use.md).

--- a/packages/vaultkeeper/src/backend/one-password-backend.ts
+++ b/packages/vaultkeeper/src/backend/one-password-backend.ts
@@ -383,13 +383,17 @@ export class OnePasswordBackend implements ListableBackend, PresenceCapableBacke
         stderrChunks.push(chunk)
       })
 
-      child.on('close', (code) => {
+      child.on('close', (code, signal) => {
         const raw = Buffer.concat(stdoutChunks).toString('utf8').trim()
 
         // If worker produced no stdout, use exit code + stderr for diagnostics
         if (raw === '') {
           const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
-          const detail = stderr !== '' ? stderr : `exit code ${String(code)}`
+          const exitDescription =
+            typeof signal === 'string'
+              ? `terminated by signal ${signal}`
+              : `exit code ${String(code)}`
+          const detail = stderr !== '' ? stderr : exitDescription
           reject(
             new BackendUnavailableError(
               `1Password per-access worker crashed for secret ${id}: ${detail}`,
@@ -500,12 +504,18 @@ export class OnePasswordBackend implements ListableBackend, PresenceCapableBacke
         stderrChunks.push(chunk)
       })
 
-      child.on('close', (code) => {
+      child.on('close', (code, signal) => {
         const raw = Buffer.concat(stdoutChunks).toString('utf8').trim()
 
         if (raw === '') {
           const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
-          const detail = stderr !== '' ? stderr : `exit code ${String(code)}`
+          // A signal-terminated worker reports code null — name the signal
+          // instead of an unhelpful 'exit code null'.
+          const exitDescription =
+            typeof signal === 'string'
+              ? `terminated by signal ${signal}`
+              : `exit code ${String(code)}`
+          const detail = stderr !== '' ? stderr : exitDescription
           reject(
             new BackendUnavailableError(
               `1Password per-access worker crashed during ${op} of secret ${id}: ${detail}`,

--- a/packages/vaultkeeper/src/backend/one-password-backend.ts
+++ b/packages/vaultkeeper/src/backend/one-password-backend.ts
@@ -117,7 +117,11 @@ interface WorkerWriteSuccess {
 type WorkerWriteResponse = WorkerWriteSuccess | WorkerFailure
 
 function isWorkerWriteSuccess(res: WorkerWriteResponse): res is WorkerWriteSuccess {
-  return 'ok' in res
+  // Check the VALUE, not just key presence: a malformed/buggy worker response
+  // like `{ ok: false, error, code }` passes isWorkerWriteResponse via its
+  // failure branch and must never be classified as a successful write.
+  const record: Record<string, unknown> = { ...res }
+  return record.ok === true
 }
 
 function isWorkerWriteResponse(value: unknown): value is WorkerWriteResponse {

--- a/packages/vaultkeeper/src/backend/one-password-backend.ts
+++ b/packages/vaultkeeper/src/backend/one-password-backend.ts
@@ -487,6 +487,14 @@ export class OnePasswordBackend implements ListableBackend, PresenceCapableBacke
       })
 
       if (needsStdin && child.stdin !== null) {
+        // A worker that exits before draining stdin (e.g. a protocol
+        // validation failure) makes this write raise EPIPE, which without a
+        // handler becomes an unhandled 'error' event and crashes the parent.
+        // The worker's own failure is already reported through the close
+        // handler below, so the stream error itself is safe to swallow.
+        child.stdin.on('error', () => {
+          /* reported via the close handler */
+        })
         child.stdin.write(secret, 'utf8')
         child.stdin.end()
       }

--- a/packages/vaultkeeper/src/backend/one-password-backend.ts
+++ b/packages/vaultkeeper/src/backend/one-password-backend.ts
@@ -7,17 +7,17 @@
  *
  * Supports two access modes:
  * - `session`: A single SDK client is created on first use and cached for all operations.
- * - `per-access`: The `retrieve()` operation spawns a child process that creates a fresh
- *   SDK client (triggering biometric auth) for each retrieval. Other operations still use
- *   the cached session client.
+ * - `per-access`: Every keyed operation (`retrieve()`, `store()`, `delete()`) spawns a child
+ *   process that creates a fresh SDK client (triggering biometric auth) for that single
+ *   operation. `exists()`/`list()` still use the cached session client — they are read-only
+ *   probes, not the presence-gated path.
  *
- * Presence-per-use follows directly from this: in `per-access` mode the instance
- * forces a fresh biometric only for reads, so {@link OnePasswordBackend.getCapabilities}
- * reports `presencePerUse: true` scoped to `presenceEnforcedOperations: ['read']`.
- * A `--require-presence-per-use` `store`/`delete` is therefore refused with a
- * `NotCapableError` (fail closed) rather than passing through the cached session
- * client — the guarantee is enforced for the covered operation and never silently
- * bypassed for an uncovered one. `session` mode reports `false`.
+ * Presence-per-use follows directly from this: in `per-access` mode the instance forces a
+ * fresh biometric for `read`, `store`, and `delete`, so {@link OnePasswordBackend.getCapabilities}
+ * reports `presencePerUse: true` scoped to `presenceEnforcedOperations: ['read', 'store', 'delete']`.
+ * `session` mode reports `false`.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/211
  */
 
 import { spawn } from 'node:child_process'
@@ -30,8 +30,18 @@ import {
   BackendUnavailableError,
   AuthorizationDeniedError,
   ConfigValidationError,
+  PresenceDeclinedError,
+  PresenceTimeoutError,
 } from '../errors.js'
 import type { ListableBackend, PresenceCapableBackend, BackendCapabilities } from './types.js'
+import {
+  TAG,
+  findItemOverviewByTitle,
+  findItemByTitle,
+  extractPasswordField,
+  storeSecretItem,
+  deleteSecretItem,
+} from './one-password-item-ops.js'
 
 // ---- SDK type imports (runtime-dynamic, not static imports) ----
 // We import the SDK dynamically so that the backend degrades gracefully
@@ -39,17 +49,14 @@ import type { ListableBackend, PresenceCapableBackend, BackendCapabilities } fro
 
 type SdkModule = typeof import('@1password/sdk')
 type Client = import('@1password/sdk').Client
-type Item = import('@1password/sdk').Item
-type ItemOverview = import('@1password/sdk').ItemOverview
 
-const TAG = 'vaultkeeper'
-const PASSWORD_FIELD_TITLE = 'password'
 const SESSION_TIMEOUT_MS = 30_000
 import {
   INTEGRATION_NAME,
   SDK_INSTALL_URL,
   SDK_NOT_INSTALLED_MESSAGE,
   SDK_PACKAGE,
+  PRESENCE_WRITE_TIMEOUT_MS,
   getIntegrationVersion,
   isModuleNotFoundError,
 } from './one-password-constants.js'
@@ -92,6 +99,30 @@ function isWorkerSuccess(res: WorkerResponse): res is WorkerSuccess {
 function isWorkerResponse(value: unknown): value is WorkerResponse {
   if (value === null || typeof value !== 'object') return false
   if ('value' in value && typeof value.value === 'string') return true
+  if (
+    'error' in value &&
+    typeof value.error === 'string' &&
+    'code' in value &&
+    typeof value.code === 'string'
+  )
+    return true
+  return false
+}
+
+/** Worker response shape for a successful `store`/`delete` (no value to report). */
+interface WorkerWriteSuccess {
+  ok: true
+}
+
+type WorkerWriteResponse = WorkerWriteSuccess | WorkerFailure
+
+function isWorkerWriteSuccess(res: WorkerWriteResponse): res is WorkerWriteSuccess {
+  return 'ok' in res
+}
+
+function isWorkerWriteResponse(value: unknown): value is WorkerWriteResponse {
+  if (value === null || typeof value !== 'object') return false
+  if ('ok' in value && value.ok === true) return true
   if (
     'error' in value &&
     typeof value.error === 'string' &&
@@ -157,31 +188,37 @@ export class OnePasswordBackend implements ListableBackend, PresenceCapableBacke
    * Report this instance's capabilities.
    *
    * @remarks
-   * `presencePerUse` is `true` only in `per-access` mode, where each
-   * `retrieve()` spawns a fresh worker process that creates a new SDK client and
-   * triggers a per-read biometric approval that cannot be satisfied from the
-   * cached session client. In the default `session` mode a single client is
-   * cached for all operations, so operations ride one earlier unlock — that mode
-   * reports `false`.
+   * `presencePerUse` is `true` only in `per-access` mode, where every keyed
+   * operation (`retrieve()`, `store()`, `delete()`) spawns a fresh worker
+   * process that creates a new SDK client and triggers a per-operation
+   * biometric approval that cannot be satisfied from the cached session
+   * client. In the default `session` mode a single client is cached for all
+   * operations, so operations ride one earlier unlock — that mode reports
+   * `false`.
    *
-   * **Operation coverage:** the per-access biometric path gates `retrieve()`
-   * only (the read behind `setup`/`exec`); `store`/`delete` route through the
-   * cached session client and are **not** presence-forced. To keep the
-   * guarantee non-bypassable, this reports `presenceEnforcedOperations: ['read']`
-   * so a `--require-presence-per-use` `store`/`delete` is refused with a
-   * `NotCapableError` (fail closed) rather than silently passing. Callers
-   * requiring presence for writes should use a touch device.
+   * **Operation coverage:** the per-access biometric path gates `retrieve()`,
+   * `store()`, and `delete()` — every keyed operation reachable from
+   * `presenceEnforcedOperations`. `exists()`/`list()` are read-only probes,
+   * not keyed operations the presence contract covers, so they continue to
+   * use the cached session client. This reports
+   * `presenceEnforcedOperations: ['read', 'store', 'delete']` (issue #211
+   * closed the earlier `store`/`delete` gap — see
+   * {@link https://github.com/mike-north/vaultkeeper/issues/211}).
    *
-   * **Truth-basis / cached-OS-unlock caveat:** even for reads the fresh action
-   * is "a fresh SDK client plus whatever the OS enforces at that moment" — a
-   * "fresh process/SDK client" is **not** the same as a guaranteed fresh
-   * hardware action. A per-access read can still ride a cached OS-level Touch ID
-   * / Windows Hello unlock if the OS does not re-prompt. The strongest per-use
-   * hardware guarantee comes from a touch device (YubiKey / gpg smartcard).
+   * **Truth-basis / cached-OS-unlock caveat:** even for a covered operation
+   * the fresh action is "a fresh SDK client plus whatever the OS enforces at
+   * that moment" — a "fresh process/SDK client" is **not** the same as a
+   * guaranteed fresh hardware action. A per-access call can still ride a
+   * cached OS-level Touch ID / Windows Hello unlock if the OS does not
+   * re-prompt. The strongest per-use hardware guarantee comes from a touch
+   * device (YubiKey / gpg smartcard).
    */
   getCapabilities(): Promise<BackendCapabilities> {
     if (this.accessMode === 'per-access') {
-      return Promise.resolve({ presencePerUse: true, presenceEnforcedOperations: ['read'] })
+      return Promise.resolve({
+        presencePerUse: true,
+        presenceEnforcedOperations: ['read', 'store', 'delete'],
+      })
     }
     return Promise.resolve({ presencePerUse: false })
   }
@@ -282,87 +319,22 @@ export class OnePasswordBackend implements ListableBackend, PresenceCapableBacke
     return new sdk.DesktopAuth(accountName)
   }
 
-  // ---- Helpers for item lookup by title ----
-
-  /**
-   * List all items in the vault tagged "vaultkeeper" and find one with the
-   * matching title (= secret ID). Returns `undefined` if not found.
-   */
-  private async findItemOverview(client: Client, id: string): Promise<ItemOverview | undefined> {
-    const overviews = await client.items.list(this.vaultId)
-    for (const overview of overviews) {
-      if (overview.title === id && overview.tags.includes(TAG)) {
-        return overview
-      }
-    }
-    return undefined
-  }
-
-  /**
-   * Fetch the full item for a given secret id. Returns `undefined` if not found.
-   */
-  private async findItem(client: Client, id: string): Promise<Item | undefined> {
-    const overview = await this.findItemOverview(client, id)
-    if (overview === undefined) return undefined
-    return client.items.get(this.vaultId, overview.id)
-  }
-
-  /**
-   * Extract the concealed password field value from an item.
-   */
-  private extractSecret(item: Item, id: string): string {
-    for (const field of item.fields) {
-      if (field.title === PASSWORD_FIELD_TITLE) {
-        return field.value
-      }
-    }
-    throw new SecretNotFoundError(`Secret found in 1Password but missing password field: ${id}`)
-  }
-
   // ---- SecretBackend / ListableBackend implementation ----
 
   async store(id: string, secret: string): Promise<void> {
+    if (this.accessMode === 'per-access') {
+      return this.writeViaWorker('store', id, secret)
+    }
     const { ItemCategory, ItemFieldType } = await this.requireSdk()
     const client = await this.acquireClient()
-
-    const existing = await this.findItem(client, id)
-
-    if (existing !== undefined) {
-      // Update the existing item's password field, or append one if missing
-      const hasPasswordField = existing.fields.some((f) => f.title === PASSWORD_FIELD_TITLE)
-      const updatedFields = hasPasswordField
-        ? existing.fields.map((f) => {
-            if (f.title === PASSWORD_FIELD_TITLE) {
-              return { ...f, value: secret }
-            }
-            return f
-          })
-        : [
-            ...existing.fields,
-            {
-              id: 'password',
-              title: PASSWORD_FIELD_TITLE,
-              fieldType: ItemFieldType.Concealed,
-              value: secret,
-            },
-          ]
-      await client.items.put({ ...existing, fields: updatedFields })
-    } else {
-      await client.items.create({
-        category: ItemCategory.Password,
-        vaultId: this.vaultId,
-        title: id,
-        tags: [TAG],
-        fields: [
-          {
-            id: 'password',
-            title: PASSWORD_FIELD_TITLE,
-            fieldType: ItemFieldType.Concealed,
-            value: secret,
-          },
-        ],
-      })
-    }
+    await storeSecretItem(
+      client,
+      this.vaultId,
+      id,
+      secret,
+      ItemCategory.Password,
+      ItemFieldType.Concealed,
+    )
   }
 
   async retrieve(id: string): Promise<string> {
@@ -374,11 +346,15 @@ export class OnePasswordBackend implements ListableBackend, PresenceCapableBacke
 
   private async retrieveViaSession(id: string): Promise<string> {
     const client = await this.acquireClient()
-    const item = await this.findItem(client, id)
+    const item = await findItemByTitle(client, this.vaultId, id)
     if (item === undefined) {
       throw new SecretNotFoundError(`Secret not found in 1Password: ${id}`)
     }
-    return this.extractSecret(item, id)
+    const value = extractPasswordField(item)
+    if (value === undefined) {
+      throw new SecretNotFoundError(`Secret found in 1Password but missing password field: ${id}`)
+    }
+    return value
   }
 
   /**
@@ -482,18 +458,160 @@ export class OnePasswordBackend implements ListableBackend, PresenceCapableBacke
     })
   }
 
+  /**
+   * Spawn the per-access worker script to perform a `store` or `delete`,
+   * triggering a fresh biometric prompt for this single write (issue #211).
+   *
+   * @remarks
+   * For `store`, `secret` is delivered to the worker over **stdin**, never
+   * argv — it must never appear in a process listing, shell history, or log.
+   * `delete` needs no payload, so no stdin is written and the worker's stdin
+   * is left `'ignore'`d, mirroring the retrieve path's spawn options.
+   */
+  private writeViaWorker(op: 'store' | 'delete', id: string, secret?: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const workerPath = join(dirname(fileURLToPath(import.meta.url)), 'one-password-worker.js')
+
+      const accountArg = this.account ?? ''
+      const needsStdin = secret !== undefined
+      const child = spawn(process.execPath, [workerPath, accountArg, this.vaultId, id, op], {
+        stdio: [needsStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+      })
+
+      if (needsStdin && child.stdin !== null) {
+        child.stdin.write(secret, 'utf8')
+        child.stdin.end()
+      }
+
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+      // The ternary in `stdio` above (rather than a fixed literal tuple) means
+      // TS can't narrow `stdout`/`stderr` to non-null from `spawn`'s overloads
+      // — both are always piped regardless, so optional chaining here mirrors
+      // the same null-safety idiom `execCommandFull` already uses in `util/exec.ts`.
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdoutChunks.push(chunk)
+      })
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderrChunks.push(chunk)
+      })
+
+      child.on('close', (code) => {
+        const raw = Buffer.concat(stdoutChunks).toString('utf8').trim()
+
+        if (raw === '') {
+          const stderr = Buffer.concat(stderrChunks).toString('utf8').trim()
+          const detail = stderr !== '' ? stderr : `exit code ${String(code)}`
+          reject(
+            new BackendUnavailableError(
+              `1Password per-access worker crashed during ${op} of secret ${id}: ${detail}`,
+              'worker-crashed',
+              ['1password'],
+            ),
+          )
+          return
+        }
+
+        let parsed: unknown
+        try {
+          parsed = JSON.parse(raw)
+        } catch {
+          reject(
+            new BackendUnavailableError(
+              `Worker returned unparseable output during ${op} of secret ${id}`,
+              'worker-internal-error',
+              ['1password'],
+            ),
+          )
+          return
+        }
+        if (!isWorkerWriteResponse(parsed)) {
+          reject(
+            new BackendUnavailableError(
+              `Worker returned unexpected response shape during ${op} of secret ${id}`,
+              'worker-internal-error',
+              ['1password'],
+            ),
+          )
+          return
+        }
+        if (isWorkerWriteSuccess(parsed)) {
+          resolve()
+          return
+        }
+        switch (parsed.code) {
+          case 'PLUGIN_NOT_FOUND':
+            reject(new PluginNotFoundError(SDK_NOT_INSTALLED_MESSAGE, SDK_PACKAGE, SDK_INSTALL_URL))
+            break
+          case 'NOT_FOUND':
+            reject(new SecretNotFoundError(`Secret not found in 1Password: ${id}`))
+            break
+          case 'LOCKED':
+            reject(new BackendLockedError('1Password is locked. Please unlock and retry.', true))
+            break
+          case 'PRESENCE_DECLINED':
+            reject(
+              new PresenceDeclinedError(
+                `1Password ${op} presence action was declined for secret ${id}`,
+                '1password',
+              ),
+            )
+            break
+          case 'PRESENCE_TIMEOUT':
+            reject(
+              new PresenceTimeoutError(
+                `1Password ${op} presence action timed out for secret ${id}`,
+                '1password',
+                PRESENCE_WRITE_TIMEOUT_MS,
+              ),
+            )
+            break
+          case 'INTERNAL':
+            reject(
+              new BackendUnavailableError(
+                `1Password per-access worker failed during ${op} of secret ${id}: ${parsed.error}`,
+                'worker-internal-error',
+                ['1password'],
+              ),
+            )
+            break
+          default:
+            reject(
+              new BackendUnavailableError(
+                `Worker failed during ${op} of secret ${id}: ${parsed.error}`,
+                'worker-internal-error',
+                ['1password'],
+              ),
+            )
+        }
+      })
+
+      child.on('error', (err) => {
+        reject(
+          new BackendUnavailableError(
+            `Failed to spawn 1Password per-access worker at ${workerPath}: ${String(err)}`,
+            'worker-spawn-failed',
+            ['1password'],
+          ),
+        )
+      })
+    })
+  }
+
   async delete(id: string): Promise<void> {
+    if (this.accessMode === 'per-access') {
+      return this.writeViaWorker('delete', id)
+    }
     const client = await this.acquireClient()
-    const overview = await this.findItemOverview(client, id)
-    if (overview === undefined) {
+    const deleted = await deleteSecretItem(client, this.vaultId, id)
+    if (!deleted) {
       throw new SecretNotFoundError(`Secret not found in 1Password: ${id}`)
     }
-    await client.items.delete(this.vaultId, overview.id)
   }
 
   async exists(id: string): Promise<boolean> {
     const client = await this.acquireClient()
-    const overview = await this.findItemOverview(client, id)
+    const overview = await findItemOverviewByTitle(client, this.vaultId, id)
     return overview !== undefined
   }
 

--- a/packages/vaultkeeper/src/backend/one-password-constants.ts
+++ b/packages/vaultkeeper/src/backend/one-password-constants.ts
@@ -28,6 +28,19 @@ export const SDK_INSTALL_URL = 'https://developer.1password.com/docs/sdks/'
 export const SDK_NOT_INSTALLED_MESSAGE = `1Password SDK (${SDK_PACKAGE}) is not installed. Install it to use the 1Password backend.`
 
 /**
+ * How long the per-access worker waits for `createClient()` to resolve during
+ * a presence-covered `store`/`delete` write before treating the fresh action
+ * as timed out (`PresenceTimeoutError`).
+ *
+ * @remarks
+ * Shared between the worker (which starts the timer) and the backend (which
+ * reports this value on the resulting {@link PresenceTimeoutError}), so the
+ * two never drift. Reads are unaffected — issue #211 only extends presence
+ * coverage to writes; see {@link https://github.com/mike-north/vaultkeeper/issues/211}.
+ */
+export const PRESENCE_WRITE_TIMEOUT_MS = 30_000
+
+/**
  * Whether an error thrown by `import('@1password/sdk')` means the module could
  * not be resolved (i.e. the optional peer is not installed), as opposed to a
  * present-but-broken SDK (native binding failure, init throw, incompatible

--- a/packages/vaultkeeper/src/backend/one-password-item-ops.ts
+++ b/packages/vaultkeeper/src/backend/one-password-item-ops.ts
@@ -1,0 +1,138 @@
+/**
+ * Shared 1Password item read/write operations.
+ *
+ * @remarks
+ * Both `OnePasswordBackend` (session client) and `one-password-worker.ts` (the
+ * per-access worker process spawned for a fresh biometric approval) look items
+ * up by title the same way, and must create-or-update / delete a
+ * `Password`-category item identically — see issue #211. Centralising that
+ * logic here keeps the two call sites from diverging.
+ *
+ * All SDK types are imported `import type` only, so this module carries no
+ * runtime dependency on `@1password/sdk` and stays lazy-load-safe like the
+ * rest of the 1Password integration: callers pass in an already-created
+ * `Client` plus the SDK's own `ItemCategory`/`ItemFieldType` enum members
+ * (obtained from their own dynamically-loaded SDK instance).
+ *
+ * @internal
+ */
+
+import type { Client, Item, ItemOverview, ItemCategory, ItemFieldType } from '@1password/sdk'
+
+/** Tag applied to every item vaultkeeper manages, used to scope list/find calls. */
+export const TAG = 'vaultkeeper'
+
+/** Title of the field that carries the secret value. */
+export const PASSWORD_FIELD_TITLE = 'password'
+
+/**
+ * List all items in the vault tagged "vaultkeeper" and find one with the
+ * matching title (= secret ID). Returns `undefined` if not found.
+ */
+export async function findItemOverviewByTitle(
+  client: Client,
+  vaultId: string,
+  title: string,
+): Promise<ItemOverview | undefined> {
+  const overviews = await client.items.list(vaultId)
+  for (const overview of overviews) {
+    if (overview.title === title && overview.tags.includes(TAG)) {
+      return overview
+    }
+  }
+  return undefined
+}
+
+/**
+ * Fetch the full item for a given secret id. Returns `undefined` if not found.
+ */
+export async function findItemByTitle(
+  client: Client,
+  vaultId: string,
+  title: string,
+): Promise<Item | undefined> {
+  const overview = await findItemOverviewByTitle(client, vaultId, title)
+  if (overview === undefined) return undefined
+  return client.items.get(vaultId, overview.id)
+}
+
+/**
+ * Extract the concealed password field value from an item, or `undefined` if
+ * the item has no `password`-titled field.
+ */
+export function extractPasswordField(item: Item): string | undefined {
+  for (const field of item.fields) {
+    if (field.title === PASSWORD_FIELD_TITLE) {
+      return field.value
+    }
+  }
+  return undefined
+}
+
+/**
+ * Create-or-update a `Password`-category item's concealed password field.
+ *
+ * @remarks
+ * Updates the existing item's password field (appending one if missing) via
+ * `items.put`, or creates a new tagged item via `items.create` when none
+ * exists yet under `title`. `passwordCategory`/`concealedFieldType` are the
+ * caller's own `ItemCategory.Password` / `ItemFieldType.Concealed` enum
+ * members — passed in rather than imported here so this module never needs a
+ * value import of the optional `@1password/sdk` peer.
+ */
+export async function storeSecretItem(
+  client: Client,
+  vaultId: string,
+  title: string,
+  secret: string,
+  passwordCategory: ItemCategory,
+  concealedFieldType: ItemFieldType,
+): Promise<void> {
+  const existing = await findItemByTitle(client, vaultId, title)
+
+  if (existing !== undefined) {
+    const hasPasswordField = existing.fields.some((f) => f.title === PASSWORD_FIELD_TITLE)
+    const updatedFields = hasPasswordField
+      ? existing.fields.map((f) => (f.title === PASSWORD_FIELD_TITLE ? { ...f, value: secret } : f))
+      : [
+          ...existing.fields,
+          {
+            id: 'password',
+            title: PASSWORD_FIELD_TITLE,
+            fieldType: concealedFieldType,
+            value: secret,
+          },
+        ]
+    await client.items.put({ ...existing, fields: updatedFields })
+  } else {
+    await client.items.create({
+      category: passwordCategory,
+      vaultId,
+      title,
+      tags: [TAG],
+      fields: [
+        {
+          id: 'password',
+          title: PASSWORD_FIELD_TITLE,
+          fieldType: concealedFieldType,
+          value: secret,
+        },
+      ],
+    })
+  }
+}
+
+/**
+ * Delete the tagged item matching `title`.
+ * @returns `true` if a matching item was found and deleted, `false` if none matched.
+ */
+export async function deleteSecretItem(
+  client: Client,
+  vaultId: string,
+  title: string,
+): Promise<boolean> {
+  const overview = await findItemOverviewByTitle(client, vaultId, title)
+  if (overview === undefined) return false
+  await client.items.delete(vaultId, overview.id)
+  return true
+}

--- a/packages/vaultkeeper/src/backend/one-password-item-ops.ts
+++ b/packages/vaultkeeper/src/backend/one-password-item-ops.ts
@@ -44,7 +44,9 @@ export async function findItemOverviewByTitle(
 }
 
 /**
- * Fetch the full item for a given secret id. Returns `undefined` if not found.
+ * Fetch the full item for a given secret id. Returns `undefined` when no
+ * tagged item with that title exists; rejects if the item fetch itself fails
+ * (the overview was found but `items.get` errored).
  */
 export async function findItemByTitle(
   client: Client,

--- a/packages/vaultkeeper/src/backend/one-password-worker.ts
+++ b/packages/vaultkeeper/src/backend/one-password-worker.ts
@@ -39,7 +39,12 @@ import {
   getIntegrationVersion,
   isModuleNotFoundError,
 } from './one-password-constants.js'
-import { storeSecretItem, deleteSecretItem } from './one-password-item-ops.js'
+import {
+  storeSecretItem,
+  deleteSecretItem,
+  TAG,
+  PASSWORD_FIELD_TITLE,
+} from './one-password-item-ops.js'
 
 interface RetrieveSuccessResponse {
   value: string
@@ -255,7 +260,7 @@ async function main(): Promise<void> {
 
   let targetId: string | undefined
   for (const overview of overviews) {
-    if (overview.title === secretId && overview.tags.includes('vaultkeeper')) {
+    if (overview.title === secretId && overview.tags.includes(TAG)) {
       targetId = overview.id
       break
     }
@@ -276,7 +281,7 @@ async function main(): Promise<void> {
 
   let secretValue: string | undefined
   for (const field of item.fields) {
-    if (field.title === 'password') {
+    if (field.title === PASSWORD_FIELD_TITLE) {
       secretValue = field.value
       break
     }

--- a/packages/vaultkeeper/src/backend/one-password-worker.ts
+++ b/packages/vaultkeeper/src/backend/one-password-worker.ts
@@ -42,8 +42,8 @@ import {
 import {
   storeSecretItem,
   deleteSecretItem,
-  TAG,
-  PASSWORD_FIELD_TITLE,
+  findItemOverviewByTitle,
+  extractPasswordField,
 } from './one-password-item-ops.js'
 
 interface RetrieveSuccessResponse {
@@ -261,44 +261,32 @@ async function main(): Promise<void> {
     return
   }
 
-  // op === 'retrieve' — unchanged read path.
-  let overviews
+  // op === 'retrieve' — the read path, sharing the same find/extract helpers
+  // as the parent backend and the write path so the tag/field conventions
+  // cannot drift. The failure-code taxonomy is preserved exactly: a list
+  // failure is INTERNAL, a missing item or a get failure is NOT_FOUND.
+  let overview
   try {
-    overviews = await client.items.list(vaultId)
+    overview = await findItemOverviewByTitle(client, vaultId, secretId)
   } catch (err) {
     writeFailure(`Failed to list items: ${String(err)}`, 'INTERNAL')
     process.exit(1)
   }
 
-  let targetId: string | undefined
-  for (const overview of overviews) {
-    if (overview.title === secretId && overview.tags.includes(TAG)) {
-      targetId = overview.id
-      break
-    }
-  }
-
-  if (targetId === undefined) {
+  if (overview === undefined) {
     writeFailure(`Secret not found: ${secretId}`, 'NOT_FOUND')
     process.exit(1)
   }
 
   let item
   try {
-    item = await client.items.get(vaultId, targetId)
+    item = await client.items.get(vaultId, overview.id)
   } catch (err) {
     writeFailure(`Failed to retrieve item: ${String(err)}`, 'NOT_FOUND')
     process.exit(1)
   }
 
-  let secretValue: string | undefined
-  for (const field of item.fields) {
-    if (field.title === PASSWORD_FIELD_TITLE) {
-      secretValue = field.value
-      break
-    }
-  }
-
+  const secretValue = extractPasswordField(item)
   if (secretValue === undefined) {
     writeFailure(`Item found but missing password field: ${secretId}`, 'NOT_FOUND')
     process.exit(1)

--- a/packages/vaultkeeper/src/backend/one-password-worker.ts
+++ b/packages/vaultkeeper/src/backend/one-password-worker.ts
@@ -3,28 +3,50 @@
  *
  * @remarks
  * This script is spawned as a child process by `OnePasswordBackend` when
- * `accessMode` is set to `'per-access'`. It creates a fresh SDK client
- * (which triggers a biometric prompt via the desktop app), retrieves a single
- * secret, writes the result to stdout as JSON, then exits immediately.
+ * `accessMode` is set to `'per-access'`. It creates a fresh SDK client (which
+ * triggers a biometric prompt via the desktop app), performs a single keyed
+ * operation, writes the result to stdout as JSON, then exits immediately.
  *
  * argv layout:
- *   node one-password-worker.js <accountName> <vaultId> <secretId>
+ *   node one-password-worker.js <accountName> <vaultId> <secretId> [op]
  *
- * stdout on success: `{ "value": "<secret>" }`
+ * `op` is one of `'retrieve'` (default, for backward compatibility with the
+ * original 3-argument invocation), `'store'`, or `'delete'`.
+ *
+ * For `'store'`, the secret value is read from **stdin** (UTF-8, until EOF) —
+ * never argv — so it never appears in `ps`/process listings, shell history,
+ * or logs (repo security rule; mirrors the stdin plumbing already used by
+ * `execCommandFull` in `util/exec.ts`).
+ *
+ * stdout on success:
+ *   `retrieve` — `{ "value": "<secret>" }`
+ *   `store`/`delete` — `{ "ok": true }`
  * stdout on failure: `{ "error": "<message>", "code": "<code>" }`
+ *
+ * `store`/`delete` are the presence-covered write paths added by issue #211:
+ * each spawns a fresh SDK client exactly like `retrieve` does, forcing the
+ * same fresh biometric approval, so `OnePasswordBackend.getCapabilities()`
+ * can report `store`/`delete` in `presenceEnforcedOperations` instead of
+ * refusing them with `NotCapableError`.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/211
  */
 
-const TAG = 'vaultkeeper'
-const PASSWORD_FIELD_TITLE = 'password'
 import {
   INTEGRATION_NAME,
   SDK_NOT_INSTALLED_MESSAGE,
+  PRESENCE_WRITE_TIMEOUT_MS,
   getIntegrationVersion,
   isModuleNotFoundError,
 } from './one-password-constants.js'
+import { storeSecretItem, deleteSecretItem } from './one-password-item-ops.js'
 
-interface SuccessResponse {
+interface RetrieveSuccessResponse {
   value: string
+}
+
+interface WriteSuccessResponse {
+  ok: true
 }
 
 interface FailureResponse {
@@ -32,8 +54,24 @@ interface FailureResponse {
   code: string
 }
 
-function writeSuccess(value: string): void {
-  const response: SuccessResponse = { value }
+const VALID_OPS = ['retrieve', 'store', 'delete'] as const
+type WorkerOp = (typeof VALID_OPS)[number]
+
+function isValidOp(value: string | undefined): value is WorkerOp {
+  if (value === undefined) return false
+  for (const op of VALID_OPS) {
+    if (op === value) return true
+  }
+  return false
+}
+
+function writeRetrieveSuccess(value: string): void {
+  const response: RetrieveSuccessResponse = { value }
+  process.stdout.write(JSON.stringify(response))
+}
+
+function writeWriteSuccess(): void {
+  const response: WriteSuccessResponse = { ok: true }
   process.stdout.write(JSON.stringify(response))
 }
 
@@ -42,16 +80,38 @@ function writeFailure(error: string, code: string): void {
   process.stdout.write(JSON.stringify(response))
 }
 
+/** Read all of stdin (UTF-8) into a single string. Used only for `store`. */
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk: string) => {
+      data += chunk
+    })
+    process.stdin.on('end', () => {
+      resolve(data)
+    })
+    process.stdin.on('error', (err: unknown) => {
+      reject(err instanceof Error ? err : new Error(String(err)))
+    })
+  })
+}
+
+/** Sentinel rejection used to distinguish a presence-timeout from any other createClient failure. */
+class PresenceTimeoutSentinel extends Error {}
+
 async function main(): Promise<void> {
-  const [, , accountName, vaultId, secretId] = process.argv
+  const [, , accountName, vaultId, secretId, opArg] = process.argv
 
   if (accountName === undefined || vaultId === undefined || secretId === undefined) {
     writeFailure('Worker invoked with missing arguments', 'INTERNAL')
     process.exit(1)
   }
 
+  const op: WorkerOp = isValidOp(opArg) ? opArg : 'retrieve'
+
   // The SDK is an optional peer dependency, loaded lazily so the worker only
-  // requires it when a per-access retrieval actually runs. A genuine "module
+  // requires it when a per-access operation actually runs. A genuine "module
   // not resolved" is reported with PLUGIN_NOT_FOUND (the parent maps it to a
   // typed PluginNotFoundError); a present-but-broken SDK surfaces its real
   // error instead of a misleading "not installed" message.
@@ -70,22 +130,121 @@ async function main(): Promise<void> {
   }
   const { createClient, DesktopAuth, DesktopSessionExpiredError } = sdk
 
-  let client
-  try {
-    client = await createClient({
-      auth: new DesktopAuth(accountName),
-      integrationName: INTEGRATION_NAME,
-      integrationVersion: getIntegrationVersion(),
-    })
-  } catch (err) {
-    if (err instanceof DesktopSessionExpiredError) {
-      writeFailure('1Password session has expired', 'LOCKED')
-    } else {
-      writeFailure(`Authentication failed: ${String(err)}`, 'AUTH_DENIED')
+  // `store` needs the secret value before touching the SDK at all, so a
+  // stdin read failure never reaches the biometric prompt.
+  let pendingSecret: string | undefined
+  if (op === 'store') {
+    try {
+      pendingSecret = await readStdin()
+    } catch (err) {
+      writeFailure(`Failed to read secret value from stdin: ${String(err)}`, 'INTERNAL')
+      process.exit(1)
     }
-    process.exit(1)
   }
 
+  let client
+  if (op === 'retrieve') {
+    // Unchanged from before issue #211 — reads are a non-goal of that issue.
+    try {
+      client = await createClient({
+        auth: new DesktopAuth(accountName),
+        integrationName: INTEGRATION_NAME,
+        integrationVersion: getIntegrationVersion(),
+      })
+    } catch (err) {
+      if (err instanceof DesktopSessionExpiredError) {
+        writeFailure('1Password session has expired', 'LOCKED')
+      } else {
+        writeFailure(`Authentication failed: ${String(err)}`, 'AUTH_DENIED')
+      }
+      process.exit(1)
+    }
+  } else {
+    // `store`/`delete` are the new presence-covered write paths (#211): a
+    // fresh client is required for every call, exactly like `retrieve`, but
+    // the failure taxonomy differs because these calls only ever happen when
+    // a fresh human action was demanded. The SDK exposes only
+    // `DesktopSessionExpiredError` and `RateLimitExceededError` as typed
+    // errors (see `@1password/sdk`'s `errors.d.ts`) — there is no distinct
+    // "user cancelled the biometric prompt" error. A bounded race against
+    // `PRESENCE_WRITE_TIMEOUT_MS` distinguishes "no action within the
+    // window" (`PRESENCE_TIMEOUT`) from any other client-creation failure,
+    // which is treated as the human declining the fresh action
+    // (`PRESENCE_DECLINED`) rather than the generic `AUTH_DENIED` used for
+    // reads, since a write only reaches this point because presence was
+    // required.
+    let timerId: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_resolve, reject) => {
+      timerId = setTimeout(() => {
+        reject(new PresenceTimeoutSentinel('presence action timed out'))
+      }, PRESENCE_WRITE_TIMEOUT_MS)
+    })
+    try {
+      client = await Promise.race([
+        createClient({
+          auth: new DesktopAuth(accountName),
+          integrationName: INTEGRATION_NAME,
+          integrationVersion: getIntegrationVersion(),
+        }),
+        timeoutPromise,
+      ])
+    } catch (err) {
+      if (err instanceof PresenceTimeoutSentinel) {
+        writeFailure(
+          `No fresh presence action within ${String(PRESENCE_WRITE_TIMEOUT_MS)}ms`,
+          'PRESENCE_TIMEOUT',
+        )
+      } else if (err instanceof DesktopSessionExpiredError) {
+        writeFailure('1Password session has expired', 'LOCKED')
+      } else {
+        writeFailure(`1Password presence action declined: ${String(err)}`, 'PRESENCE_DECLINED')
+      }
+      process.exit(1)
+    } finally {
+      if (timerId !== undefined) {
+        clearTimeout(timerId)
+      }
+    }
+  }
+
+  if (op === 'store') {
+    // `pendingSecret` is always set here — `op === 'store'` only when the
+    // stdin read above succeeded (a failed read already exited above).
+    try {
+      await storeSecretItem(
+        client,
+        vaultId,
+        secretId,
+        pendingSecret ?? '',
+        sdk.ItemCategory.Password,
+        sdk.ItemFieldType.Concealed,
+      )
+    } catch (err) {
+      writeFailure(`Failed to store item: ${String(err)}`, 'INTERNAL')
+      process.exit(1)
+    }
+    writeWriteSuccess()
+    return
+  }
+
+  if (op === 'delete') {
+    let deleted: boolean
+    try {
+      deleted = await deleteSecretItem(client, vaultId, secretId)
+    } catch (err) {
+      writeFailure(`Failed to delete item: ${String(err)}`, 'INTERNAL')
+      process.exit(1)
+      return
+    }
+    if (!deleted) {
+      writeFailure(`Secret not found: ${secretId}`, 'NOT_FOUND')
+      process.exit(1)
+    }
+    writeWriteSuccess()
+    return
+  }
+
+  // op === 'retrieve' — unchanged read path.
   let overviews
   try {
     overviews = await client.items.list(vaultId)
@@ -96,7 +255,7 @@ async function main(): Promise<void> {
 
   let targetId: string | undefined
   for (const overview of overviews) {
-    if (overview.title === secretId && overview.tags.includes(TAG)) {
+    if (overview.title === secretId && overview.tags.includes('vaultkeeper')) {
       targetId = overview.id
       break
     }
@@ -117,7 +276,7 @@ async function main(): Promise<void> {
 
   let secretValue: string | undefined
   for (const field of item.fields) {
-    if (field.title === PASSWORD_FIELD_TITLE) {
+    if (field.title === 'password') {
       secretValue = field.value
       break
     }
@@ -128,7 +287,7 @@ async function main(): Promise<void> {
     process.exit(1)
   }
 
-  writeSuccess(secretValue)
+  writeRetrieveSuccess(secretValue)
 }
 
 main().catch((err: unknown) => {

--- a/packages/vaultkeeper/src/backend/one-password-worker.ts
+++ b/packages/vaultkeeper/src/backend/one-password-worker.ts
@@ -143,8 +143,9 @@ async function main(): Promise<void> {
   }
   const { createClient, DesktopAuth, DesktopSessionExpiredError, RateLimitExceededError } = sdk
 
-  // `store` needs the secret value before touching the SDK at all, so a
-  // stdin read failure never reaches the biometric prompt.
+  // `store` reads the secret value before triggering the biometric prompt
+  // (`createClient` below), so a stdin read failure never costs the user a
+  // fresh presence action.
   let pendingSecret: string | undefined
   if (op === 'store') {
     try {
@@ -209,7 +210,10 @@ async function main(): Promise<void> {
         )
       } else if (err instanceof DesktopSessionExpiredError) {
         writeFailure('1Password session has expired', 'LOCKED')
-      } else if (err instanceof RateLimitExceededError) {
+      } else if (
+        typeof RateLimitExceededError === 'function' &&
+        err instanceof RateLimitExceededError
+      ) {
         // Not a human declining anything — a service-side throttle. Reporting
         // it as PRESENCE_DECLINED would misdirect the user toward the prompt.
         writeFailure(`1Password rate limit exceeded: ${String(err)}`, 'INTERNAL')

--- a/packages/vaultkeeper/src/backend/one-password-worker.ts
+++ b/packages/vaultkeeper/src/backend/one-password-worker.ts
@@ -88,13 +88,13 @@ function writeFailure(error: string, code: string): void {
 /** Read all of stdin (UTF-8) into a single string. Used only for `store`. */
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
-    let data = ''
+    const chunks: string[] = []
     process.stdin.setEncoding('utf8')
     process.stdin.on('data', (chunk: string) => {
-      data += chunk
+      chunks.push(chunk)
     })
     process.stdin.on('end', () => {
-      resolve(data)
+      resolve(chunks.join(''))
     })
     process.stdin.on('error', (err: unknown) => {
       reject(err instanceof Error ? err : new Error(String(err)))

--- a/packages/vaultkeeper/src/backend/one-password-worker.ts
+++ b/packages/vaultkeeper/src/backend/one-password-worker.ts
@@ -141,7 +141,7 @@ async function main(): Promise<void> {
     }
     process.exit(1)
   }
-  const { createClient, DesktopAuth, DesktopSessionExpiredError } = sdk
+  const { createClient, DesktopAuth, DesktopSessionExpiredError, RateLimitExceededError } = sdk
 
   // `store` needs the secret value before touching the SDK at all, so a
   // stdin read failure never reaches the biometric prompt.
@@ -209,6 +209,10 @@ async function main(): Promise<void> {
         )
       } else if (err instanceof DesktopSessionExpiredError) {
         writeFailure('1Password session has expired', 'LOCKED')
+      } else if (err instanceof RateLimitExceededError) {
+        // Not a human declining anything — a service-side throttle. Reporting
+        // it as PRESENCE_DECLINED would misdirect the user toward the prompt.
+        writeFailure(`1Password rate limit exceeded: ${String(err)}`, 'INTERNAL')
       } else {
         writeFailure(`1Password presence action declined: ${String(err)}`, 'PRESENCE_DECLINED')
       }

--- a/packages/vaultkeeper/src/backend/one-password-worker.ts
+++ b/packages/vaultkeeper/src/backend/one-password-worker.ts
@@ -113,6 +113,14 @@ async function main(): Promise<void> {
     process.exit(1)
   }
 
+  // Omitted op defaults to 'retrieve' (compatibility with parents that
+  // predate the write path). A PRESENT but unrecognized op is a
+  // parent/worker protocol mismatch — fail closed rather than silently
+  // running the wrong operation.
+  if (opArg !== undefined && !isValidOp(opArg)) {
+    writeFailure(`Worker invoked with unknown operation: ${opArg}`, 'INTERNAL')
+    process.exit(1)
+  }
   const op: WorkerOp = isValidOp(opArg) ? opArg : 'retrieve'
 
   // The SDK is an optional peer dependency, loaded lazily so the worker only

--- a/packages/vaultkeeper/test/unit/backend/capabilities.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/capabilities.test.ts
@@ -83,16 +83,17 @@ describe('per-backend truth basis (AC2)', () => {
     })
   })
 
-  it('1Password reports true only in per-access mode, and only for reads', async () => {
-    // per-access forces a fresh per-read biometric approval; session rides one
-    // cached unlock. Writes (store/delete) route through the cached session
-    // client, so per-access covers only the 'read' operation — a flagged
-    // store/delete must fail closed (see the enforcement tests).
+  it('1Password reports true only in per-access mode, covering read, store, and delete', async () => {
+    // per-access forces a fresh per-operation biometric approval for every
+    // keyed operation — reads route through the per-access worker (shipped in
+    // #210), and store/delete now do too (#211 closed the earlier gap where
+    // writes rode the cached session client). Session mode rides one cached
+    // unlock for everything, so it reports false.
     const perAccess = new OnePasswordBackend({ vault: 'v', accessMode: 'per-access' })
     const session = new OnePasswordBackend({ vault: 'v', accessMode: 'session' })
     await expect(perAccess.getCapabilities()).resolves.toEqual({
       presencePerUse: true,
-      presenceEnforcedOperations: ['read'],
+      presenceEnforcedOperations: ['read', 'store', 'delete'],
     })
     await expect(session.getCapabilities()).resolves.toEqual({ presencePerUse: false })
   })

--- a/packages/vaultkeeper/test/unit/backend/one-password-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/one-password-backend.test.ts
@@ -283,7 +283,7 @@ function makeWorkerErrorProcess(spawnErr: Error): MockChildProcess {
   // Present so a write-path spawn error (store, which writes to stdin before
   // the 'error' event fires) doesn't throw on a missing `.stdin` — retrieve
   // and delete never touch it.
-  const stdin = { write: vi.fn(), end: vi.fn() }
+  const stdin = { on: vi.fn(), write: vi.fn(), end: vi.fn() }
 
   const proc: MockChildProcess = {
     stdout,
@@ -347,6 +347,7 @@ function makeWorkerWriteProcess(
     }),
   }
   const stdin = {
+    on: vi.fn(),
     write: vi.fn((chunk: string) => {
       stdinRecorder?.writes.push(chunk)
     }),

--- a/packages/vaultkeeper/test/unit/backend/one-password-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/one-password-backend.test.ts
@@ -98,7 +98,10 @@ import {
   AuthorizationDeniedError,
   PluginNotFoundError,
   ConfigValidationError,
+  PresenceDeclinedError,
+  PresenceTimeoutError,
 } from '../../../src/errors.js'
+import { PRESENCE_WRITE_TIMEOUT_MS } from '../../../src/backend/one-password-constants.js'
 
 // ---- Test helpers ----
 
@@ -205,6 +208,11 @@ interface MockChildProcess {
     on: (event: string, cb: (chunk: Buffer) => void) => void
   }
   on: (event: string, cb: (...args: unknown[]) => void) => void
+  /** Only present on write-path mocks; retrieve never writes to stdin. */
+  stdin?: {
+    write: (chunk: string, encoding?: string) => void
+    end: () => void
+  }
 }
 
 interface WorkerProcessOptions {
@@ -272,10 +280,15 @@ function makeWorkerErrorProcess(spawnErr: Error): MockChildProcess {
 
   const stdout = { on: vi.fn() }
   const stderr = { on: vi.fn() }
+  // Present so a write-path spawn error (store, which writes to stdin before
+  // the 'error' event fires) doesn't throw on a missing `.stdin` — retrieve
+  // and delete never touch it.
+  const stdin = { write: vi.fn(), end: vi.fn() }
 
   const proc: MockChildProcess = {
     stdout,
     stderr,
+    stdin,
     on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
       if (event === 'error') errorListeners.push(cb)
     }),
@@ -284,6 +297,88 @@ function makeWorkerErrorProcess(spawnErr: Error): MockChildProcess {
   setTimeout(() => {
     for (const listener of errorListeners) {
       listener(spawnErr)
+    }
+  }, 0)
+
+  return proc
+}
+
+/** Records what a mock write-worker's stdin received, for argv-hygiene assertions. */
+interface StdinRecorder {
+  writes: string[]
+  ended: boolean
+}
+
+interface MockWriteChildProcess extends MockChildProcess {
+  stdin: {
+    write: (chunk: string, encoding?: string) => void
+    end: () => void
+  }
+}
+
+/**
+ * Set up a mock child process for the `store`/`delete` write path — same
+ * stdout/stderr/close wiring as {@link makeWorkerProcess}, plus a `stdin` that
+ * records what was written so tests can assert the secret value travelled via
+ * stdin, never argv.
+ */
+function makeWorkerWriteProcess(
+  stdoutDataOrOptions: string | WorkerProcessOptions,
+  stdinRecorder?: StdinRecorder,
+): MockWriteChildProcess {
+  const opts: WorkerProcessOptions =
+    typeof stdoutDataOrOptions === 'string' ? { stdout: stdoutDataOrOptions } : stdoutDataOrOptions
+  const stdoutData = opts.stdout ?? ''
+  const stderrData = opts.stderr ?? ''
+  const exitCode = opts.exitCode ?? 0
+
+  const stdoutListeners: ((chunk: Buffer) => void)[] = []
+  const stderrListeners: ((chunk: Buffer) => void)[] = []
+  const closeListeners: ((...args: unknown[]) => void)[] = []
+
+  const stdout = {
+    on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+      if (event === 'data') stdoutListeners.push(cb)
+    }),
+  }
+  const stderr = {
+    on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+      if (event === 'data') stderrListeners.push(cb)
+    }),
+  }
+  const stdin = {
+    write: vi.fn((chunk: string) => {
+      stdinRecorder?.writes.push(chunk)
+    }),
+    end: vi.fn(() => {
+      if (stdinRecorder !== undefined) {
+        stdinRecorder.ended = true
+      }
+    }),
+  }
+
+  const proc: MockWriteChildProcess = {
+    stdout,
+    stderr,
+    stdin,
+    on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+      if (event === 'close') closeListeners.push(cb)
+    }),
+  }
+
+  setTimeout(() => {
+    if (stdoutData !== '') {
+      for (const listener of stdoutListeners) {
+        listener(Buffer.from(stdoutData, 'utf8'))
+      }
+    }
+    if (stderrData !== '') {
+      for (const listener of stderrListeners) {
+        listener(Buffer.from(stderrData, 'utf8'))
+      }
+    }
+    for (const listener of closeListeners) {
+      listener(exitCode)
     }
   }, 0)
 
@@ -630,26 +725,6 @@ describe('OnePasswordBackend', () => {
       expect(mockCreateClient).not.toHaveBeenCalled()
     })
 
-    it('should use session client for store in per-access mode', async () => {
-      const backend = makePerAccessBackend()
-      mockList.mockResolvedValue([])
-
-      await backend.store('my-secret', 'val')
-
-      expect(mockCreateClient).toHaveBeenCalledTimes(1)
-      expect(mockSpawn).not.toHaveBeenCalled()
-    })
-
-    it('should use session client for delete in per-access mode', async () => {
-      const backend = makePerAccessBackend()
-      mockList.mockResolvedValue([makeOverview('item-1', 'my-secret')])
-
-      await backend.delete('my-secret')
-
-      expect(mockCreateClient).toHaveBeenCalledTimes(1)
-      expect(mockSpawn).not.toHaveBeenCalled()
-    })
-
     it('should use session client for exists in per-access mode', async () => {
       const backend = makePerAccessBackend()
       mockList.mockResolvedValue([makeOverview('item-1', 'my-secret')])
@@ -825,6 +900,217 @@ describe('OnePasswordBackend', () => {
       expect(error).not.toBeInstanceOf(SecretNotFoundError)
       // The real load error text is preserved, not swapped for a "reinstall" hint.
       expect(error instanceof Error ? error.message : '').toContain('native binding failed')
+    })
+  })
+
+  // ---- store (per-access mode) — issue #211 ----
+
+  describe('store — per-access mode', () => {
+    it('should spawn a worker forcing a fresh action instead of using the session client', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(JSON.stringify({ ok: true }))
+      mockSpawn.mockReturnValue(proc)
+
+      await backend.store('my-secret', 'hunter2')
+
+      expect(mockSpawn).toHaveBeenCalledTimes(1)
+      expect(mockCreateClient).not.toHaveBeenCalled()
+    })
+
+    // Regression: issue #211 — before the write path existed, per-access store
+    // silently routed through the cached session client, so a
+    // --require-presence-per-use store never forced a fresh action. This pins
+    // the fix: store must go through the worker in per-access mode.
+    it('should force a fresh action for each store call (two stores spawn two workers)', async () => {
+      const backend = makePerAccessBackend()
+      mockSpawn
+        .mockReturnValueOnce(makeWorkerWriteProcess(JSON.stringify({ ok: true })))
+        .mockReturnValueOnce(makeWorkerWriteProcess(JSON.stringify({ ok: true })))
+
+      await backend.store('a', '1')
+      await backend.store('b', '2')
+
+      expect(mockSpawn).toHaveBeenCalledTimes(2)
+    })
+
+    it('should deliver the secret value via stdin, never as a spawn argument (argv hygiene)', async () => {
+      const backend = makePerAccessBackend()
+      const stdinRecorder: StdinRecorder = { writes: [], ended: false }
+      const proc = makeWorkerWriteProcess(JSON.stringify({ ok: true }), stdinRecorder)
+      mockSpawn.mockReturnValue(proc)
+
+      await backend.store('my-secret', 'super-secret-value')
+
+      // The secret must never appear among the spawn arguments.
+      const spawnArgs: unknown = mockSpawn.mock.calls[0]?.[1]
+      expect(Array.isArray(spawnArgs)).toBe(true)
+      if (Array.isArray(spawnArgs)) {
+        for (const arg of spawnArgs) {
+          expect(arg).not.toContain('super-secret-value')
+        }
+      }
+      // It travelled over stdin instead, and stdin was closed.
+      expect(stdinRecorder.writes.join('')).toBe('super-secret-value')
+      expect(stdinRecorder.ended).toBe(true)
+    })
+
+    it('should pass the store op and secret id as spawn arguments', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(JSON.stringify({ ok: true }))
+      mockSpawn.mockReturnValue(proc)
+
+      await backend.store('my-secret', 'v')
+
+      const spawnArgs: unknown = mockSpawn.mock.calls[0]?.[1]
+      expect(spawnArgs).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('one-password-worker'),
+          'my-secret',
+          'store',
+        ]),
+      )
+    })
+
+    it('should throw PresenceDeclinedError when the worker reports PRESENCE_DECLINED', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(
+        JSON.stringify({ error: 'presence action declined', code: 'PRESENCE_DECLINED' }),
+      )
+      mockSpawn.mockReturnValue(proc)
+
+      await expect(backend.store('my-secret', 'v')).rejects.toBeInstanceOf(PresenceDeclinedError)
+    })
+
+    it('should throw PresenceTimeoutError with the configured timeout when the worker reports PRESENCE_TIMEOUT', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(
+        JSON.stringify({ error: 'no fresh action within window', code: 'PRESENCE_TIMEOUT' }),
+      )
+      mockSpawn.mockReturnValue(proc)
+
+      const error = await backend.store('my-secret', 'v').catch((err: unknown) => err)
+      expect(error).toBeInstanceOf(PresenceTimeoutError)
+      if (error instanceof PresenceTimeoutError) {
+        expect(error.timeoutMs).toBe(PRESENCE_WRITE_TIMEOUT_MS)
+        expect(error.backendType).toBe('1password')
+      }
+      expect(error).not.toBeInstanceOf(PresenceDeclinedError)
+    })
+
+    it('should throw BackendLockedError when the worker reports LOCKED', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(JSON.stringify({ error: 'locked', code: 'LOCKED' }))
+      mockSpawn.mockReturnValue(proc)
+
+      await expect(backend.store('my-secret', 'v')).rejects.toBeInstanceOf(BackendLockedError)
+    })
+
+    it('should throw PluginNotFoundError when the worker reports PLUGIN_NOT_FOUND', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(
+        JSON.stringify({ error: 'SDK not installed', code: 'PLUGIN_NOT_FOUND' }),
+      )
+      mockSpawn.mockReturnValue(proc)
+
+      await expect(backend.store('my-secret', 'v')).rejects.toBeInstanceOf(PluginNotFoundError)
+    })
+
+    it('should throw a typed BackendUnavailableError when the worker reports INTERNAL', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(
+        JSON.stringify({ error: 'unexpected failure', code: 'INTERNAL' }),
+      )
+      mockSpawn.mockReturnValue(proc)
+
+      const error = await backend.store('my-secret', 'v').catch((err: unknown) => err)
+      expect(error).toBeInstanceOf(BackendUnavailableError)
+      expect(error instanceof Error ? error.message : '').toContain('unexpected failure')
+    })
+
+    it('should throw a typed BackendUnavailableError when worker output is unparseable', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess('not-valid-json{{')
+      mockSpawn.mockReturnValue(proc)
+
+      await expect(backend.store('my-secret', 'v')).rejects.toBeInstanceOf(BackendUnavailableError)
+    })
+
+    it('should throw a typed BackendUnavailableError when the worker crashes with no stdout', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess({ stdout: '', stderr: '', exitCode: 137 })
+      mockSpawn.mockReturnValue(proc)
+
+      const error = await backend.store('my-secret', 'v').catch((err: unknown) => err)
+      expect(error).toBeInstanceOf(BackendUnavailableError)
+      if (error instanceof BackendUnavailableError) {
+        expect(error.reason).toBe('worker-crashed')
+      }
+    })
+
+    it('should throw a typed BackendUnavailableError when spawn itself errors', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerErrorProcess(new Error('spawn ENOENT'))
+      mockSpawn.mockReturnValue(proc)
+
+      const error = await backend.store('my-secret', 'v').catch((err: unknown) => err)
+      expect(error).toBeInstanceOf(BackendUnavailableError)
+      if (error instanceof BackendUnavailableError) {
+        expect(error.reason).toBe('worker-spawn-failed')
+      }
+    })
+  })
+
+  // ---- delete (per-access mode) — issue #211 ----
+
+  describe('delete — per-access mode', () => {
+    it('should spawn a worker forcing a fresh action instead of using the session client', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(JSON.stringify({ ok: true }))
+      mockSpawn.mockReturnValue(proc)
+
+      await backend.delete('my-secret')
+
+      expect(mockSpawn).toHaveBeenCalledTimes(1)
+      expect(mockCreateClient).not.toHaveBeenCalled()
+    })
+
+    it('should not write anything to stdin (no secret value to send)', async () => {
+      const stdinRecorder: StdinRecorder = { writes: [], ended: false }
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(JSON.stringify({ ok: true }), stdinRecorder)
+      mockSpawn.mockReturnValue(proc)
+
+      await backend.delete('my-secret')
+
+      expect(stdinRecorder.writes).toEqual([])
+    })
+
+    it('should throw SecretNotFoundError when the worker reports NOT_FOUND', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(JSON.stringify({ error: 'not found', code: 'NOT_FOUND' }))
+      mockSpawn.mockReturnValue(proc)
+
+      await expect(backend.delete('missing')).rejects.toBeInstanceOf(SecretNotFoundError)
+    })
+
+    it('should throw PresenceDeclinedError when the worker reports PRESENCE_DECLINED', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(
+        JSON.stringify({ error: 'presence action declined', code: 'PRESENCE_DECLINED' }),
+      )
+      mockSpawn.mockReturnValue(proc)
+
+      await expect(backend.delete('my-secret')).rejects.toBeInstanceOf(PresenceDeclinedError)
+    })
+
+    it('should throw PresenceTimeoutError when the worker reports PRESENCE_TIMEOUT', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(
+        JSON.stringify({ error: 'no fresh action within window', code: 'PRESENCE_TIMEOUT' }),
+      )
+      mockSpawn.mockReturnValue(proc)
+
+      await expect(backend.delete('my-secret')).rejects.toBeInstanceOf(PresenceTimeoutError)
     })
   })
 

--- a/packages/vaultkeeper/test/unit/backend/one-password-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/one-password-backend.test.ts
@@ -1035,6 +1035,21 @@ describe('OnePasswordBackend', () => {
       await expect(backend.store('my-secret', 'v')).rejects.toBeInstanceOf(BackendUnavailableError)
     })
 
+    // Regression for the PR #222 review thread (comment 3592005272): a
+    // malformed worker response carrying BOTH `ok: false` and an error/code
+    // pair passes the response-shape guard via its failure branch. The
+    // success narrowing must check ok's VALUE, not mere key presence — this
+    // response is a failed write and must never be classified as success.
+    it('treats an { ok: false, error, code } worker response as a failure, never success', async () => {
+      const backend = makePerAccessBackend()
+      const proc = makeWorkerWriteProcess(
+        JSON.stringify({ ok: false, error: 'write exploded', code: 'INTERNAL' }),
+      )
+      mockSpawn.mockReturnValue(proc)
+
+      await expect(backend.store('my-secret', 'v')).rejects.toBeInstanceOf(BackendUnavailableError)
+    })
+
     it('should throw a typed BackendUnavailableError when the worker crashes with no stdout', async () => {
       const backend = makePerAccessBackend()
       const proc = makeWorkerWriteProcess({ stdout: '', stderr: '', exitCode: 137 })


### PR DESCRIPTION
## Summary

PR #210 shipped presence-per-use enforcement with operation coverage, but the 1Password per-access worker was read-only, so `OnePasswordBackend` reported `presenceEnforcedOperations: ['read']` and a flagged `--require-presence-per-use store`/`delete` failed closed with `NotCapableError`. This extends the worker with a write path so that guarantee becomes real for writes too.

- The per-access worker (`one-password-worker.ts`) now accepts `store` and `delete` operations in addition to `retrieve`. `store`'s secret value is delivered over **stdin**, never argv, so it never appears in a process listing, shell history, or log — mirroring the stdin plumbing `execCommandFull` already uses in `util/exec.ts`.
- `OnePasswordBackend.store()`/`delete()` route through the worker (a fresh spawned process forcing a fresh biometric approval) when `accessMode: 'per-access'`, instead of the cached session client. `getCapabilities()` now reports `presenceEnforcedOperations: ['read', 'store', 'delete']`.
- A declined presence action during a write maps to `PresenceDeclinedError`; a timed-out one (bounded by a new `PRESENCE_WRITE_TIMEOUT_MS` constant) maps to `PresenceTimeoutError`. The read path is unchanged — this is a non-goal per the issue.
- Create-or-update/delete/find-by-title logic is extracted into a new shared module, `one-password-item-ops.ts`, imported by both the backend (session mode) and the worker (per-access mode), so the two can't diverge.
- Docs: per-backend truth-basis table in the library README, and the 1Password section of `docs/manual-tests/presence-per-use.md`, updated to reflect write coverage. Changeset (minor) added for `vaultkeeper`.

## Acceptance criteria → tests

1. Worker accepts store (stdin value)/delete forcing fresh approval, no secret in argv/logs → `one-password-backend.test.ts`: `store — per-access mode > should deliver the secret value via stdin, never as a spawn argument (argv hygiene)`, plus the full `store — per-access mode` / `delete — per-access mode` suites (17 tests) exercising spawn args, PRESENCE_DECLINED/PRESENCE_TIMEOUT/LOCKED/PLUGIN_NOT_FOUND/NOT_FOUND/INTERNAL/crash/unparseable/spawn-error paths.
2. `OnePasswordBackend` routes flagged store/delete through the worker; `presenceEnforcedOperations` includes `'store'`/`'delete'` → `capabilities.test.ts`: `1Password reports true only in per-access mode, covering read, store, and delete` (flipped from the #210 read-only expectation).
3. Create-or-update/delete logic shared, not diverged → new `one-password-item-ops.ts`, imported by both `one-password-backend.ts` and `one-password-worker.ts`.
4. Mock-worker tests for declined/timeout/argv-hygiene, #210 NotCapableError expectations flipped → the two former "should use session client for store/delete in per-access mode" tests (which encoded the pre-#211 gap) are removed and replaced by the new per-access `store`/`delete` describe blocks asserting worker/spawn usage and the full error-code mapping, including `PresenceDeclinedError`/`PresenceTimeoutError`.
5. Docs/changeset → `packages/vaultkeeper/README.md` truth-basis table + caveat, `docs/manual-tests/presence-per-use.md` 1Password section, `.changeset/one-password-worker-write-path.md` (minor on `vaultkeeper`). No public API surface change, so `api-report`/`docs/api` are unaffected (verified via `pnpm generate:api-report` and `pnpm check:api-docs`).

## Non-goals (unchanged, per issue)

Read path, touch-device backends, and the operation-coverage contract shape (all shipped in #210).

## Test plan

- [x] `pnpm --filter vaultkeeper check:typecheck`
- [x] `pnpm --filter vaultkeeper check:lint-ts`
- [x] `pnpm --filter vaultkeeper test` (956 passed)
- [x] `pnpm build` / `pnpm check` / `pnpm test` at the workspace root
- [x] `pnpm check:api-docs` (docs/api up to date, no regen needed)

Refs #211