### PR TITLE
Fix CLI README sign/verify example + add README example-fence CI check

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ await vault.fetch(token, {
 
 Minimal CLI flow:
 
+<!-- readme-example: skip - `exec` targets a placeholder caller path; see the CLI README for a runnable sign/verify walkthrough -->
+
 ```sh
 vaultkeeper config init                       # safe default: file backend
 echo "my-secret-value" | vaultkeeper store --name MY_API_KEY
@@ -129,6 +131,8 @@ Both the native Rust CLI and the Node.js CLI share the same command surface:
 > [!NOTE]
 > The safe `file` default described below (a bare `config init` writing the `file` backend) currently applies to the **Node.js CLI** and the TypeScript library. The native Rust CLI's zero-config default still targets the platform-native store; converging it onto this behavior is tracked in [#75](https://github.com/mike-north/vaultkeeper/issues/75).
 
+<!-- readme-example: skip - full command tour; `approve`/`exec`/`dev-mode` reference placeholder tool paths, not runnable verbatim -->
+
 ```sh
 # Every command accepts a global `--config-dir <path>` (or the
 # VAULTKEEPER_CONFIG_DIR env var) that isolates config, key material, and the
@@ -161,7 +165,11 @@ vaultkeeper key create --name approval-signing-key --type ed25519
 vaultkeeper key export --name approval-signing-key > approval.pub
 
 # Sign an arbitrary challenge from stdin; stdout is exactly the detached
-# signature (a compact JWS), so it is safe to redirect into a file
+# signature (a compact JWS), so it is safe to redirect into a file. Feed the
+# SAME bytes to sign and verify — here both read from `printf '%s'`. A
+# here-string (`<<<`) or `echo` would append a trailing newline, so verify
+# would see one more byte than sign signed and fail with exit 3.
+CHALLENGE="hello-challenge"
 printf '%s' "$CHALLENGE" | vaultkeeper sign --name approval-signing-key > sig
 
 # List each backend's security capabilities (which can force a fresh, per-use
@@ -175,7 +183,7 @@ printf '%s' "$CHALLENGE" | vaultkeeper sign --name approval-signing-key --requir
 
 # Verify a detached signature fully offline — only the public key, the payload
 # on stdin, and the signature. Exit 0 = valid, 3 = did not verify.
-vaultkeeper verify --public-key approval.pub --signature sig <<<"$CHALLENGE"
+printf '%s' "$CHALLENGE" | vaultkeeper verify --public-key approval.pub --signature sig
 
 # Pre-approve an executable (TOFU): records its SHA-256 in the trust manifest
 vaultkeeper approve --script /usr/local/bin/my-tool
@@ -203,6 +211,8 @@ On an interactive terminal you are prompted `[y/N]`; with non-TTY stdin (CI,
 Docker) there is no prompt, so approve the caller ahead of time — or approve a
 single invocation with `--yes` (or `VAULTKEEPER_YES=1`). The `file` backend needs
 no system credential store, which makes it a good fit for CI.
+
+<!-- readme-example: skip - CI recipe using `$CI_SCRIPT`/`./deploy.sh` placeholders, not runnable verbatim -->
 
 ```sh
 # Recommended: pre-approve the caller once, then exec runs unattended.

--- a/packages/cli-tests/test/e2e/readme-example-harness.ts
+++ b/packages/cli-tests/test/e2e/readme-example-harness.ts
@@ -187,11 +187,22 @@ export function runShellFence(fence: Fence): ShellRunResult {
       mode: 0o755,
     })
 
+    // Build a minimal, deterministic environment instead of inheriting the full
+    // parent env: README fences run verbatim, so they must not depend on ambient
+    // VAULTKEEPER_* toggles (which would make the example non-reproducible), and CI
+    // secrets must never be exposed to a fence that forwards env. Only HOME +
+    // VAULTKEEPER_CONFIG_DIR are set explicitly; a small locale/tmp allowlist is
+    // carried through when present so tools behave normally.
     const env: NodeJS.ProcessEnv = {
-      ...process.env,
       PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
       HOME: root,
       VAULTKEEPER_CONFIG_DIR: configDir,
+    }
+    for (const key of ['LANG', 'LC_ALL', 'LC_CTYPE', 'TMPDIR', 'TERM']) {
+      const value = process.env[key]
+      if (value !== undefined) {
+        env[key] = value
+      }
     }
 
     const result = spawnSync('bash', ['--noprofile', '--norc', '-euo', 'pipefail', '-c', fence.code], {

--- a/packages/cli-tests/test/e2e/readme-example-harness.ts
+++ b/packages/cli-tests/test/e2e/readme-example-harness.ts
@@ -202,8 +202,8 @@ export function runShellFence(fence: Fence): ShellRunResult {
     })
     return {
       exitCode: result.status ?? (result.signal !== null ? 1 : 0),
-      stdout: result.stdout ?? '',
-      stderr: result.stderr ?? '',
+      stdout: result.stdout,
+      stderr: result.stderr,
     }
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
@@ -258,7 +258,7 @@ export function typecheckCodeFence(fence: Fence): TypecheckResult {
     })
     return {
       exitCode: result.status ?? 1,
-      output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+      output: `${result.stdout}${result.stderr}`,
     }
   } finally {
     fs.rmSync(scratch, { recursive: true, force: true })

--- a/packages/cli-tests/test/e2e/readme-example-harness.ts
+++ b/packages/cli-tests/test/e2e/readme-example-harness.ts
@@ -22,7 +22,8 @@
  * Many fenced examples are intentionally illustrative fragments, not runnable
  * programs (they reference a `vault` bound in a previous fence, a placeholder
  * path like `/usr/local/bin/my-tool`, or a network endpoint). Mark such a fence
- * with an HTML comment on the line immediately preceding its opening fence:
+ * with an HTML comment preceding its opening fence — the extractor scans backward
+ * over any intervening blank lines, so the marker need not be immediately adjacent:
  *
  * ```md
  * <!-- readme-example: skip - references a vault from an earlier fence -->
@@ -200,6 +201,14 @@ export function runShellFence(fence: Fence): ShellRunResult {
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 60_000,
     })
+    // spawnSync could not start bash at all (missing binary, permission, etc.):
+    // status and signal are both null. Fail loudly instead of reporting a vacuous
+    // exitCode 0 that would let the fence check pass without running anything.
+    if (result.error) {
+      throw new Error(
+        `Failed to run shell fence from ${fence.readme}:${String(fence.startLine)}: ${result.error.message}`,
+      )
+    }
     return {
       exitCode: result.status ?? (result.signal !== null ? 1 : 0),
       stdout: result.stdout,

--- a/packages/cli-tests/test/e2e/readme-example-harness.ts
+++ b/packages/cli-tests/test/e2e/readme-example-harness.ts
@@ -265,6 +265,13 @@ export function typecheckCodeFence(fence: Fence): TypecheckResult {
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 120_000,
     })
+    // spawnSync could not start tsc at all (missing/non-executable binary, etc.):
+    // surface the underlying error instead of a silent, hard-to-diagnose failure.
+    if (result.error) {
+      throw new Error(
+        `Failed to run tsc for a TS/JS fence: ${result.error.message}`,
+      )
+    }
     return {
       exitCode: result.status ?? 1,
       output: `${result.stdout}${result.stderr}`,

--- a/packages/cli-tests/test/e2e/readme-example-harness.ts
+++ b/packages/cli-tests/test/e2e/readme-example-harness.ts
@@ -1,0 +1,266 @@
+/**
+ * Harness for validating the fenced examples in the *shipped* READMEs against
+ * the *built* packages, so a copy-pasteable example that no longer works fails
+ * CI instead of a real user (issue #217).
+ *
+ * Two validation modes, keyed off the fence language:
+ *
+ * - **Shell** fences (`sh` / `bash` / `shell` / `console`) are *executed*
+ *   verbatim through real `bash -euo pipefail` in an isolated config dir +
+ *   `file` backend, with a `vaultkeeper` shim on `PATH`. The command sequence
+ *   must exit `0`. Because it runs the *actual* shell, it reproduces shell
+ *   byte-semantics — e.g. it catches the `printf '%s'` (no newline) vs `<<<`
+ *   (trailing newline) sign/verify mismatch of issue #214, which makes the
+ *   detached signature verify fail with exit `3`.
+ * - **TypeScript/JavaScript** fences (`ts` / `js`) in the two *library*
+ *   READMEs are *type-checked* under the repo's strict NodeNext config against
+ *   each package's built `.d.ts`, so a snippet with a wrong signature (e.g. a
+ *   2-arg `setup()`) fails CI.
+ *
+ * ## Opting a fence out
+ *
+ * Many fenced examples are intentionally illustrative fragments, not runnable
+ * programs (they reference a `vault` bound in a previous fence, a placeholder
+ * path like `/usr/local/bin/my-tool`, or a network endpoint). Mark such a fence
+ * with an HTML comment on the line immediately preceding its opening fence:
+ *
+ * ```md
+ * <!-- readme-example: skip - references a vault from an earlier fence -->
+ * ```ts
+ * await vault.exec(token, { ... })
+ * ```
+ * ```
+ *
+ * The text after `skip` is a free-form reason (optional but encouraged).
+ * Package-manager install lines (`pnpm add`, `npm install`, `cargo install`,
+ * …) are auto-skipped without a marker because they need network access.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/217
+ * @see https://github.com/mike-north/vaultkeeper/issues/214
+ */
+import { spawnSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** Repo root, resolved from this file (packages/cli-tests/test/e2e/). */
+export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..')
+
+/** Languages whose fences are executed as shell scripts. */
+const SHELL_LANGS = new Set(['sh', 'bash', 'shell', 'console'])
+/** Languages whose fences are type-checked. */
+const TS_LANGS = new Set(['ts', 'typescript'])
+const JS_LANGS = new Set(['js', 'javascript'])
+
+/** A fenced code block extracted from a README. */
+export interface Fence {
+  /** README this fence came from, repo-relative (e.g. `packages/cli/README.md`). */
+  readme: string
+  /** Lowercased fence info-string language (e.g. `sh`, `ts`). */
+  lang: string
+  /** Fence body (without the ``` delimiters). */
+  code: string
+  /** 1-based line number of the opening ``` fence. */
+  startLine: number
+  /** True if a `readme-example: skip` marker precedes the fence. */
+  skipped: boolean
+  /** The free-form reason from the skip marker, if any. */
+  skipReason: string | undefined
+}
+
+const SKIP_MARKER = /<!--\s*readme-example:\s*skip\b[ \t-]*(.*?)\s*-->/i
+
+/**
+ * Extract every fenced code block from `markdown`, recording each fence's
+ * language, body, opening line, and whether a `readme-example: skip` HTML
+ * comment marker immediately precedes it (scanning back over blank lines).
+ */
+export function extractFences(markdown: string, readme: string): Fence[] {
+  const lines = markdown.split('\n')
+  const out: Fence[] = []
+  let i = 0
+  while (i < lines.length) {
+    const open = /^```(\S*)/.exec((lines[i] ?? '').trim())
+    if (open === null) {
+      i += 1
+      continue
+    }
+    const lang = (open[1] ?? '').toLowerCase()
+    const startLine = i + 1
+    const body: string[] = []
+    let j = i + 1
+    while (j < lines.length && !(lines[j] ?? '').trim().startsWith('```')) {
+      body.push(lines[j] ?? '')
+      j += 1
+    }
+    // Look back over blank lines for a skip marker on the preceding line.
+    let k = i - 1
+    while (k >= 0 && (lines[k] ?? '').trim() === '') k -= 1
+    const marker = k >= 0 ? SKIP_MARKER.exec(lines[k] ?? '') : null
+    out.push({
+      readme,
+      lang,
+      code: body.join('\n'),
+      startLine,
+      skipped: marker !== null,
+      skipReason: marker !== null ? (marker[1] === undefined || marker[1] === '' ? undefined : marker[1]) : undefined,
+    })
+    i = j + 1
+  }
+  return out
+}
+
+/** True when `fence` is a shell fence. */
+export function isShellFence(fence: Fence): boolean {
+  return SHELL_LANGS.has(fence.lang)
+}
+
+/** True when `fence` is a TypeScript or JavaScript fence. */
+export function isCodeFence(fence: Fence): boolean {
+  return TS_LANGS.has(fence.lang) || JS_LANGS.has(fence.lang)
+}
+
+const INSTALL_LINE = /^\s*(?:pnpm|npm|yarn|cargo)\s+(?:add|install|i|dlx)\b/
+
+/**
+ * A shell fence is auto-skipped (no marker required) when it only demonstrates
+ * a package-manager install — those need network access and are not part of the
+ * runnable walkthroughs.
+ */
+export function isInstallOnlyFence(fence: Fence): boolean {
+  const cmds = fence.code
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l !== '' && !l.startsWith('#'))
+  return cmds.length > 0 && cmds.every((l) => INSTALL_LINE.test(l))
+}
+
+/** Result of executing a shell fence. */
+export interface ShellRunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+const DEFAULT_CONFIG = {
+  version: 1,
+  backends: [{ type: 'file', enabled: true }],
+  keyRotation: { gracePeriodDays: 7 },
+  defaults: { ttlMinutes: 60, trustTier: 3 },
+}
+
+/** Resolve the CLI entry point: prefer the built `dist/bin.js`, else `src/bin.ts` via tsx. */
+function resolveCliCommand(): { runner: string; entry: string } {
+  const distBin = path.join(REPO_ROOT, 'packages', 'cli', 'dist', 'bin.js')
+  if (fs.existsSync(distBin)) return { runner: process.execPath, entry: distBin }
+  const tsx = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx')
+  return { runner: tsx, entry: path.join(REPO_ROOT, 'packages', 'cli', 'src', 'bin.ts') }
+}
+
+/**
+ * Execute a shell fence's body verbatim through `bash -euo pipefail` in a
+ * fresh isolated environment: a temp config dir seeded with a `file`-backend
+ * `config.json`, a temp working directory, and a `vaultkeeper` shim on `PATH`
+ * that invokes the real CLI. Returns the shell's exit code and output.
+ */
+export function runShellFence(fence: Fence): ShellRunResult {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-readme-'))
+  try {
+    const configDir = path.join(root, 'config')
+    const workDir = path.join(root, 'work')
+    const binDir = path.join(root, 'bin')
+    fs.mkdirSync(path.join(configDir, 'secrets'), { recursive: true })
+    fs.mkdirSync(workDir, { recursive: true })
+    fs.mkdirSync(binDir, { recursive: true })
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n', {
+      encoding: 'utf8',
+      mode: 0o600,
+    })
+
+    const { runner, entry } = resolveCliCommand()
+    const shim = path.join(binDir, 'vaultkeeper')
+    // Quote runner/entry so paths with spaces survive; forward all args + stdin.
+    fs.writeFileSync(shim, `#!/usr/bin/env bash\nexec ${JSON.stringify(runner)} ${JSON.stringify(entry)} "$@"\n`, {
+      encoding: 'utf8',
+      mode: 0o755,
+    })
+
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      HOME: root,
+      VAULTKEEPER_CONFIG_DIR: configDir,
+    }
+
+    const result = spawnSync('bash', ['--noprofile', '--norc', '-euo', 'pipefail', '-c', fence.code], {
+      cwd: workDir,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 60_000,
+    })
+    return {
+      exitCode: result.status ?? (result.signal !== null ? 1 : 0),
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+}
+
+/** Result of type-checking a TS/JS fence. */
+export interface TypecheckResult {
+  exitCode: number
+  output: string
+}
+
+const TSCONFIG = {
+  compilerOptions: {
+    target: 'ES2022',
+    module: 'NodeNext',
+    moduleResolution: 'NodeNext',
+    strict: true,
+    skipLibCheck: false,
+    noEmit: true,
+    // A realistic consumer environment: the READMEs instruct users to install
+    // @types/node (the public API references Buffer/process), so make it
+    // available here rather than the matrix's deliberately-bare `types: []`.
+    types: ['node'],
+    allowJs: true,
+    checkJs: true,
+  },
+}
+
+/**
+ * Type-check a TS/JS fence against the built package types. The snippet is
+ * written into `packages/cli-tests/` (whose `node_modules` links the workspace
+ * packages) so NodeNext resolution finds each package's built `.d.ts` through
+ * its `exports` map, exactly as an external consumer would.
+ */
+export function typecheckCodeFence(fence: Fence): TypecheckResult {
+  const scratch = fs.mkdtempSync(path.join(REPO_ROOT, 'packages', 'cli-tests', '.readme-tc-'))
+  try {
+    const ext = JS_LANGS.has(fence.lang) ? 'js' : 'ts'
+    fs.writeFileSync(path.join(scratch, `snippet.${ext}`), fence.code, 'utf8')
+    fs.writeFileSync(
+      path.join(scratch, 'tsconfig.json'),
+      JSON.stringify({ ...TSCONFIG, include: [`snippet.${ext}`] }, null, 2),
+      'utf8',
+    )
+    const tsc = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsc')
+    const result = spawnSync(tsc, ['-p', path.join(scratch, 'tsconfig.json')], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+    })
+    return {
+      exitCode: result.status ?? 1,
+      output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+    }
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true })
+  }
+}

--- a/packages/cli-tests/test/e2e/readme-examples.test.ts
+++ b/packages/cli-tests/test/e2e/readme-examples.test.ts
@@ -1,0 +1,161 @@
+/**
+ * README example drift guard (issue #217): the fenced examples in every shipped
+ * README are validated against the *built* packages, so an example that no
+ * longer works fails CI instead of a fresh user.
+ *
+ * - Shell fences in the CLI + root README are executed verbatim in an isolated
+ *   `file`-backend environment and must exit 0.
+ * - TS/JS fences in the two library READMEs are type-checked against the built
+ *   `.d.ts` and must compile clean.
+ *
+ * The proving case for issue #214 is the CLI README's sign/verify walkthrough:
+ * it reproduces the shell newline mismatch (`printf '%s'` vs `<<<`) that made
+ * the documented sequence fail, so this test fails against the pre-fix README
+ * and passes against the corrected one.
+ *
+ * See {@link ./readme-example-harness.ts} for the extraction/execution/type-check
+ * machinery and the documented `readme-example: skip` opt-out marker.
+ *
+ * @see https://github.com/mike-north/vaultkeeper/issues/217
+ * @see https://github.com/mike-north/vaultkeeper/issues/214
+ */
+import { readFileSync } from 'node:fs'
+import * as path from 'node:path'
+import { describe, it, expect } from 'vitest'
+import {
+  REPO_ROOT,
+  extractFences,
+  isShellFence,
+  isCodeFence,
+  isInstallOnlyFence,
+  runShellFence,
+  typecheckCodeFence,
+  type Fence,
+} from './readme-example-harness.js'
+
+/** READMEs whose shell fences are executed. */
+const EXEC_READMES = ['packages/cli/README.md', 'README.md']
+/** READMEs whose TS/JS fences are type-checked. */
+const TYPECHECK_READMES = ['packages/vaultkeeper/README.md', 'packages/vaultkeeper-wasm/README.md']
+
+function fencesFor(readme: string): Fence[] {
+  return extractFences(readFileSync(path.join(REPO_ROOT, readme), 'utf8'), readme)
+}
+
+const EXEC_FENCES = EXEC_READMES.flatMap(fencesFor).filter(isShellFence)
+const TYPECHECK_FENCES = TYPECHECK_READMES.flatMap(fencesFor).filter(isCodeFence)
+
+/** A fence is a sign/verify walkthrough if it drives both `sign` and `verify`. */
+function isSignVerifyFence(fence: Fence): boolean {
+  return /vaultkeeper sign\b/.test(fence.code) && /vaultkeeper verify\b/.test(fence.code)
+}
+
+describe('README shell examples run clean against the built CLI', () => {
+  for (const fence of EXEC_FENCES) {
+    const id = `${fence.readme}:${String(fence.startLine)}`
+    if (fence.skipped) {
+      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => {})
+      continue
+    }
+    if (isInstallOnlyFence(fence)) {
+      it.skip(`${id} (install-only, needs network)`, () => {})
+      continue
+    }
+    it(`${id} exits 0`, () => {
+      const result = runShellFence(fence)
+      expect(
+        result.exitCode,
+        `\`${fence.readme}\` fence at line ${String(fence.startLine)} exited ${String(result.exitCode)}.\n` +
+          `--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+      ).toBe(0)
+    })
+  }
+})
+
+describe('README TypeScript/JavaScript examples type-check against the built types', () => {
+  for (const fence of TYPECHECK_FENCES) {
+    const id = `${fence.readme}:${String(fence.startLine)}`
+    if (fence.skipped) {
+      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => {})
+      continue
+    }
+    it(`${id} (${fence.lang}) compiles`, () => {
+      const result = typecheckCodeFence(fence)
+      expect(
+        result.exitCode,
+        `\`${fence.readme}\` ${fence.lang} fence at line ${String(fence.startLine)} did not type-check:\n${result.output}`,
+      ).toBe(0)
+    })
+  }
+})
+
+describe('coverage guards (non-vacuous)', () => {
+  it('finds shell fences to execute and TS/JS fences to type-check', () => {
+    // Guard against a parser regression that silently matches nothing, which
+    // would make every check vacuously pass.
+    expect(EXEC_FENCES.some((f) => !f.skipped && !isInstallOnlyFence(f))).toBe(true)
+    expect(TYPECHECK_FENCES.some((f) => !f.skipped)).toBe(true)
+  })
+
+  it('executes the sign/verify walkthrough as the #214 proving case', () => {
+    // The CLI README's sign/verify walkthrough must be a real, executed fence —
+    // not skipped or install-only — so this suite genuinely reproduces #214.
+    const signVerify = EXEC_FENCES.filter(
+      (f) => f.readme === 'packages/cli/README.md' && isSignVerifyFence(f),
+    )
+    expect(signVerify.length).toBeGreaterThan(0)
+    for (const fence of signVerify) {
+      expect(fence.skipped, 'the sign/verify walkthrough must not be opted out').toBe(false)
+      expect(isInstallOnlyFence(fence)).toBe(false)
+    }
+  })
+
+  it('type-checks a quick-start fence in each library README', () => {
+    for (const readme of TYPECHECK_READMES) {
+      expect(
+        TYPECHECK_FENCES.some((f) => f.readme === readme && !f.skipped),
+        `${readme} should have at least one type-checked fence`,
+      ).toBe(true)
+    }
+  })
+})
+
+describe('harness: fence extraction and classification', () => {
+  it('records a skip marker (and its reason) on the immediately preceding line', () => {
+    const md = ['<!-- readme-example: skip - references an earlier vault -->', '```ts', 'await vault.x()', '```'].join(
+      '\n',
+    )
+    const [fence] = extractFences(md, 'X.md')
+    expect(fence?.skipped).toBe(true)
+    expect(fence?.skipReason).toBe('references an earlier vault')
+  })
+
+  it('detects a skip marker across intervening blank lines', () => {
+    const md = ['<!-- readme-example: skip -->', '', '```sh', 'vaultkeeper exec ...', '```'].join('\n')
+    const [fence] = extractFences(md, 'X.md')
+    expect(fence?.skipped).toBe(true)
+    expect(fence?.skipReason).toBeUndefined()
+  })
+
+  it('does not treat an ordinary fence as skipped', () => {
+    const md = ['Some prose.', '```sh', 'vaultkeeper doctor', '```'].join('\n')
+    const [fence] = extractFences(md, 'X.md')
+    expect(fence?.skipped).toBe(false)
+  })
+
+  it('auto-skips an install-only fence but not a real command sequence', () => {
+    const [install] = extractFences(['```sh', 'pnpm add -g @vaultkeeper/cli', '```'].join('\n'), 'X.md')
+    expect(install && isInstallOnlyFence(install)).toBe(true)
+    const [run] = extractFences(['```sh', '# install first', 'vaultkeeper doctor', '```'].join('\n'), 'X.md')
+    expect(run && isInstallOnlyFence(run)).toBe(false)
+  })
+
+  it('classifies fence languages', () => {
+    const fences = extractFences(
+      ['```sh', 'x', '```', '```ts', 'y', '```', '```json', 'z', '```'].join('\n'),
+      'X.md',
+    )
+    expect(fences.filter(isShellFence).map((f) => f.lang)).toEqual(['sh'])
+    expect(fences.filter(isCodeFence).map((f) => f.lang)).toEqual(['ts'])
+  })
+})

--- a/packages/cli-tests/test/e2e/readme-examples.test.ts
+++ b/packages/cli-tests/test/e2e/readme-examples.test.ts
@@ -54,11 +54,11 @@ describe('README shell examples run clean against the built CLI', () => {
   for (const fence of EXEC_FENCES) {
     const id = `${fence.readme}:${String(fence.startLine)}`
     if (fence.skipped) {
-      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => {})
+      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => { /* opted out */ })
       continue
     }
     if (isInstallOnlyFence(fence)) {
-      it.skip(`${id} (install-only, needs network)`, () => {})
+      it.skip(`${id} (install-only, needs network)`, () => { /* opted out */ })
       continue
     }
     it(`${id} exits 0`, () => {
@@ -76,7 +76,7 @@ describe('README TypeScript/JavaScript examples type-check against the built typ
   for (const fence of TYPECHECK_FENCES) {
     const id = `${fence.readme}:${String(fence.startLine)}`
     if (fence.skipped) {
-      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => {})
+      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => { /* opted out */ })
       continue
     }
     it(`${id} (${fence.lang}) compiles`, () => {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -155,7 +155,7 @@ CHALLENGE="hello-challenge"
 vaultkeeper key create --name approval-signing-key --type ed25519   # unknown --type exits 2
 vaultkeeper key export --name approval-signing-key > approval.pub   # SPKI PEM public key
 printf '%s' "$CHALLENGE" | vaultkeeper sign --name approval-signing-key > sig
-vaultkeeper verify --public-key approval.pub --signature sig <<<"$CHALLENGE"   # exit 0 = valid
+printf '%s' "$CHALLENGE" | vaultkeeper verify --public-key approval.pub --signature sig   # exit 0 = valid
 ```
 
 Feed `sign` and `verify` the payload the **same way** — here, `printf '%s'` piped into
@@ -174,6 +174,8 @@ the public key, the payload on stdin, and the signature.
 
 Discover which backends can force a **fresh, per-use human action** (a distinct touch/biometric that
 no cached or session unlock can satisfy), then require it for an operation:
+
+<!-- readme-example: skip - fragment; reuses the approval-signing-key and $CHALLENGE created in the sign/verify fence above -->
 
 ```sh
 # List each registered backend and whether it forces a fresh per-use action.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -152,7 +152,7 @@ fully offline:
 
 ```sh
 CHALLENGE="hello-challenge"
-vaultkeeper key create --name approval-signing-key --type ed25519   # unknown --type exits 2
+vaultkeeper key create --name approval-signing-key --type ed25519   # an unknown --type value exits 2
 vaultkeeper key export --name approval-signing-key > approval.pub   # SPKI PEM public key
 printf '%s' "$CHALLENGE" | vaultkeeper sign --name approval-signing-key > sig
 printf '%s' "$CHALLENGE" | vaultkeeper verify --public-key approval.pub --signature sig   # exit 0 = valid

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,8 @@ vaultkeeper --config-dir /tmp/ci-vault doctor
 VAULTKEEPER_CONFIG_DIR=/tmp/ci-vault vaultkeeper doctor
 ```
 
+<!-- readme-example: skip - overview of the command surface; `approve`/`exec`/`dev-mode` reference placeholder tool paths, not runnable verbatim -->
+
 ```sh
 # Run preflight checks
 vaultkeeper doctor
@@ -149,11 +151,18 @@ from stdin (the detached signature is the only thing on stdout, so it is pipelin
 fully offline:
 
 ```sh
+CHALLENGE="hello-challenge"
 vaultkeeper key create --name approval-signing-key --type ed25519   # unknown --type exits 2
 vaultkeeper key export --name approval-signing-key > approval.pub   # SPKI PEM public key
 printf '%s' "$CHALLENGE" | vaultkeeper sign --name approval-signing-key > sig
 vaultkeeper verify --public-key approval.pub --signature sig <<<"$CHALLENGE"   # exit 0 = valid
 ```
+
+Feed `sign` and `verify` the payload the **same way** — here, `printf '%s'` piped into
+both — so each reads byte-identical stdin. A detached signature covers the exact bytes it was
+given, so a construct that changes them breaks verification: a here-string (`<<<"$CHALLENGE"`)
+appends a trailing newline in bash and zsh, and `echo` does too, so mixing either with
+`printf '%s'` makes `verify` see one more byte than `sign` signed and fail with exit `3`.
 
 The signature is a detached-payload Compact JWS (algorithm `EdDSA` / Ed25519; base64url without
 padding, [RFC 7515](https://www.rfc-editor.org/rfc/rfc7515); detached payload via

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -127,6 +127,8 @@ Other access patterns share the same capability-token flow (`setup()` → `autho
 which is visible to other processes via `ps`. Placeholders are substituted in `env` values only
 (passing `{{secret}}` in `command`/`args` throws `ExecError`):
 
+<!-- readme-example: skip - fragment; `vault`/`token` come from the quick-start fence above -->
+
 ```ts
 // `token` comes from authorize(), exactly like the fetch() example above.
 const { result } = await vault.exec(token, {
@@ -145,6 +147,8 @@ applies. With a `SecretTokenMap` (multiple secrets), **every** injected value is
 out and receive the raw, unredacted output — for example when you need to parse a payload that
 legitimately contains the value — pass `redact: false` (mirroring the CLI's `--no-redact`):
 
+<!-- readme-example: skip - fragment; `vault`/`token` come from the quick-start fence above -->
+
 ```ts
 // Raw output — the injected secret is NOT scrubbed. Handle the result carefully;
 // it may contain the secret verbatim.
@@ -161,6 +165,8 @@ whose secret is only reachable through a single-use `read(callback)` call backed
 buffer; no placeholder substitution is involved. `read()` returns whatever the callback returns, so
 derive the value you need (a header string, a hash) inside the callback and capture that — never the
 raw `Buffer`, which is zeroed before `read()` returns. A second `read()` throws `AccessorConsumedError`:
+
+<!-- readme-example: skip - fragment; `vault`/`token` come from the quick-start fence above -->
 
 ```ts
 // `token` comes from authorize(), exactly like the fetch()/exec() examples above.
@@ -182,6 +188,8 @@ signatures.
 (`Record<string, CapabilityToken>`) to inject several secrets into one call. With a map, reference
 each secret by the **named** placeholder `{{secret:<name>}}`, where `<name>` is a key in the map,
 instead of the bare `{{secret}}`:
+
+<!-- readme-example: skip - fragment; `vault` comes from the quick-start fence above -->
 
 ```ts
 // Authorize each secret independently, then key the tokens by the names you'll
@@ -322,6 +330,8 @@ a binary that's rebuilt frequently during local development doesn't get rejected
 `config.developmentMode.executables`). Only use this for local workflows — remove the executable
 from the list (or don't add it) so a production caller stays on TOFU verification.
 
+<!-- readme-example: skip - fragment; `vault` comes from the quick-start fence above -->
+
 ```ts
 // Persist an executable as dev-mode-exempt across setup() calls, while still
 // passing its real path (so re-enabling verification later is a one-line change):
@@ -345,6 +355,8 @@ name-binding calls — `store()`, `setup()`, `createSigningKey()`, `exportPublic
 `authorizeSigningKey()` — reject a `name` containing `':'` with a `VaultError`. Read/delete/existence
 calls (`delete()`, `secretExists()`) stay permissive, so a legacy secret whose name happens to
 contain `':'` remains reachable for inspection and cleanup.
+
+<!-- readme-example: skip - fragment; `vault` comes from the quick-start fence above -->
 
 ```ts
 // 1. Enroll a signing key (backend-side; the `file` backend supports this today)

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -413,6 +413,8 @@ you require it for a specific operation.
 
 **Query a backend's capabilities:**
 
+<!-- readme-example: skip - fragment; `vault` comes from the quick-start fence above -->
+
 ```ts
 const caps = await vault.getActiveBackendCapabilities()
 if (!caps.presencePerUse) {
@@ -432,6 +434,8 @@ or `sign`. When the active backend cannot guarantee it, the call throws `NotCapa
 any credential, session, or device is touched**. When the backend is capable, the operation forces a
 fresh human action for that specific call (a declined action throws `PresenceDeclinedError`; a
 timeout throws `PresenceTimeoutError`):
+
+<!-- readme-example: skip - fragment; `vault` comes from the quick-start fence above -->
 
 ```ts
 // Presence-gated signing: each sign performs a fresh backend round-trip, so no


### PR DESCRIPTION
Refs #214, Refs #217.

## #214 — CLI README sign/verify example fails as written (fixed)
The `@vaultkeeper/cli` README's sign/verify walkthrough fed `sign` via `printf '%s'` (no trailing newline) but `verify` via `<<<"$CHALLENGE"` (bash/zsh append `\n`), so sign and verify hashed byte-different payloads → "Signature did not verify." (exit 3). The command now feeds **both** via `printf '%s' "$CHALLENGE" | vaultkeeper ...`, with a prose note on the here-string/`echo` trailing-newline pitfall.

```diff
 printf '%s' "$CHALLENGE" | vaultkeeper sign --name approval-signing-key > sig
-vaultkeeper verify --public-key approval.pub --signature sig <<<"$CHALLENGE"
+printf '%s' "$CHALLENGE" | vaultkeeper verify --public-key approval.pub --signature sig
```

## #217 — README example-fence CI check (added)
New `packages/cli-tests/test/e2e/readme-examples.test.ts` + `readme-example-harness.ts`:
- **Shell fences** (```sh/```bash in the CLI + root READMEs): extracted and executed in an isolated HOME + file backend; asserts exit 0 where the doc implies success. The sign/verify walkthrough is wired as the **#214 proving case** — it fails this check against the pre-fix README and passes after.
- **TS/JS fences** (```ts/```js in the library + WASM READMEs): type-checked under strict NodeNext against the built `.d.ts`.
- Fences that are intentionally illustrative-not-runnable (fragments referencing a `vault` from an earlier fence, install-only, placeholder tool paths) opt out via `<!-- readme-example: skip - <reason> -->`.

This fence check ALSO surfaced that the sign/verify command bug was only half-fixed (prose updated, command not) and caught three fragment fences that needed skip markers — exactly the example-drift class it exists to prevent.

Coverage guards assert the harness isn't vacuous (it finds shell + TS fences, runs the sign/verify proving case, type-checks a quick-start fence per library README).

Green: readme fence check 15 passed; `@vaultkeeper/cli-tests` 207 passed; full `pnpm check` clean.