### PR TITLE
Wrap config-dir creation EACCES in a typed FilesystemError

### DIFF
--- a/.changeset/cli-config-dir-mkdir-eacces.md
+++ b/.changeset/cli-config-dir-mkdir-eacces.md
@@ -1,0 +1,10 @@
+---
+'vaultkeeper': patch
+'@vaultkeeper/cli': patch
+---
+
+Wrap config-directory CREATION failures in a typed `FilesystemError` instead of leaking a raw Node error.
+
+`vaultkeeper config init` (and the first `store`, which persists key state before writing any secret) against a config directory whose parent is read-only previously aborted with the raw, unwrapped `Error: EACCES: permission denied, mkdir '<path>'` — no error class, no plain-English description, no fix hint. Only the config-directory READ paths had been wrapped previously.
+
+The directory-creation path now surfaces a typed `FilesystemError` (with the path and the underlying errno code) rendered through the CLI's error formatter with directory-specific wording and a parent-directory fix hint (check that the parent directory is writable, or choose a writable location with `--config-dir`). The raw `EACCES`/`mkdir` errno text no longer reaches the user, and the command still exits non-zero. The key-state write path is likewise wrapped.

--- a/packages/cli-tests/test/e2e/config-init-mkdir-readonly.test.ts
+++ b/packages/cli-tests/test/e2e/config-init-mkdir-readonly.test.ts
@@ -1,0 +1,112 @@
+/**
+ * UATs for issue #228: `config init` and the first `store` against a config
+ * directory whose PARENT is read-only previously leaked a raw, unwrapped Node
+ * error — `Error: EACCES: permission denied, mkdir '<path>'` — instead of the
+ * typed FilesystemError the read paths (#181/#169) already render.
+ *
+ * The config-dir CREATION path was the gap: `config init` (`fs.mkdir`) and the
+ * key-state persistence during a first `store` (`saveKeyState`'s `fs.mkdir`)
+ * were not wrapped. Both must now render a typed `FilesystemError` through the
+ * CLI's `formatError`: directory-specific wording naming the path, a
+ * parent-directory fix hint, a non-zero exit, and NO raw `EACCES` / `mkdir`
+ * errno string.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { createCliTestEnv } from '@vaultkeeper/cli-test-helpers'
+import type { CliResult, CliTestEnv } from '@vaultkeeper/cli-test-helpers'
+
+// A chmod-500 (read-only) parent directory only denies `mkdir` on POSIX, and
+// not for root (which bypasses permission bits), so this repro is guarded to a
+// non-root POSIX host (matches the #181/#169 guards).
+const canTestDirPermissions =
+  process.platform !== 'win32' && !(typeof process.getuid === 'function' && process.getuid() === 0)
+
+/**
+ * Assert the config-dir-creation failure contract: the raw errno text never
+ * leaks, and the user sees the typed, directory-oriented FilesystemError.
+ */
+function expectUnwritableParentContract(result: CliResult, targetDir: string): void {
+  // Non-zero exit — an unwritable parent is a real failure, never a success.
+  expect(result.exitCode).not.toBe(0)
+
+  // The raw Node errno string never leaks to the user (neither stream).
+  expect(result.stdout).not.toContain('EACCES')
+  expect(result.stderr).not.toContain('EACCES')
+  expect(result.stderr).not.toMatch(/mkdir '.*'/)
+
+  // A typed, human FilesystemError naming the directory and pointing at the
+  // parent directory as the fix.
+  expect(result.stderr).toContain('FilesystemError')
+  expect(result.stderr).toContain(targetDir)
+  expect(result.stderr).toContain('could not be created')
+  expect(result.stderr).toContain('parent directory')
+}
+
+describe.skipIf(!canTestDirPermissions)(
+  'read-only parent dir renders a typed FilesystemError, not a raw EACCES mkdir (issue #228)',
+  () => {
+    let env: CliTestEnv | undefined
+    let readonlyParent: string | undefined
+
+    afterEach(async () => {
+      // Restore write permission so the harness can remove the temp tree, even
+      // if an assertion threw before any in-test restore ran.
+      if (readonlyParent !== undefined) {
+        await fs.chmod(readonlyParent, 0o755).catch(() => undefined)
+        readonlyParent = undefined
+      }
+      if (env !== undefined) {
+        await env.cleanup()
+        env = undefined
+      }
+    })
+
+    /**
+     * Create a read-only parent directory inside the isolated temp env, target
+     * a not-yet-existing subdirectory under it via `--config-dir`, run `args`,
+     * then restore write permission immediately so later assertions can't leave
+     * a locked tree. Returns the result and the (never-created) target dir.
+     */
+    async function runAgainstReadonlyParent(
+      args: string[],
+      stdin?: string,
+    ): Promise<{ result: CliResult; targetDir: string }> {
+      // 'flag' mode so `--config-dir` names the dir explicitly and no
+      // VAULTKEEPER_CONFIG_DIR is inherited.
+      env = await createCliTestEnv({ configDirMode: 'flag' })
+      const parent = path.join(env.configDir, 'ro')
+      await fs.mkdir(parent, { recursive: true })
+      await fs.chmod(parent, 0o500)
+      readonlyParent = parent
+      const targetDir = path.join(parent, 'sub')
+
+      const withDir = ['--config-dir', targetDir, ...args]
+      const result =
+        stdin !== undefined ? await env.runWithStdin(withDir, stdin) : await env.run(withDir)
+
+      await fs.chmod(parent, 0o755)
+      readonlyParent = undefined
+      return { result, targetDir }
+    }
+
+    it('config init', async () => {
+      const { result, targetDir } = await runAgainstReadonlyParent([
+        'config',
+        'init',
+        '--backend',
+        'file',
+      ])
+      expectUnwritableParentContract(result, targetDir)
+    })
+
+    it('store (creates the config dir on first write)', async () => {
+      const { result, targetDir } = await runAgainstReadonlyParent(
+        ['store', '--name', 'FOO'],
+        'secret-value',
+      )
+      expectUnwritableParentContract(result, targetDir)
+    })
+  },
+)

--- a/packages/cli/src/cache.ts
+++ b/packages/cli/src/cache.ts
@@ -95,6 +95,17 @@ export async function writeCachedToken(
   const tmpPath = filePath + `.${crypto.randomUUID()}.tmp`
   try {
     await fs.writeFile(tmpPath, jwe, { encoding: 'utf8', mode: 0o600 })
+  } catch (err) {
+    throw new FilesystemError(
+      `Failed to write cached token at ${tmpPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      tmpPath,
+      'write',
+      err,
+    )
+  }
+  try {
     await fs.rename(tmpPath, filePath)
   } catch (err) {
     throw new FilesystemError(

--- a/packages/cli/src/cache.ts
+++ b/packages/cli/src/cache.ts
@@ -2,6 +2,7 @@ import * as crypto from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as os from 'node:os'
+import { FilesystemError } from 'vaultkeeper'
 
 /**
  * Resolve the cache directory for JWE tokens.
@@ -73,13 +74,38 @@ export async function writeCachedToken(
   jwe: string,
 ): Promise<void> {
   const dir = getCacheDir()
-  await fs.mkdir(dir, { recursive: true, mode: 0o700 })
+  // Split try/catches so each failure blames the path/operation that actually
+  // failed (issue #228's audit: a shared catch would misattribute a mkdir
+  // EACCES as a failed token write).
+  try {
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 })
+  } catch (err) {
+    throw new FilesystemError(
+      `Failed to create token-cache directory at ${dir}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      dir,
+      'create',
+      err,
+    )
+  }
   const filePath = path.join(dir, cacheFileName(callerPath, secretName))
   // Atomic write: write to a temp file with correct permissions,
   // then rename into place. rename() is atomic on POSIX filesystems.
   const tmpPath = filePath + `.${crypto.randomUUID()}.tmp`
-  await fs.writeFile(tmpPath, jwe, { encoding: 'utf8', mode: 0o600 })
-  await fs.rename(tmpPath, filePath)
+  try {
+    await fs.writeFile(tmpPath, jwe, { encoding: 'utf8', mode: 0o600 })
+    await fs.rename(tmpPath, filePath)
+  } catch (err) {
+    throw new FilesystemError(
+      `Failed to write cached token at ${filePath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      filePath,
+      'write',
+      err,
+    )
+  }
 }
 
 /**

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -6,6 +6,7 @@ import {
   defaultBackendType,
   platformNativeBackendType,
   loadConfig,
+  FilesystemError,
 } from 'vaultkeeper'
 import { formatError } from '../output.js'
 import { CONFIG_DIR_HELP_OPTION, CONFIG_DIR_HELP_ENV } from '../config-dir.js'
@@ -181,8 +182,22 @@ async function configInit(rest: string[], configDir: string): Promise<number> {
 
   try {
     const configPath = path.join(configDir, 'config.json')
-    // Create config directory with restrictive permissions.
-    await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
+    // Create config directory with restrictive permissions. A failure here
+    // (e.g. the parent directory is read-only) must surface as a typed
+    // FilesystemError rendered by formatError, not the raw Node
+    // `EACCES: … mkdir '<path>'` text (issue #228).
+    try {
+      await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
+    } catch (err) {
+      throw new FilesystemError(
+        `Failed to create config directory at ${configDir}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        configDir,
+        'create',
+        err,
+      )
+    }
 
     // Only a genuinely missing file (ENOENT, via configFileExists) is safe to
     // proceed over; any other access failure (e.g. EACCES) is a real problem
@@ -196,10 +211,21 @@ async function configInit(rest: string[], configDir: string): Promise<number> {
       return 1
     }
 
-    await fs.writeFile(configPath, buildConfig(backendType) + '\n', {
-      encoding: 'utf8',
-      mode: 0o600,
-    })
+    try {
+      await fs.writeFile(configPath, buildConfig(backendType) + '\n', {
+        encoding: 'utf8',
+        mode: 0o600,
+      })
+    } catch (err) {
+      throw new FilesystemError(
+        `Failed to write config file at ${configPath}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        configPath,
+        'write',
+        err,
+      )
+    }
     process.stdout.write(`Config created at ${configPath}\n`)
 
     if (requestedBackend === undefined) {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -253,6 +253,11 @@ const FS_OPERATION_VERB: Record<string, string> = {
   // it fails to create its storage directory, so map it to the operation that
   // actually failed rather than the generic "accessed" fallback.
   rwx: 'created',
+  // Directory-creation failures (config init / first store creating the config
+  // dir, issue #228) use the `'create'` permission and get directory-specific
+  // wording in `formatFilesystemError`; this verb is the fallback if that
+  // branch is ever bypassed.
+  create: 'created',
 }
 
 /**
@@ -297,6 +302,23 @@ function classifyFilesystemError(err: FilesystemError): 'missing' | 'denied' | '
 function formatFilesystemError(err: FilesystemError): string {
   const quotedPath = `\`${err.path}\``
   const kind = classifyFilesystemError(err)
+  // Directory-creation failures (`config init` / first `store` creating the
+  // config dir, issue #228) get directory-specific wording and a
+  // parent-directory hint, rather than the file-oriented messages below —
+  // the thing that could not be created is a directory, and the fix lives in
+  // the parent directory's permissions (or choosing a writable location).
+  if (err.permission === 'create') {
+    if (kind === 'denied') {
+      return (
+        `${err.name}: The directory at ${quotedPath} could not be created (permission denied). ` +
+        'Check that its parent directory is writable, or choose a writable location with --config-dir, then try again.'
+      )
+    }
+    return (
+      `${err.name}: The directory at ${quotedPath} could not be created. ` +
+      'Check that its parent directory exists and is writable, then try again.'
+    )
+  }
   if (kind === 'missing') {
     return (
       `${err.name}: The file at ${quotedPath} does not exist. ` +

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -299,7 +299,7 @@ function classifyFilesystemError(err: FilesystemError): 'missing' | 'denied' | '
  * carries no next step (issue #150). Mirrors the fix-oriented shape of the
  * config-error and identity-mismatch messages.
  */
-function formatFilesystemError(err: FilesystemError): string {
+function formatFilesystemError(err: FilesystemError, configDir: string): string {
   const quotedPath = `\`${err.path}\``
   const kind = classifyFilesystemError(err)
   // Directory-creation failures (`config init` / first `store` creating the
@@ -310,10 +310,15 @@ function formatFilesystemError(err: FilesystemError): string {
   // `rwx` is FileBackend's legacy label for the same failure class (its
   // storage-directory mkdir), so it gets the same directory wording.
   if (err.permission === 'create' || err.permission === 'rwx') {
+    // The --config-dir hint only helps when the failing directory actually
+    // lives under the configured config dir — a token-cache dir (XDG runtime)
+    // or an explicitly configured backend storage dir would not move with it.
+    const underConfigDir = err.path === configDir || err.path.startsWith(configDir + path.sep)
+    const relocationHint = underConfigDir ? ', or choose a writable location with --config-dir' : ''
     if (kind === 'denied') {
       return (
         `${err.name}: The directory at ${quotedPath} could not be created (permission denied). ` +
-        'Check that its parent directory is writable, or choose a writable location with --config-dir, then try again.'
+        `Check that its parent directory is writable${relocationHint}, then try again.`
       )
     }
     return (
@@ -415,7 +420,7 @@ export function formatError(err: unknown, configDir: string): string {
     return formatConfigReadError(err)
   }
   if (err instanceof FilesystemError) {
-    return formatFilesystemError(err)
+    return formatFilesystemError(err, configDir)
   }
   if (err instanceof Error) {
     return `${err.name}: ${err.message}`

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -313,7 +313,16 @@ function formatFilesystemError(err: FilesystemError, configDir: string): string 
     // The --config-dir hint only helps when the failing directory actually
     // lives under the configured config dir — a token-cache dir (XDG runtime)
     // or an explicitly configured backend storage dir would not move with it.
-    const underConfigDir = err.path === configDir || err.path.startsWith(configDir + path.sep)
+    // Resolve both sides (and fold case on Windows, matching the
+    // isPlatformDefaultConfigDir normalization) so a relative spelling or
+    // trailing separator can't flip the hint.
+    const normalizePath = (p: string): string => {
+      const resolved = path.resolve(p)
+      return process.platform === 'win32' ? resolved.toLowerCase() : resolved
+    }
+    const errPath = normalizePath(err.path)
+    const confDir = normalizePath(configDir)
+    const underConfigDir = errPath === confDir || errPath.startsWith(confDir + path.sep)
     const relocationHint = underConfigDir ? ', or choose a writable location with --config-dir' : ''
     if (kind === 'denied') {
       return (

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -307,7 +307,9 @@ function formatFilesystemError(err: FilesystemError): string {
   // parent-directory hint, rather than the file-oriented messages below —
   // the thing that could not be created is a directory, and the fix lives in
   // the parent directory's permissions (or choosing a writable location).
-  if (err.permission === 'create') {
+  // `rwx` is FileBackend's legacy label for the same failure class (its
+  // storage-directory mkdir), so it gets the same directory wording.
+  if (err.permission === 'create' || err.permission === 'rwx') {
     if (kind === 'denied') {
       return (
         `${err.name}: The directory at ${quotedPath} could not be created (permission denied). ` +

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -705,10 +705,13 @@ describe('formatError renders FilesystemError without raw OS text (issue #150)',
 
     const formatted = formatError(err, CONFIG_DIR)
 
+    // The storage dir lives outside the config dir, so the --config-dir
+    // relocation hint would be misleading and must be omitted.
     expect(formatted).toBe(
       `FilesystemError: The directory at \`${dir}\` could not be created (permission denied). ` +
-        'Check that its parent directory is writable, or choose a writable location with --config-dir, then try again.',
+        'Check that its parent directory is writable, then try again.',
     )
+    expect(formatted).not.toContain('--config-dir')
     expect(formatted).not.toContain('accessed')
     expect(formatted).not.toContain('EACCES')
   })
@@ -729,7 +732,10 @@ describe('formatError renders FilesystemError without raw OS text (issue #150)',
       cause,
     )
 
-    const formatted = formatError(err, CONFIG_DIR)
+    // In the real flow the failing path IS the config dir formatError
+    // receives, so pass it as such — that is what makes the --config-dir
+    // relocation hint applicable.
+    const formatted = formatError(err, dir)
 
     expect(formatted).toBe(
       `FilesystemError: The directory at \`${dir}\` could not be created (permission denied). ` +

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -711,6 +711,54 @@ describe('formatError renders FilesystemError without raw OS text (issue #150)',
     expect(formatted).not.toContain('EACCES')
   })
 
+  // Config-dir CREATION failures (`config init` / first `store`) use
+  // `permission: 'create'` and must read as a DIRECTORY that could not be
+  // created, with a parent-directory fix hint — not the file-oriented wording
+  // above (issue #228).
+  it("renders a config-dir creation EACCES (permission 'create') as a directory + parent hint", () => {
+    const dir = '/tmp/readonly/sub'
+    const cause = Object.assign(new Error("EACCES: permission denied, mkdir '/tmp/readonly/sub'"), {
+      code: 'EACCES',
+    })
+    const err = new FilesystemError(
+      `Failed to create config directory at ${dir}: ${cause.message}`,
+      dir,
+      'create',
+      cause,
+    )
+
+    const formatted = formatError(err, CONFIG_DIR)
+
+    expect(formatted).toBe(
+      `FilesystemError: The directory at \`${dir}\` could not be created (permission denied). ` +
+        'Check that its parent directory is writable, or choose a writable location with --config-dir, then try again.',
+    )
+    expect(formatted).not.toContain('EACCES')
+    expect(formatted).not.toContain('mkdir')
+    // Directory wording, never "The file at".
+    expect(formatted).not.toContain('The file at')
+  })
+
+  it("renders a non-permission config-dir creation failure (permission 'create') without a permission claim", () => {
+    const dir = '/tmp/readonly/sub'
+    const cause = Object.assign(new Error('EROFS: read-only file system'), { code: 'EROFS' })
+    const err = new FilesystemError(
+      `Failed to create config directory at ${dir}: ${cause.message}`,
+      dir,
+      'create',
+      cause,
+    )
+
+    const formatted = formatError(err, CONFIG_DIR)
+
+    expect(formatted).toBe(
+      `FilesystemError: The directory at \`${dir}\` could not be created. ` +
+        'Check that its parent directory exists and is writable, then try again.',
+    )
+    expect(formatted).not.toContain('permission denied')
+    expect(formatted).not.toContain('EROFS')
+  })
+
   it('falls back to a clean generic message for an unrecognized OS code', () => {
     const p = '/tmp/busy'
     const err = new FilesystemError(`Failed to read at ${p}: EBUSY: resource busy`, p, 'read')

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -692,8 +692,10 @@ describe('formatError renders FilesystemError without raw OS text (issue #150)',
 
   // FileBackend throws `permission: 'rwx'` when it can't create its storage
   // directory — a permission SET, not an operation verb. It must still read
-  // as the operation that failed (created), not the generic "accessed".
-  it("renders a storage-directory creation failure (permission 'rwx') as 'created'", () => {
+  // as a DIRECTORY-creation failure: 'rwx' is FileBackend's legacy label for
+  // the same failure class as 'create' (its storage-dir mkdir), so it gets the
+  // same directory-oriented wording (review follow-up on issue #228).
+  it("renders a storage-directory creation failure (permission 'rwx') with the directory wording", () => {
     const dir = '/tmp/vk-store/secrets'
     const err = new FilesystemError(
       `Failed to create storage directory: ${dir}: EACCES`,
@@ -704,8 +706,8 @@ describe('formatError renders FilesystemError without raw OS text (issue #150)',
     const formatted = formatError(err, CONFIG_DIR)
 
     expect(formatted).toBe(
-      `FilesystemError: The file at \`${dir}\` cannot be created (permission denied). ` +
-        "Check the file's permissions and try again.",
+      `FilesystemError: The directory at \`${dir}\` could not be created (permission denied). ` +
+        'Check that its parent directory is writable, or choose a writable location with --config-dir, then try again.',
     )
     expect(formatted).not.toContain('accessed')
     expect(formatted).not.toContain('EACCES')

--- a/packages/cli/test/unit/output.test.ts
+++ b/packages/cli/test/unit/output.test.ts
@@ -747,6 +747,84 @@ describe('formatError renders FilesystemError without raw OS text (issue #150)',
     expect(formatted).not.toContain('The file at')
   })
 
+  // Review follow-up (issue #231): the `--config-dir` relocation hint is only
+  // applicable when the failing path is genuinely under the configured
+  // config dir. That comparison used raw string equality/`startsWith`, so a
+  // differently-spelled but equivalent form of the config dir (relative vs.
+  // absolute, trailing separator, Windows casing) would misclassify — the
+  // hint could wrongly appear or disappear depending on incidental spelling
+  // rather than the actual path relationship.
+  describe('the --config-dir relocation hint compares normalized paths (issue #231)', () => {
+    it('recognizes a relative spelling of the config dir as equivalent to the absolute failing path', () => {
+      const absoluteConfigDir = '/tmp/vk-relative-test/config'
+      const dir = path.join(absoluteConfigDir, 'sub')
+      const relativeConfigDir = path.relative(process.cwd(), absoluteConfigDir)
+      const err = new FilesystemError(
+        `Failed to create config directory at ${dir}: EACCES`,
+        dir,
+        'create',
+      )
+
+      // path.resolve() collapses the relative spelling back to the same
+      // absolute config dir as the one the failing path lives under.
+      const formatted = formatError(err, relativeConfigDir)
+
+      expect(formatted).toContain('or choose a writable location with --config-dir')
+    })
+
+    it('recognizes a trailing-separator spelling of the config dir as equivalent to the failing path', () => {
+      const configDir = '/tmp/vk-trailing-test/config'
+      const dir = path.join(configDir, 'sub')
+      const err = new FilesystemError(
+        `Failed to create config directory at ${dir}: EACCES`,
+        dir,
+        'create',
+      )
+
+      const formatted = formatError(err, configDir + path.sep)
+
+      expect(formatted).toContain('or choose a writable location with --config-dir')
+    })
+
+    it.runIf(process.platform === 'win32')(
+      'recognizes a differently-cased spelling of the config dir as equivalent on Windows',
+      () => {
+        const configDir = 'C:\\Users\\me\\AppData\\vaultkeeper'
+        const dir = configDir + '\\sub'
+        const err = new FilesystemError(
+          `Failed to create config directory at ${dir}: EACCES`,
+          dir,
+          'create',
+        )
+
+        const formatted = formatError(err, configDir.toUpperCase())
+
+        expect(formatted).toContain('or choose a writable location with --config-dir')
+      },
+    )
+
+    // The classic startsWith footgun: a sibling directory that merely shares
+    // a prefix with the config dir must NOT be misclassified as living under
+    // it, even after normalization.
+    it('does not treat a sibling directory that only shares a name prefix as under the config dir', () => {
+      const configDir = '/home/u/.config/vaultkeeper'
+      const dir = '/home/u/.config/vaultkeeper-backup'
+      const err = new FilesystemError(
+        `Failed to create config directory at ${dir}: EACCES`,
+        dir,
+        'create',
+      )
+
+      const formatted = formatError(err, configDir)
+
+      expect(formatted).not.toContain('--config-dir')
+      expect(formatted).toBe(
+        `FilesystemError: The directory at \`${dir}\` could not be created (permission denied). ` +
+          'Check that its parent directory is writable, then try again.',
+      )
+    })
+  })
+
   it("renders a non-permission config-dir creation failure (permission 'create') without a permission claim", () => {
     const dir = '/tmp/readonly/sub'
     const cause = Object.assign(new Error('EROFS: read-only file system'), { code: 'EROFS' })

--- a/packages/vaultkeeper/src/identity/manifest.ts
+++ b/packages/vaultkeeper/src/identity/manifest.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { FilesystemError } from '../errors.js'
+import { FilesystemError, toFilesystemError } from '../errors.js'
 import type { TrustManifest, TrustManifestEntry } from './types.js'
 
 const MANIFEST_FILENAME = 'trust-manifest.json'
@@ -102,13 +102,20 @@ export async function loadManifest(configDir: string): Promise<TrustManifest> {
  */
 export async function saveManifest(configDir: string, manifest: TrustManifest): Promise<void> {
   const manifestPath = path.join(configDir, MANIFEST_FILENAME)
+  // Split try/catches so each failure blames the path and operation that
+  // actually failed: a shared catch would report a config-dir mkdir EACCES
+  // as a failed manifest *write* at manifestPath (issue #228 audit).
   try {
     await fs.mkdir(configDir, { recursive: true })
-    const entries: Record<string, TrustManifestEntry> = {}
-    for (const [namespace, entry] of manifest) {
-      entries[namespace] = entry
-    }
-    const raw: RawManifest = { version: 1, entries }
+  } catch (err) {
+    throw toFilesystemError(err, 'trust-manifest directory', configDir, 'create')
+  }
+  const entries: Record<string, TrustManifestEntry> = {}
+  for (const [namespace, entry] of manifest) {
+    entries[namespace] = entry
+  }
+  const raw: RawManifest = { version: 1, entries }
+  try {
     await fs.writeFile(manifestPath, JSON.stringify(raw, null, 2), 'utf8')
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err)

--- a/packages/vaultkeeper/src/keys/storage.ts
+++ b/packages/vaultkeeper/src/keys/storage.ts
@@ -22,6 +22,7 @@
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { encryptGcm, decryptGcm, getOrCreateWrapKey } from '../util/at-rest.js'
+import { toFilesystemError } from '../errors.js'
 import type { KeyMaterial, KeyStateSnapshot } from './types.js'
 
 const KEY_STATE_FILE = 'keys.enc'
@@ -155,7 +156,15 @@ export async function loadKeyState(configDir: string): Promise<KeyStateSnapshot 
  * @internal
  */
 export async function saveKeyState(configDir: string, snapshot: KeyStateSnapshot): Promise<void> {
-  await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
+  // Creating the config directory can fail (e.g. its parent is read-only) on
+  // the first `store`, which persists key state before any secret is written.
+  // Surface a typed FilesystemError rather than leaking the raw Node
+  // `EACCES: … mkdir '<path>'` text (issue #228).
+  try {
+    await fs.mkdir(configDir, { recursive: true, mode: 0o700 })
+  } catch (err) {
+    throw toFilesystemError(err, 'config directory', configDir, 'create')
+  }
 
   const raw: RawKeyState = {
     version: 1,
@@ -176,6 +185,10 @@ export async function saveKeyState(configDir: string, snapshot: KeyStateSnapshot
 
   const statePath = path.join(configDir, KEY_STATE_FILE)
   const tmpPath = `${statePath}.${String(process.pid)}.tmp`
-  await fs.writeFile(tmpPath, envelope, { encoding: 'utf8', mode: 0o600 })
-  await fs.rename(tmpPath, statePath)
+  try {
+    await fs.writeFile(tmpPath, envelope, { encoding: 'utf8', mode: 0o600 })
+    await fs.rename(tmpPath, statePath)
+  } catch (err) {
+    throw toFilesystemError(err, 'key state file', statePath, 'write')
+  }
 }

--- a/packages/vaultkeeper/src/keys/storage.ts
+++ b/packages/vaultkeeper/src/keys/storage.ts
@@ -185,8 +185,16 @@ export async function saveKeyState(configDir: string, snapshot: KeyStateSnapshot
 
   const statePath = path.join(configDir, KEY_STATE_FILE)
   const tmpPath = `${statePath}.${String(process.pid)}.tmp`
+  // Keep the write and the rename in separate try/catch blocks so the reported
+  // FilesystemError path matches whichever step actually failed: the temp file
+  // on a write failure (e.g. EACCES/ENOSPC creating it), the final state file
+  // on a rename failure. A single shared catch would always blame `statePath`.
   try {
     await fs.writeFile(tmpPath, envelope, { encoding: 'utf8', mode: 0o600 })
+  } catch (err) {
+    throw toFilesystemError(err, 'key state file', tmpPath, 'write')
+  }
+  try {
     await fs.rename(tmpPath, statePath)
   } catch (err) {
     throw toFilesystemError(err, 'key state file', statePath, 'write')

--- a/packages/vaultkeeper/test/unit/keys/storage.test.ts
+++ b/packages/vaultkeeper/test/unit/keys/storage.test.ts
@@ -156,3 +156,41 @@ describe('corrupt / tampered state degrades safely', () => {
     expect(loaded?.current.id).toBe('k-new-bbbb')
   })
 })
+
+// Regression: issue #228. The first `store` persists key state before any
+// secret is written, so `saveKeyState` is the code path that creates the config
+// directory. When its parent is read-only, `fs.mkdir` fails with EACCES; that
+// failure previously propagated as a raw Node error and the CLI leaked
+// `EACCES: … mkdir '<path>'`. It must now surface as a typed FilesystemError
+// (permission 'create', errno code preserved) so the CLI can render it cleanly.
+describe('saveKeyState wraps a config-dir creation failure as a typed FilesystemError (issue #228)', () => {
+  // chmod-500 only denies mkdir on POSIX, and not for root (which bypasses
+  // permission bits) — mirror the CLI UAT guard.
+  const canTestDirPermissions =
+    process.platform !== 'win32' &&
+    !(typeof process.getuid === 'function' && process.getuid() === 0)
+
+  it.skipIf(!canTestDirPermissions)(
+    'throws FilesystemError (not a raw EACCES) when the parent dir is read-only',
+    async () => {
+      const parent = path.join(dir, 'ro')
+      await fs.mkdir(parent, { recursive: true })
+      await fs.chmod(parent, 0o500)
+      const target = path.join(parent, 'sub')
+
+      try {
+        await expect(saveKeyState(target, { current: makeKey('k-1-aaaa', 0x11) })).rejects.toEqual(
+          expect.objectContaining({
+            name: 'FilesystemError',
+            path: target,
+            permission: 'create',
+            code: 'EACCES',
+          }),
+        )
+      } finally {
+        // Restore write permission so afterEach can remove the temp tree.
+        await fs.chmod(parent, 0o755).catch(() => undefined)
+      }
+    },
+  )
+})


### PR DESCRIPTION
Refs #228

## Problem

`vaultkeeper config init` (and the first `store`, which persists key state before any secret is written) against a config directory whose **parent** is read-only leaked a raw, unwrapped Node error instead of the documented typed `FilesystemError`. Wave-14 (#181/#169) wrapped the config-dir READ paths, but the config-dir **creation** path was still unwrapped:

- `config init` — `fs.mkdir` in `packages/cli/src/commands/config.ts`
- first `store` — `fs.mkdir` in `saveKeyState` (`packages/vaultkeeper/src/keys/storage.ts`)

## Fix

Wrap the `mkdir` (and the adjacent file write) failures in both paths in a typed `FilesystemError` — the errored path plus the underlying errno `code` — and render it through the CLI's `formatError` with directory-specific wording and a parent-directory fix hint. `saveManifest` was already wrapped; the exec-token cache dir is derived from the OS cache/temp location (not `--config-dir`) and is intentionally left out of scope.

A new `'create'` permission distinguishes directory creation from file writes, so the message reads as a *directory* that could not be created and points the fix at the parent directory (matching the existing `FilesystemError` rendering machinery the read paths use).

## Before / after

### `vaultkeeper --config-dir <ro>/sub config init --backend file` (parent read-only)

```diff
-Error: EACCES: permission denied, mkdir '<ro>/sub'
+FilesystemError: The directory at `<ro>/sub` could not be created (permission denied). Check that its parent directory is writable, or choose a writable location with --config-dir, then try again.
```

### `echo secret | vaultkeeper --config-dir <ro>/sub store --name FOO` (parent read-only)

```diff
 No config file found; using the default backend (file). Run 'vaultkeeper config init --backend file' to persist it.
-Error: EACCES: permission denied, mkdir '<ro>/sub'
+FilesystemError: The directory at `<ro>/sub` could not be created (permission denied). Check that its parent directory is writable, or choose a writable location with --config-dir, then try again.
```

Both still exit non-zero; the raw `EACCES` / `mkdir` errno text no longer reaches the user.

## Tests

- **Subprocess UAT** (`packages/cli-tests/test/e2e/config-init-mkdir-readonly.test.ts`): `config init` and `store` against a chmod-500 parent assert a typed `FilesystemError`, the parent-dir hint, a non-zero exit, and no raw `EACCES`/`mkdir` string. Guarded to non-root POSIX.
- **Unit** (`packages/cli/test/unit/output.test.ts`): `'create'`-permission rendering for both the permission-denied and non-permission (EROFS) cases.
- **Unit** (`packages/vaultkeeper/test/unit/keys/storage.test.ts`): `saveKeyState` throws a typed `FilesystemError` (`permission: 'create'`, `code: 'EACCES'`) against a read-only parent.

## Verification

- `pnpm --filter @vaultkeeper/cli test` — 350 passed
- `pnpm --filter @vaultkeeper/cli-tests test` — 210 passed / 45 skipped
- `pnpm --filter vaultkeeper test` — 970 passed / 4 skipped
- `pnpm check` — typecheck + lint + format + api-report all pass (no public API/JSDoc change)

Changeset: `vaultkeeper` + `@vaultkeeper/cli` patch.
