### PR TITLE
Fix crates.io publish: drop impossible pre-flight cli packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,15 +142,15 @@ jobs:
 
       # Only vaultkeeper-core can be pre-verified here. Packaging
       # vaultkeeper-cli requires vaultkeeper-core to already exist on the
-      # crates.io index (its manifest carries `vaultkeeper-core = { path,
-      # version = "<X>" }`, and `cargo package` — even with --no-verify —
+      # crates.io index (its manifest carries `vaultkeeper-core = { path =
+      # "...", version = "<X>" }`, and `cargo package` — even with --no-verify —
       # resolves that dependency against the registry). At release time the
       # just-bumped core version has not been published yet, so packaging
       # cli here always failed with "no matching package named
       # vaultkeeper-core found". cli packaging is instead exercised by its
       # own publish step below, which retries to absorb index propagation
       # after core is published.
-      - name: Verify crate packaging
+      - name: Verify vaultkeeper-core packaging
         run: |
           cargo package -p vaultkeeper-core --no-verify
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,19 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # Only vaultkeeper-core can be pre-verified here. Packaging
+      # vaultkeeper-cli requires vaultkeeper-core to already exist on the
+      # crates.io index (its manifest carries `vaultkeeper-core = { path,
+      # version = "<X>" }`, and `cargo package` — even with --no-verify —
+      # resolves that dependency against the registry). At release time the
+      # just-bumped core version has not been published yet, so packaging
+      # cli here always failed with "no matching package named
+      # vaultkeeper-core found". cli packaging is instead exercised by its
+      # own publish step below, which retries to absorb index propagation
+      # after core is published.
       - name: Verify crate packaging
         run: |
           cargo package -p vaultkeeper-core --no-verify
-          cargo package -p vaultkeeper-cli --no-verify
 
       - name: Publish vaultkeeper-core
         run: |


### PR DESCRIPTION
The `publish-crates` job in `release.yml` has never successfully published either crate. `vaultkeeper-core` and `vaultkeeper-cli` are both absent from the crates.io index.

## Root cause

The `Verify crate packaging` step runs, before anything is published:

```
cargo package -p vaultkeeper-core --no-verify
cargo package -p vaultkeeper-cli --no-verify
```

Packaging `vaultkeeper-cli` fails because its manifest carries `vaultkeeper-core = { path = "...", version = "<X>" }`, and `cargo package` resolves that dependency against the crates.io index even in skip-verify mode (the flag skips the build step, not dependency resolution). At release time the just-bumped `vaultkeeper-core` version has not been published yet, so the step fails with:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `vaultkeeper-core` found
  location searched: crates.io index
  required by package `vaultkeeper-cli`
```

Reproduced locally against the current tree. This fails on every release (the just-bumped core version is never on the index when this step runs), which is why nothing has ever reached crates.io.

The failing step was consistently `Verify crate packaging` across runs [22808005833](https://github.com/mike-north/vaultkeeper/actions/runs/22808005833), [22809188976](https://github.com/mike-north/vaultkeeper/actions/runs/22809188976), [22810162291](https://github.com/mike-north/vaultkeeper/actions/runs/22810162291), [22815767059](https://github.com/mike-north/vaultkeeper/actions/runs/22815767059), and [22824167479](https://github.com/mike-north/vaultkeeper/actions/runs/22824167479) (first observed 2026-03-07). Older runs skipped `publish-crates` entirely (changesets published nothing).

## Fix

Verify only `vaultkeeper-core` in the pre-flight step — it has no unpublished internal dependencies, so it always packages cleanly. `vaultkeeper-cli` packaging cannot be pre-verified before `vaultkeeper-core` exists on the index; it is instead exercised by its own publish step, which already runs in a retry loop specifically to absorb index-propagation delay after core publishes.

## Blast radius

Single-line removal from one workflow step (plus an explanatory comment). No change to publish ordering, auth, or the retry logic. The TS-version matrix consistency test (which asserts the fixtures-install command string in `release.yml`) is unaffected; `actionlint` is clean.

Refs the failing runs above.