### PR TITLE
Refuse a late TOFU conflict at commit instead of merging it in (TS)

### DIFF
--- a/.changeset/ts-late-tofu-conflict.md
+++ b/.changeset/ts-late-tofu-conflict.md
@@ -1,0 +1,5 @@
+---
+'vaultkeeper': patch
+---
+
+Fix a late TOFU conflict window in `commitTrust`: if another process recorded a _different_ executable hash for the same trust-manifest namespace between the verify and commit phases, `commitTrust` reloaded the manifest but then unconditionally merged the staged hash in — silently approving a second hash for that namespace and bypassing the TOFU-conflict record-nothing rule. `commitTrust` now re-classifies the staged entry against the freshly reloaded manifest: an already-trusted hash stays a no-op, an empty namespace still merges, but a namespace whose approved hashes don't include the staged one now throws `IdentityMismatchError` and writes nothing. Mirrors the Rust `PendingTrust::commit` fix.

--- a/packages/vaultkeeper/src/identity/trust.ts
+++ b/packages/vaultkeeper/src/identity/trust.ts
@@ -15,6 +15,7 @@
 
 import { hashExecutable } from './hash.js'
 import { loadManifest, saveManifest, addTrustedHash, isTrusted } from './manifest.js'
+import { IdentityMismatchError } from '../errors.js'
 import type { TrustVerificationResult, TrustOptions, PendingTrust } from './types.js'
 
 /** Attempt Sigstore bundle verification (Tier 1). Returns `true` on success. */
@@ -152,7 +153,7 @@ export async function verifyTrustPending(
 
 /**
  * Commit phase of the verify/commit split: persist a {@link PendingTrust}'s
- * staged namespace/hash entry, if any.
+ * staged trust-manifest entry, if any.
  *
  * A no-op when {@link PendingTrust.pendingWrite} is `undefined` (a registry
  * match, a TOFU conflict, or dev-mode bypass never write).
@@ -160,11 +161,25 @@ export async function verifyTrustPending(
  * Verification and commit are not atomic — another process can write to the
  * manifest in between (e.g. approving a different executable, or the same
  * one). To avoid clobbering that concurrent write, this reloads the manifest
- * from disk immediately before saving and unions `pendingWrite` into the
- * *current* state, rather than persisting the snapshot captured back in
- * {@link verifyTrustPending}.
+ * from disk immediately before saving and re-classifies the staged
+ * `(namespace, hash)` entry against the *current* state, rather than
+ * persisting a snapshot captured back in {@link verifyTrustPending} (#209):
+ *
+ * - Already trusted (e.g. a concurrent commit for the same executable landed
+ *   first) — a no-op; skipping the redundant `saveManifest` avoids
+ *   unnecessary I/O and shrinks the window for a last-writer-wins race.
+ * - The namespace has approved hashes that do **not** include the staged one
+ *   — a concurrent process recorded a *different* executable for this
+ *   namespace in the window since verification. Merging anyway would
+ *   silently approve a second hash for one namespace, bypassing the
+ *   TOFU-conflict record-nothing rule enforced at verify time (#148). This
+ *   re-classifies as a conflict: throws {@link IdentityMismatchError} and
+ *   writes nothing.
+ * - The namespace has no entry yet — merges the staged entry in, as before.
  *
  * @param pending - The result of {@link verifyTrustPending} to commit.
+ * @throws {@link IdentityMismatchError} If a concurrent process recorded a
+ *   different hash for the same namespace since verification.
  * @internal
  */
 export async function commitTrust(pending: PendingTrust): Promise<void> {
@@ -173,6 +188,18 @@ export async function commitTrust(pending: PendingTrust): Promise<void> {
   }
   const { namespace, hash } = pending.pendingWrite
   const current = await loadManifest(pending.configDir)
+  const existing = current.get(namespace)
+  if (existing?.hashes.includes(hash) === true) {
+    return
+  }
+  if (existing !== undefined && existing.hashes.length > 0) {
+    const previousHash = existing.hashes.at(-1) ?? hash
+    throw new IdentityMismatchError(
+      'Executable hash changed — re-approval required',
+      previousHash,
+      hash,
+    )
+  }
   const merged = addTrustedHash(current, namespace, hash)
   await saveManifest(pending.configDir, merged)
 }

--- a/packages/vaultkeeper/test/unit/identity/trust.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/trust.test.ts
@@ -4,6 +4,7 @@ import * as os from 'node:os'
 import * as path from 'node:path'
 import { verifyTrust, verifyTrustPending, commitTrust } from '../../../src/identity/trust.js'
 import { loadManifest, addTrustedHash, saveManifest } from '../../../src/identity/manifest.js'
+import { IdentityMismatchError } from '../../../src/errors.js'
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vaultkeeper-trust-'))
@@ -294,6 +295,73 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
       const manifest = await loadManifest(configDir)
       expect(manifest.get('other-tool')?.hashes).toEqual(['concurrent-hash'])
       expect(manifest.has('my-tool')).toBe(true)
+    })
+  })
+
+  // Issue #223 (mirrors Rust fix c46913d, #213 review follow-up): a *late*
+  // TOFU conflict. If a concurrent process records a DIFFERENT hash for the
+  // SAME namespace in the window between verify and commit, blindly merging
+  // the staged hash would silently approve a second hash for one namespace —
+  // bypassing the TOFU-conflict record-nothing rule enforced at verify time
+  // (issue #148). commitTrust must re-classify against the freshly reloaded
+  // manifest and refuse: throw IdentityMismatchError and write nothing.
+  it('commitTrust refuses when a concurrent process recorded a different hash for the same namespace', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')
+      const configDir = path.join(dir, 'config')
+
+      const pending = await verifyTrustPending(execPath, {
+        configDir,
+        namespace: 'my-tool',
+        skipSigstore: true,
+      })
+      const stagedHash = pending.identity.hash
+
+      // Simulate a concurrent process recording a DIFFERENT hash for the SAME
+      // namespace before our commit reloads the manifest.
+      const concurrentManifest = await loadManifest(configDir)
+      const withOtherHash = addTrustedHash(concurrentManifest, 'my-tool', 'concurrent-hash-b')
+      await saveManifest(configDir, withOtherHash)
+
+      await expect(commitTrust(pending)).rejects.toThrow(IdentityMismatchError)
+
+      // Nothing was written beyond the concurrent entry: our staged hash never
+      // landed, and the namespace still has only one approved hash.
+      const manifest = await loadManifest(configDir)
+      expect(manifest.get('my-tool')?.hashes).toEqual(['concurrent-hash-b'])
+      expect(manifest.get('my-tool')?.hashes).not.toContain(stagedHash)
+    })
+  })
+
+  it('commitTrust throws IdentityMismatchError carrying the previous and staged hashes', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')
+      const configDir = path.join(dir, 'config')
+
+      const pending = await verifyTrustPending(execPath, {
+        configDir,
+        namespace: 'my-tool',
+        skipSigstore: true,
+      })
+      const stagedHash = pending.identity.hash
+
+      const concurrentManifest = await loadManifest(configDir)
+      const withOtherHash = addTrustedHash(concurrentManifest, 'my-tool', 'concurrent-hash-b')
+      await saveManifest(configDir, withOtherHash)
+
+      let caught: unknown
+      try {
+        await commitTrust(pending)
+      } catch (err) {
+        caught = err
+      }
+      if (!(caught instanceof IdentityMismatchError)) {
+        throw new Error(
+          `expected commitTrust to throw IdentityMismatchError, got: ${String(caught)}`,
+        )
+      }
+      expect(caught.previousHash).toBe('concurrent-hash-b')
+      expect(caught.currentHash).toBe(stagedHash)
     })
   })
 

--- a/packages/vaultkeeper/test/unit/identity/trust.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/trust.test.ts
@@ -385,14 +385,19 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
       const concurrentManifest = await loadManifest(configDir)
       await saveManifest(configDir, addTrustedHash(concurrentManifest, 'my-tool', stagedHash))
       const manifestPath = path.join(configDir, 'trust-manifest.json')
-      const before = await fs.stat(manifestPath)
+      // Pin the mtime to a fixed past instant so ANY rewrite — which stamps
+      // ~now — is detectable regardless of the filesystem's timestamp
+      // resolution (a plain before/after comparison can false-pass on
+      // coarse-resolution filesystems when both reads land in one tick).
+      const sentinel = new Date('2020-01-01T00:00:00.000Z')
+      await fs.utimes(manifestPath, sentinel, sentinel)
 
       await expect(commitTrust(pending)).resolves.toBeUndefined()
 
-      // No redundant save: the file was not rewritten, and the namespace still
-      // holds exactly one copy of the hash.
+      // No redundant save: the file still carries the sentinel mtime, and the
+      // namespace still holds exactly one copy of the hash.
       const after = await fs.stat(manifestPath)
-      expect(after.mtimeMs).toBe(before.mtimeMs)
+      expect(after.mtimeMs).toBe(sentinel.getTime())
       const manifest = await loadManifest(configDir)
       expect(manifest.get('my-tool')?.hashes).toEqual([stagedHash])
     })

--- a/packages/vaultkeeper/test/unit/identity/trust.test.ts
+++ b/packages/vaultkeeper/test/unit/identity/trust.test.ts
@@ -365,6 +365,39 @@ describe('verifyTrustPending / commitTrust — verify/commit split (#148)', () =
     })
   })
 
+  // Mirrors Rust's commit_skips_save_when_staged_entry_already_trusted: when a
+  // concurrent commit of the SAME hash landed first, the staged entry is
+  // already trusted — commit must no-op without a redundant save (the
+  // last-writer-wins window shrinks when we skip the write entirely).
+  it('commitTrust no-ops without rewriting when the staged hash is already trusted', async () => {
+    await withTempDir(async (dir) => {
+      const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')
+      const configDir = path.join(dir, 'config')
+
+      const pending = await verifyTrustPending(execPath, {
+        configDir,
+        namespace: 'my-tool',
+        skipSigstore: true,
+      })
+      const stagedHash = pending.identity.hash
+
+      // Simulate a concurrent commit of the SAME executable landing first.
+      const concurrentManifest = await loadManifest(configDir)
+      await saveManifest(configDir, addTrustedHash(concurrentManifest, 'my-tool', stagedHash))
+      const manifestPath = path.join(configDir, 'trust-manifest.json')
+      const before = await fs.stat(manifestPath)
+
+      await expect(commitTrust(pending)).resolves.toBeUndefined()
+
+      // No redundant save: the file was not rewritten, and the namespace still
+      // holds exactly one copy of the hash.
+      const after = await fs.stat(manifestPath)
+      expect(after.mtimeMs).toBe(before.mtimeMs)
+      const manifest = await loadManifest(configDir)
+      expect(manifest.get('my-tool')?.hashes).toEqual([stagedHash])
+    })
+  })
+
   it('verifyTrust (eager wrapper) still verifies and commits in one call', async () => {
     await withTempDir(async (dir) => {
       const execPath = await createTempBinary(dir, 'my-tool', 'binary-content-v1')


### PR DESCRIPTION
## Summary

`commitTrust` (`packages/vaultkeeper/src/identity/trust.ts`) reloads the on-disk trust manifest at commit time but was unconditionally merging the staged `(namespace, hash)` entry into it via `addTrustedHash`. If a concurrent process recorded a *different* hash for the same namespace during the verify→commit window, that merge silently approved a second hash for the namespace — bypassing the TOFU-conflict record-nothing rule (#148). This mirrors the Rust fix already merged on PR #213 (commit c46913d on `fix/rust-trust-manifest-merge`).

`commitTrust` now re-classifies the staged entry against the freshly reloaded manifest:
- staged hash already present → no-op (unchanged behavior, no write)
- namespace occupied by other hashes only → throws `IdentityMismatchError`, writes nothing
- namespace empty/absent → merges and saves, as before

## Acceptance criteria mapping (issue #223)

| Criterion | Test |
|---|---|
| 1. Re-classification semantics (no-op / conflict / merge) | Implementation in `commitTrust`; exercised by all three branches across the existing and new tests below |
| 2. Regression test: verify hash A, concurrent direct write of hash B to the same namespace → commit throws `IdentityMismatchError`, manifest still holds only B | `commitTrust refuses when a concurrent process recorded a different hash for the same namespace` and `commitTrust throws IdentityMismatchError carrying the previous and staged hashes` in `packages/vaultkeeper/test/unit/identity/trust.test.ts` |
| 3. Existing cross-namespace interleaving test (#204) still passes unchanged | `commitTrust merges with a concurrent manifest write instead of clobbering it` — unmodified, still green |
| 4. Patch changeset; internal API only | `.changeset/ts-late-tofu-conflict.md` added; `pnpm generate:api-report` produced no diff and `pnpm check:api-docs` reports docs up to date |

**Fails-before evidence:** the two new regression tests were run against the pre-fix `commitTrust` and failed as expected:
```
× commitTrust refuses when a concurrent process recorded a different hash for the same namespace
  → promise resolved "undefined" instead of rejecting
× commitTrust throws IdentityMismatchError carrying the previous and staged hashes
  → expected undefined to be an instance of IdentityMismatchError
```
After applying the fix, all 41 tests in `trust.test.ts` + `vault-trust.test.ts` pass.

## Non-goals

File locking/atomicity beyond this re-classification; the Rust side (already in #213).

Refs #213, #209, #204, #148, #223