### PR TITLE
Fix multi-secret README example and run designated README fences

### DIFF
--- a/.changeset/multisecret-example-store.md
+++ b/.changeset/multisecret-example-store.md
@@ -1,0 +1,10 @@
+---
+'vaultkeeper': patch
+---
+
+Fix the README "Multiple secrets in one request" example so it runs verbatim. It
+authorized `API_KEY` and `DB_PASSWORD` without storing them first, so a
+copy-pasted run threw `SecretNotFoundError` before reaching the network. The
+example is now self-contained (imports `VaultKeeper`, initializes, and stores
+each secret) and is executed against the built package in CI — not just
+type-checked — so a runtime-throwing example fails the build.

--- a/packages/cli-tests/test/e2e/readme-example-harness.ts
+++ b/packages/cli-tests/test/e2e/readme-example-harness.ts
@@ -17,6 +17,19 @@
  *   each package's built `.d.ts`, so a snippet with a wrong signature (e.g. a
  *   2-arg `setup()`) fails CI.
  *
+ * ## Running a TS/JS fence (not just type-checking it)
+ *
+ * A type-only check misses runtime-only breakage: a snippet can compile yet
+ * throw before it does anything useful — e.g. calling `setup()` on a secret it
+ * forgot to `store()` first (issue #227). Mark a *self-contained* TS/JS fence
+ * with `<!-- readme-example: run -->` and it is additionally *executed* against
+ * the built package with `tsx`, in an isolated `VAULTKEEPER_CONFIG_DIR`, with
+ * the network boundary stubbed (`globalThis.fetch` returns a canned 200 without
+ * leaving the process). The run must exit `0`, so a fence that throws on
+ * argument construction — or on a missing store/setup step — before reaching the
+ * stubbed `fetch` fails CI. A `run` fence must be self-contained (its own
+ * `import` + `VaultKeeper.init()`); it is still type-checked as well.
+ *
  * ## Opting a fence out
  *
  * Many fenced examples are intentionally illustrative fragments, not runnable
@@ -43,7 +56,7 @@ import { spawnSync } from 'node:child_process'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 /** Repo root, resolved from this file (packages/cli-tests/test/e2e/). */
 export const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..')
@@ -68,9 +81,14 @@ export interface Fence {
   skipped: boolean
   /** The free-form reason from the skip marker, if any. */
   skipReason: string | undefined
+  /** True if a `readme-example: run` marker precedes the fence. */
+  run: boolean
+  /** The free-form reason from the run marker, if any. */
+  runReason: string | undefined
 }
 
 const SKIP_MARKER = /<!--\s*readme-example:\s*skip\b[ \t-]*(.*?)\s*-->/i
+const RUN_MARKER = /<!--\s*readme-example:\s*run\b[ \t-]*(.*?)\s*-->/i
 
 /**
  * Extract every fenced code block from `markdown`, recording each fence's
@@ -95,17 +113,23 @@ export function extractFences(markdown: string, readme: string): Fence[] {
       body.push(lines[j] ?? '')
       j += 1
     }
-    // Look back over blank lines for a skip marker on the preceding line.
+    // Look back over blank lines for a skip/run marker on the preceding line.
     let k = i - 1
     while (k >= 0 && (lines[k] ?? '').trim() === '') k -= 1
-    const marker = k >= 0 ? SKIP_MARKER.exec(lines[k] ?? '') : null
+    const markerLine = k >= 0 ? (lines[k] ?? '') : ''
+    const skipMarker = SKIP_MARKER.exec(markerLine)
+    const runMarker = RUN_MARKER.exec(markerLine)
+    const reasonOf = (m: RegExpExecArray): string | undefined =>
+      m[1] === undefined || m[1] === '' ? undefined : m[1]
     out.push({
       readme,
       lang,
       code: body.join('\n'),
       startLine,
-      skipped: marker !== null,
-      skipReason: marker !== null ? (marker[1] === undefined || marker[1] === '' ? undefined : marker[1]) : undefined,
+      skipped: skipMarker !== null,
+      skipReason: skipMarker !== null ? reasonOf(skipMarker) : undefined,
+      run: runMarker !== null,
+      runReason: runMarker !== null ? reasonOf(runMarker) : undefined,
     })
     i = j + 1
   }
@@ -289,5 +313,87 @@ export function typecheckCodeFence(fence: Fence): TypecheckResult {
     }
   } finally {
     fs.rmSync(scratch, { recursive: true, force: true })
+  }
+}
+
+/** Result of executing a `run`-marked TS/JS fence. */
+export interface RunResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/**
+ * The network-stub preload installed before a `run` fence executes. Replaces
+ * `globalThis.fetch` with a canned 200 response so execution stops at the fetch
+ * boundary instead of making a real request — a fence that constructs its fetch
+ * arguments wrong, or omits a required `store()`/`setup()`, throws *before* this
+ * is reached and the process exits non-zero. Kept as a plain `.mjs` module (no
+ * TS transform) so it loads via node's `--import` before the ESM snippet runs.
+ */
+const RUN_FETCH_STUB = [
+  "globalThis.fetch = () =>",
+  "  Promise.resolve(new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }))",
+  '',
+].join('\n')
+
+/**
+ * Execute a `run`-marked TS/JS fence against the *built* package. The snippet is
+ * written into `packages/cli-tests/` (so NodeNext resolution finds each package's
+ * built output through its `exports` map, exactly as an external consumer would)
+ * and run with `tsx`, with {@link RUN_FETCH_STUB} preloaded so the network is
+ * never touched. It runs in a fresh, ambient-free `VAULTKEEPER_CONFIG_DIR` so
+ * `store()`/`setup()` are hermetic and reproducible. Returns the process exit
+ * code and output; a non-zero exit means the documented example threw at
+ * runtime — the class of bug a type-only check misses (issue #227).
+ */
+export function runCodeFence(fence: Fence): RunResult {
+  const scratch = fs.mkdtempSync(path.join(REPO_ROOT, 'packages', 'cli-tests', '.readme-run-'))
+  const configRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vk-readme-run-'))
+  try {
+    const ext = JS_LANGS.has(fence.lang) ? 'js' : 'ts'
+    const snippet = path.join(scratch, `snippet.${ext}`)
+    fs.writeFileSync(snippet, fence.code, 'utf8')
+    const preload = path.join(scratch, 'network-stub.mjs')
+    fs.writeFileSync(preload, RUN_FETCH_STUB, 'utf8')
+
+    const configDir = path.join(configRoot, 'config')
+    fs.mkdirSync(configDir, { recursive: true })
+    // Ambient-free env (mirrors runShellFence): a run fence must not depend on
+    // the developer's VAULTKEEPER_* toggles, and CI secrets must not leak in.
+    const env: NodeJS.ProcessEnv = {
+      PATH: process.env.PATH ?? '',
+      HOME: configRoot,
+      VAULTKEEPER_CONFIG_DIR: configDir,
+    }
+    for (const key of ['LANG', 'LC_ALL', 'LC_CTYPE', 'TMPDIR', 'TERM']) {
+      const value = process.env[key]
+      if (value !== undefined) {
+        env[key] = value
+      }
+    }
+
+    const tsx = path.join(REPO_ROOT, 'node_modules', '.bin', 'tsx')
+    const result = spawnSync(tsx, ['--import', pathToFileURL(preload).href, snippet], {
+      cwd: REPO_ROOT,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 120_000,
+    })
+    // spawnSync could not start tsx at all: surface it instead of a vacuous pass.
+    if (result.error) {
+      throw new Error(
+        `Failed to run a run-marked fence from ${fence.readme}:${String(fence.startLine)}: ${result.error.message}`,
+      )
+    }
+    return {
+      exitCode: result.status ?? (result.signal !== null ? 1 : 0),
+      stdout: result.stdout,
+      stderr: result.stderr,
+    }
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true })
+    fs.rmSync(configRoot, { recursive: true, force: true })
   }
 }

--- a/packages/cli-tests/test/e2e/readme-example-harness.ts
+++ b/packages/cli-tests/test/e2e/readme-example-harness.ts
@@ -118,7 +118,9 @@ export function extractFences(markdown: string, readme: string): Fence[] {
     while (k >= 0 && (lines[k] ?? '').trim() === '') k -= 1
     const markerLine = k >= 0 ? (lines[k] ?? '') : ''
     const skipMarker = SKIP_MARKER.exec(markerLine)
-    const runMarker = RUN_MARKER.exec(markerLine)
+    // Skip takes precedence over run: an explicitly opted-out fence must never
+    // execute, even if the same marker line also carries a `run` marker.
+    const runMarker = skipMarker !== null ? null : RUN_MARKER.exec(markerLine)
     const reasonOf = (m: RegExpExecArray): string | undefined =>
       m[1] === undefined || m[1] === '' ? undefined : m[1]
     out.push({

--- a/packages/cli-tests/test/e2e/readme-examples.test.ts
+++ b/packages/cli-tests/test/e2e/readme-examples.test.ts
@@ -44,11 +44,18 @@ function fencesFor(readme: string): Fence[] {
 }
 
 const EXEC_FENCES = EXEC_READMES.flatMap(fencesFor).filter(isShellFence)
-const TYPECHECK_FENCES = TYPECHECK_READMES.flatMap(fencesFor).filter(isCodeFence)
 /** `run`-marked TS/JS fences across every README — executed against the built package. */
 const RUN_FENCES = [...EXEC_READMES, ...TYPECHECK_READMES]
   .flatMap(fencesFor)
   .filter((f) => isCodeFence(f) && f.run)
+// Type-check every TS/JS fence in the library READMEs, plus every run fence
+// wherever it lives — running a fence implies it must also compile clean, so a
+// run-marked fence in a non-typecheck README is still type-checked (keeps the
+// "run fences are still type-checked" invariant true, not just for library READMEs).
+const TYPECHECK_FENCES = [
+  ...TYPECHECK_READMES.flatMap(fencesFor).filter(isCodeFence),
+  ...RUN_FENCES.filter((f) => !TYPECHECK_READMES.includes(f.readme)),
+]
 
 /** A fence is a sign/verify walkthrough if it drives both `sign` and `verify`. */
 function isSignVerifyFence(fence: Fence): boolean {
@@ -154,6 +161,18 @@ describe('coverage guards (non-vacuous)', () => {
     }
   })
 
+  it('type-checks every run fence (run implies compile-clean)', () => {
+    // Invariant: a fence that is executed is also type-checked, regardless of
+    // which README it lives in — so the harness docs' claim holds for all run
+    // fences, not just those in the library READMEs.
+    for (const runFence of RUN_FENCES) {
+      expect(
+        TYPECHECK_FENCES.some((f) => f.readme === runFence.readme && f.startLine === runFence.startLine),
+        `run fence ${runFence.readme}:${String(runFence.startLine)} must also be in the type-checked set`,
+      ).toBe(true)
+    }
+  })
+
   it('type-checks a quick-start fence in each library README', () => {
     for (const readme of TYPECHECK_READMES) {
       expect(
@@ -194,6 +213,14 @@ describe('harness: fence extraction and classification', () => {
     expect(fence?.run).toBe(true)
     expect(fence?.skipped).toBe(false)
     expect(fence?.runReason).toBe('self-contained')
+  })
+
+  it('lets a skip marker take precedence over a run marker on the same line', () => {
+    // A line carrying both markers must opt the fence out entirely — never run it.
+    const md = ['<!-- readme-example: skip run - both present -->', '```ts', 'await main()', '```'].join('\n')
+    const [fence] = extractFences(md, 'X.md')
+    expect(fence?.skipped).toBe(true)
+    expect(fence?.run).toBe(false)
   })
 
   it('auto-skips an install-only fence but not a real command sequence', () => {

--- a/packages/cli-tests/test/e2e/readme-examples.test.ts
+++ b/packages/cli-tests/test/e2e/readme-examples.test.ts
@@ -30,6 +30,7 @@ import {
   isInstallOnlyFence,
   runShellFence,
   typecheckCodeFence,
+  runCodeFence,
   type Fence,
 } from './readme-example-harness.js'
 
@@ -44,6 +45,10 @@ function fencesFor(readme: string): Fence[] {
 
 const EXEC_FENCES = EXEC_READMES.flatMap(fencesFor).filter(isShellFence)
 const TYPECHECK_FENCES = TYPECHECK_READMES.flatMap(fencesFor).filter(isCodeFence)
+/** `run`-marked TS/JS fences across every README — executed against the built package. */
+const RUN_FENCES = [...EXEC_READMES, ...TYPECHECK_READMES]
+  .flatMap(fencesFor)
+  .filter((f) => isCodeFence(f) && f.run)
 
 /** A fence is a sign/verify walkthrough if it drives both `sign` and `verify`. */
 function isSignVerifyFence(fence: Fence): boolean {
@@ -89,6 +94,20 @@ describe('README TypeScript/JavaScript examples type-check against the built typ
   }
 })
 
+describe('README run-marked examples execute clean against the built package', () => {
+  for (const fence of RUN_FENCES) {
+    const id = `${fence.readme}:${String(fence.startLine)}`
+    it(`${id} (${fence.lang}) runs to completion`, () => {
+      const result = runCodeFence(fence)
+      expect(
+        result.exitCode,
+        `\`${fence.readme}\` ${fence.lang} fence at line ${String(fence.startLine)} exited ` +
+          `${String(result.exitCode)} at runtime.\n--- stdout ---\n${result.stdout}\n--- stderr ---\n${result.stderr}`,
+      ).toBe(0)
+    })
+  }
+})
+
 describe('coverage guards (non-vacuous)', () => {
   it('finds shell fences to execute and TS/JS fences to type-check', () => {
     // Guard against a parser regression that silently matches nothing, which
@@ -107,6 +126,31 @@ describe('coverage guards (non-vacuous)', () => {
     for (const fence of signVerify) {
       expect(fence.skipped, 'the sign/verify walkthrough must not be opted out').toBe(false)
       expect(isInstallOnlyFence(fence)).toBe(false)
+    }
+  })
+
+  it('runs the multi-secret fetch example as the #227 proving case', () => {
+    // The library README's "Multiple secrets in one request" fetch example must
+    // be an actually-executed run fence — not merely type-checked — so this
+    // suite reproduces #227 (it threw a SecretNotFoundError before the network
+    // because it never stored the secrets it authorized). It must resolve
+    // `{{secret:name}}` from a SecretTokenMap and construct a `fetch()` with no
+    // `method` (defaulting to GET).
+    const multiSecret = RUN_FENCES.filter(
+      (f) =>
+        f.readme === 'packages/vaultkeeper/README.md' &&
+        f.code.includes('vault.fetch(') &&
+        f.code.includes('{{secret:apiKey}}'),
+    )
+    expect(multiSecret.length).toBeGreaterThan(0)
+    for (const fence of multiSecret) {
+      // A run fence must be self-contained so it can execute standalone.
+      expect(fence.code, 'the multi-secret run fence must import VaultKeeper').toMatch(
+        /import \{[^}]*\bVaultKeeper\b[^}]*\} from 'vaultkeeper'/,
+      )
+      expect(fence.code, 'the multi-secret run fence must store the secrets it authorizes').toMatch(
+        /vault\.store\('API_KEY'/,
+      )
     }
   })
 
@@ -141,6 +185,15 @@ describe('harness: fence extraction and classification', () => {
     const md = ['Some prose.', '```sh', 'vaultkeeper doctor', '```'].join('\n')
     const [fence] = extractFences(md, 'X.md')
     expect(fence?.skipped).toBe(false)
+    expect(fence?.run).toBe(false)
+  })
+
+  it('records a run marker (and its reason) across intervening blank lines', () => {
+    const md = ['<!-- readme-example: run - self-contained -->', '', '```ts', 'await main()', '```'].join('\n')
+    const [fence] = extractFences(md, 'X.md')
+    expect(fence?.run).toBe(true)
+    expect(fence?.skipped).toBe(false)
+    expect(fence?.runReason).toBe('self-contained')
   })
 
   it('auto-skips an install-only fence but not a real command sequence', () => {

--- a/packages/cli-tests/test/e2e/readme-examples.test.ts
+++ b/packages/cli-tests/test/e2e/readme-examples.test.ts
@@ -44,10 +44,14 @@ function fencesFor(readme: string): Fence[] {
 }
 
 const EXEC_FENCES = EXEC_READMES.flatMap(fencesFor).filter(isShellFence)
-/** `run`-marked TS/JS fences across every README — executed against the built package. */
-const RUN_FENCES = [...EXEC_READMES, ...TYPECHECK_READMES]
-  .flatMap(fencesFor)
-  .filter((f) => isCodeFence(f) && f.run)
+/**
+ * Every README this harness tracks. A `readme-example: run` marker only takes
+ * effect in a README listed here — add new READMEs to one of the lists above
+ * or their fences will silently never execute.
+ */
+const TRACKED_READMES = [...EXEC_READMES, ...TYPECHECK_READMES]
+/** `run`-marked TS/JS fences across the tracked READMEs — executed against the built package. */
+const RUN_FENCES = TRACKED_READMES.flatMap(fencesFor).filter((f) => isCodeFence(f) && f.run)
 // Type-check every TS/JS fence in the library READMEs, plus every run fence
 // wherever it lives — running a fence implies it must also compile clean, so a
 // run-marked fence in a non-typecheck README is still type-checked (keeps the
@@ -66,11 +70,15 @@ describe('README shell examples run clean against the built CLI', () => {
   for (const fence of EXEC_FENCES) {
     const id = `${fence.readme}:${String(fence.startLine)}`
     if (fence.skipped) {
-      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => { /* opted out */ })
+      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => {
+        /* opted out */
+      })
       continue
     }
     if (isInstallOnlyFence(fence)) {
-      it.skip(`${id} (install-only, needs network)`, () => { /* opted out */ })
+      it.skip(`${id} (install-only, needs network)`, () => {
+        /* opted out */
+      })
       continue
     }
     it(`${id} exits 0`, () => {
@@ -88,7 +96,9 @@ describe('README TypeScript/JavaScript examples type-check against the built typ
   for (const fence of TYPECHECK_FENCES) {
     const id = `${fence.readme}:${String(fence.startLine)}`
     if (fence.skipped) {
-      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => { /* opted out */ })
+      it.skip(`${id} (opted out${fence.skipReason !== undefined ? `: ${fence.skipReason}` : ''})`, () => {
+        /* opted out */
+      })
       continue
     }
     it(`${id} (${fence.lang}) compiles`, () => {
@@ -167,7 +177,9 @@ describe('coverage guards (non-vacuous)', () => {
     // fences, not just those in the library READMEs.
     for (const runFence of RUN_FENCES) {
       expect(
-        TYPECHECK_FENCES.some((f) => f.readme === runFence.readme && f.startLine === runFence.startLine),
+        TYPECHECK_FENCES.some(
+          (f) => f.readme === runFence.readme && f.startLine === runFence.startLine,
+        ),
         `run fence ${runFence.readme}:${String(runFence.startLine)} must also be in the type-checked set`,
       ).toBe(true)
     }
@@ -185,16 +197,21 @@ describe('coverage guards (non-vacuous)', () => {
 
 describe('harness: fence extraction and classification', () => {
   it('records a skip marker (and its reason) on the immediately preceding line', () => {
-    const md = ['<!-- readme-example: skip - references an earlier vault -->', '```ts', 'await vault.x()', '```'].join(
-      '\n',
-    )
+    const md = [
+      '<!-- readme-example: skip - references an earlier vault -->',
+      '```ts',
+      'await vault.x()',
+      '```',
+    ].join('\n')
     const [fence] = extractFences(md, 'X.md')
     expect(fence?.skipped).toBe(true)
     expect(fence?.skipReason).toBe('references an earlier vault')
   })
 
   it('detects a skip marker across intervening blank lines', () => {
-    const md = ['<!-- readme-example: skip -->', '', '```sh', 'vaultkeeper exec ...', '```'].join('\n')
+    const md = ['<!-- readme-example: skip -->', '', '```sh', 'vaultkeeper exec ...', '```'].join(
+      '\n',
+    )
     const [fence] = extractFences(md, 'X.md')
     expect(fence?.skipped).toBe(true)
     expect(fence?.skipReason).toBeUndefined()
@@ -208,7 +225,13 @@ describe('harness: fence extraction and classification', () => {
   })
 
   it('records a run marker (and its reason) across intervening blank lines', () => {
-    const md = ['<!-- readme-example: run - self-contained -->', '', '```ts', 'await main()', '```'].join('\n')
+    const md = [
+      '<!-- readme-example: run - self-contained -->',
+      '',
+      '```ts',
+      'await main()',
+      '```',
+    ].join('\n')
     const [fence] = extractFences(md, 'X.md')
     expect(fence?.run).toBe(true)
     expect(fence?.skipped).toBe(false)
@@ -217,16 +240,27 @@ describe('harness: fence extraction and classification', () => {
 
   it('lets a skip marker take precedence over a run marker on the same line', () => {
     // A line carrying both markers must opt the fence out entirely — never run it.
-    const md = ['<!-- readme-example: skip run - both present -->', '```ts', 'await main()', '```'].join('\n')
+    const md = [
+      '<!-- readme-example: skip run - both present -->',
+      '```ts',
+      'await main()',
+      '```',
+    ].join('\n')
     const [fence] = extractFences(md, 'X.md')
     expect(fence?.skipped).toBe(true)
     expect(fence?.run).toBe(false)
   })
 
   it('auto-skips an install-only fence but not a real command sequence', () => {
-    const [install] = extractFences(['```sh', 'pnpm add -g @vaultkeeper/cli', '```'].join('\n'), 'X.md')
+    const [install] = extractFences(
+      ['```sh', 'pnpm add -g @vaultkeeper/cli', '```'].join('\n'),
+      'X.md',
+    )
     expect(install && isInstallOnlyFence(install)).toBe(true)
-    const [run] = extractFences(['```sh', '# install first', 'vaultkeeper doctor', '```'].join('\n'), 'X.md')
+    const [run] = extractFences(
+      ['```sh', '# install first', 'vaultkeeper doctor', '```'].join('\n'),
+      'X.md',
+    )
     expect(run && isInstallOnlyFence(run)).toBe(false)
   })
 

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -189,13 +189,20 @@ signatures.
 each secret by the **named** placeholder `{{secret:<name>}}`, where `<name>` is a key in the map,
 instead of the bare `{{secret}}`:
 
-<!-- readme-example: skip - fragment; `vault` comes from the quick-start fence above -->
+<!-- readme-example: run - self-contained; executed against the built package with the network stubbed (issue #227) -->
 
 ```ts
-// Authorize each secret independently, then key the tokens by the names you'll
-// reference in placeholders. `{ skipTrust: true }` (development only) is shown
-// here; in production pass a stable `executablePath` instead — see
-// [Trust tiers](#trust-tiers).
+import { VaultKeeper } from 'vaultkeeper'
+
+const vault = await VaultKeeper.init()
+
+// Store each secret first (as in the quick start), then authorize each
+// independently and key the tokens by the names you'll reference in
+// placeholders. `{ skipTrust: true }` (development only) is shown here; in
+// production pass a stable `executablePath` instead — see [Trust tiers](#trust-tiers).
+await vault.store('API_KEY', 'api-secret-value')
+await vault.store('DB_PASSWORD', 'db-secret-value')
+
 const apiJwe = await vault.setup('API_KEY', { skipTrust: true })
 const dbJwe = await vault.setup('DB_PASSWORD', { skipTrust: true })
 const { token: apiToken } = await vault.authorize(apiJwe)


### PR DESCRIPTION
## Summary

The library README's **"Multiple secrets in one request"** fetch example threw before reaching the network when copy-pasted verbatim. Root-caused, fixed the example, and extended the #217 README-fence check so this class of runtime bug fails CI.

Refs #227.

## Root cause (not what the issue guessed)

The issue suspected a missing `method` field. That is **not** the cause — `FetchRequest.method` is genuinely optional and defaults to `GET` at runtime (`delegatedFetch` omits the key when undefined; existing unit tests cover this). Type, runtime, and example all agree that `method` is optional, so no library change was warranted there.

The actual defect: the example fragment authorized `API_KEY` and `DB_PASSWORD` via `setup()` **without first `store()`-ing them** (the quick-start stores `MY_API_KEY` before `setup()`; this fragment introduced new secret names and skipped that step). A verbatim run therefore threw `SecretNotFoundError: Secret not found in file store: API_KEY` on the first `setup()` call, well before any network I/O.

Reproduced against the built package: pre-fix exits non-zero with `SecretNotFoundError`; post-fix reaches the (stubbed) `fetch` and completes.

## Decision: method optional (unchanged)

`method?` stays optional with a `GET` default. It is correctly modeled and tested; the example omitting it is fine.

## Changes

1. **`packages/vaultkeeper/README.md`** — made the multi-secret example self-contained and runnable verbatim: it now imports `VaultKeeper`, calls `init()`, and `store()`s each secret before `setup()`/`authorize()`/`fetch()`.
2. **README fence harness (`packages/cli-tests`)** — extended the #217 check with a **run mode**. A TS/JS fence marked `<!-- readme-example: run -->` is *executed* against the built package (via `tsx`) in an isolated `VAULTKEEPER_CONFIG_DIR` with `globalThis.fetch` stubbed to a canned 200 — so it deterministically stops at the network boundary and any argument-construction / missing-store throw makes the run exit non-zero. Run fences are still type-checked too.
3. The multi-secret example is marked `run`, with a coverage guard asserting it is genuinely executed (it fails against the pre-fix README).
4. Swept sibling multi-secret / `SecretTokenMap` fetch/exec fragments — they legitimately reuse the quick-start's stored `token`; the multi-secret example was the only one introducing unstored secret names.

## Verification

- `pnpm --filter @vaultkeeper/cli-tests exec vitest run test/e2e/readme-examples.test.ts` — multi-secret fence now both type-checks and runs (exit 0); confirmed it exits 1 pre-fix.
- `pnpm --filter vaultkeeper test` — 969 passed.
- `pnpm --filter @vaultkeeper/cli-tests test` — 212 passed.
- `pnpm check` — typecheck, lint, format, api-report all green.