### PR TITLE
Cover the root README's sign/verify copy with the fence check; add the missed changeset

### DIFF
--- a/.changeset/cli-readme-sign-verify-fence.md
+++ b/.changeset/cli-readme-sign-verify-fence.md
@@ -1,0 +1,6 @@
+---
+'@vaultkeeper/cli': patch
+'vaultkeeper': patch
+---
+
+Fixed the CLI README's sign/verify walkthrough: `sign` and `verify` now both read the challenge via `printf '%s'`, so each sees byte-identical stdin — the previous here-string form appended a trailing newline, making the documented example fail verification with exit 3. Shipped READMEs' runnable examples are now exercised by a CI example-fence check so a documented command sequence that stops working fails the build.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,18 @@ vaultkeeper rotate-key
 vaultkeeper revoke-key
 ```
 
+The sign/verify sequence above, extracted as a runnable walkthrough (this fence
+executes in CI — see the example-fence check — so the byte-identical-stdin rule
+can't silently regress here):
+
+```sh
+CHALLENGE="hello-challenge"
+vaultkeeper key create --name approval-signing-key --type ed25519
+vaultkeeper key export --name approval-signing-key > approval.pub
+printf '%s' "$CHALLENGE" | vaultkeeper sign --name approval-signing-key > sig
+printf '%s' "$CHALLENGE" | vaultkeeper verify --public-key approval.pub --signature sig   # exit 0 = valid
+```
+
 ### Running in CI
 
 `vaultkeeper exec` requires approval the first time a caller requests a secret.


### PR DESCRIPTION
## Summary

Follow-up from the #225 review (that PR merged while review was in flight). Two gaps, both verified against the merged fence-check infrastructure:

1. **The root README's sign/verify copy was un-gated.** It lived inside the blanket-skipped command-tour fence (skipped for its placeholder `approve`/`exec` paths), so the exact #214 here-string bug could silently return in the root README while CI stayed green — only the CLI README's copy was executed. The sequence is now extracted into its own runnable fence, executed by the example check (verified: 16 executing fences, all green).
2. **The repo-convention changeset was missing**: shipped-README changes to published packages get a patch changeset (per the #187/#175 precedent). Added for `@vaultkeeper/cli` and `vaultkeeper`.

## Test plan

- [x] `readme-examples.test.ts` — 16 passed / 20 skipped, including the new root-README fence
- [x] Prettier clean

Refs #225, #214, #217