### PR TITLE
Commit approved agent tools and toolsmith registry to the repo

### DIFF
--- a/.claude/toolsmith/.gitignore
+++ b/.claude/toolsmith/.gitignore
@@ -1,0 +1,1 @@
+history.jsonl

--- a/.claude/toolsmith/registry.json
+++ b/.claude/toolsmith/registry.json
@@ -11,7 +11,7 @@
         "gh\\s+api\\b.*/pulls/comments/\\d+"
       ],
       "status": "approved",
-      "approvedSha256": "fcc765b03605c676291e3cba5f74c5918c49476409f140a838a12db8f3aeac62",
+      "approvedSha256": "0c3174fae0927b6a8ed8e80231e2613bf005dfc219c00d9374a40d954de60954",
       "permissionRule": "Bash(scripts/agent-tools/gh-review-comment:*)"
     },
     {
@@ -25,7 +25,7 @@
         "gh\\s+run\\s+view\\b.*--log-failed"
       ],
       "status": "approved",
-      "approvedSha256": "af10f2f26a0792cc63f2766c7147d7ad88edd1406cf935c3b454b4c8a2e3427e",
+      "approvedSha256": "664a7a2d0f8fa35f82c917105c5d4912fd671ca9569e02bb8d8da40c2c97aed1",
       "permissionRule": "Bash(scripts/agent-tools/gh-pr:*)"
     },
     {
@@ -39,7 +39,7 @@
         "gh\\s+api\\s+graphql\\b.*reviewThreads"
       ],
       "status": "approved",
-      "approvedSha256": "f55da066dd2b8fe29e5e2bb76a9453cf4fe4e650f6236a5bb9e7f14c2c5962ef",
+      "approvedSha256": "998949bececa676bf853e57a35257bc7b714533eb074e796e68fc72ded0d667d",
       "permissionRule": "Bash(scripts/agent-tools/pr-health:*)"
     }
   ]

--- a/.claude/toolsmith/registry.json
+++ b/.claude/toolsmith/registry.json
@@ -33,7 +33,7 @@
       "path": "scripts/agent-tools/pr-health",
       "purpose": "One-line PR health readout for this repo: CI rollup, merge state, unresolved review-thread count, Copilot-review presence — replaces the hand-assembled gh pr view + jq + GraphQL pipeline",
       "args": "<pr-number>",
-      "scope": "repo:mike-north/vaultkeeper (read-only; single positive-integer arg; fixed GraphQL query for reviewThreads; unsets GITHUB_TOKEN internally)",
+      "scope": "repo:mike-north/vaultkeeper (read-only; single positive-integer arg; fixed GraphQL query for reviewThreads; unsets GITHUB_TOKEN and GH_TOKEN internally)",
       "covers": [
         "gh\\s+pr\\s+view\\b.*statusCheckRollup",
         "gh\\s+api\\s+graphql\\b.*reviewThreads"

--- a/.claude/toolsmith/registry.json
+++ b/.claude/toolsmith/registry.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "tools": [
+    {
+      "name": "gh-review-comment",
+      "path": "scripts/agent-tools/gh-review-comment",
+      "purpose": "Print the full body (path:line, author, complete text) of one PR review comment in this repo — the piece gh-reviews truncates",
+      "args": "<comment-id>",
+      "scope": "repo:mike-north/vaultkeeper (read-only GET to pulls/comments/<id>; refuses outside the repo; id must be a positive integer)",
+      "covers": [
+        "gh\\s+api\\b.*/pulls/comments/\\d+"
+      ],
+      "status": "approved",
+      "approvedSha256": "fcc765b03605c676291e3cba5f74c5918c49476409f140a838a12db8f3aeac62",
+      "permissionRule": "Bash(scripts/agent-tools/gh-review-comment:*)"
+    },
+    {
+      "name": "gh-pr",
+      "path": "scripts/agent-tools/gh-pr",
+      "purpose": "Read-only PR status helpers for this repo: is-ready (one-line merge-readiness verdict) and get-failure-details (error lines from failing CI jobs)",
+      "args": "<is-ready|get-failure-details> <pr>",
+      "scope": "repo:mike-north/vaultkeeper (read-only; two fixed subcommands; PR must be a positive integer; no arbitrary API)",
+      "covers": [
+        "gh\\s+pr\\s+view\\b.*mergeStateStatus",
+        "gh\\s+run\\s+view\\b.*--log-failed"
+      ],
+      "status": "approved",
+      "approvedSha256": "af10f2f26a0792cc63f2766c7147d7ad88edd1406cf935c3b454b4c8a2e3427e",
+      "permissionRule": "Bash(scripts/agent-tools/gh-pr:*)"
+    },
+    {
+      "name": "pr-health",
+      "path": "scripts/agent-tools/pr-health",
+      "purpose": "One-line PR health readout for this repo: CI rollup, merge state, unresolved review-thread count, Copilot-review presence — replaces the hand-assembled gh pr view + jq + GraphQL pipeline",
+      "args": "<pr-number>",
+      "scope": "repo:mike-north/vaultkeeper (read-only; single positive-integer arg; fixed GraphQL query for reviewThreads; unsets GITHUB_TOKEN internally)",
+      "covers": [
+        "gh\\s+pr\\s+view\\b.*statusCheckRollup",
+        "gh\\s+api\\s+graphql\\b.*reviewThreads"
+      ],
+      "status": "approved",
+      "approvedSha256": "f55da066dd2b8fe29e5e2bb76a9453cf4fe4e650f6236a5bb9e7f14c2c5962ef",
+      "permissionRule": "Bash(scripts/agent-tools/pr-health:*)"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ scratch/
 !**/scratch/.gitkeep
 # Claude Code local configuration (auto-added)
 .claude/*.local.*
+.claude/worktrees/
+.claude/settings.json
+.claude/fleet-role.json

--- a/scripts/agent-tools/gh-pr
+++ b/scripts/agent-tools/gh-pr
@@ -114,7 +114,7 @@ cmd_failure_details() {
   # Fetch first (so a PR with no failing checks isn't a pipeline error), then
   # extract run ids — `|| true` because grep exits 1 on the legitimate no-match case.
   urls="$(gh pr view "$pr" --json statusCheckRollup \
-    --jq '[.statusCheckRollup[]?|select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="ERROR")|.detailsUrl]|.[]' 2>/dev/null)" \
+    --jq '[.statusCheckRollup[]?|select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="CANCELLED" or .conclusion=="ERROR")|.detailsUrl]|.[]' 2>/dev/null)" \
     || die "gh pr view failed for PR ${pr}" 4
   if [ -z "$urls" ]; then
     printf 'PR %s: no failing checks.\n' "$pr"

--- a/scripts/agent-tools/gh-pr
+++ b/scripts/agent-tools/gh-pr
@@ -116,9 +116,16 @@ cmd_failure_details() {
   urls="$(gh pr view "$pr" --json statusCheckRollup \
     --jq '[.statusCheckRollup[]?|select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="ERROR")|.detailsUrl]|.[]' 2>/dev/null)" \
     || die "gh pr view failed for PR ${pr}" 4
+  if [ -z "$urls" ]; then
+    printf 'PR %s: no failing checks.\n' "$pr"
+    exit 0
+  fi
   runs="$(printf '%s\n' "$urls" | grep -oE 'runs/[0-9]+' | cut -d/ -f2 | sort -u || true)"
   if [ -z "$runs" ]; then
-    printf 'PR %s: no failing checks.\n' "$pr"
+    # Failing checks exist but none resolve to a GitHub Actions run (external
+    # CI) — report them rather than claiming there are no failures.
+    printf 'PR %s: failing checks are not GitHub Actions runs; cannot fetch logs. Details URLs:\n' "$pr"
+    printf '%s\n' "$urls"
     exit 0
   fi
   local run

--- a/scripts/agent-tools/gh-pr
+++ b/scripts/agent-tools/gh-pr
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# gh-pr — read-only PR status helpers, scoped to one repo.
+#
+# Two fixed subcommands, each taking only a positive-integer PR number:
+#
+#   gh-pr is-ready <pr>
+#     One-line merge-readiness verdict, combining PR state + mergeStateStatus +
+#     failing status checks + unresolved review-thread count into a single read.
+#     Exit: 0 READY · 10 CI-FAILED · 20 BLOCKED/DIRTY/THREADS/pending · 30 not-open
+#
+#   gh-pr get-failure-details <pr>
+#     For each FAILED status check on the PR, resolve its Actions run and print
+#     the error/failure lines from that job's log (the "why did CI fail" pipeline).
+#     Exit: 0 (printed, incl. "no failing checks") · non-zero only on gh/API error.
+#
+# Scope is baked in: it only ever talks to the ALLOWED repo below, only does
+# read-only GETs (gh pr view / gh api graphql read query / gh run view --log-failed),
+# and accepts nothing but one of the two fixed subcommands plus a positive-integer
+# PR number. No caller-supplied path/URL/query — not a general gh wrapper.
+
+set -euo pipefail
+
+ALLOWED_OWNER="mike-north"
+ALLOWED_REPO="vaultkeeper"
+GH="${GH:-gh}"
+
+die() { printf '%s\n' "gh-pr: $*" >&2; exit "${2:-2}"; }
+
+usage() {
+  cat <<EOF
+gh-pr — read-only PR status helpers (scoped to ${ALLOWED_OWNER}/${ALLOWED_REPO}).
+
+Usage:
+  gh-pr is-ready <pr>              One-line merge-readiness verdict
+  gh-pr get-failure-details <pr>   Error lines from failing CI jobs
+  gh-pr --help
+
+<pr> must be a positive integer. Read-only. Exits non-zero for a not-ready PR
+(is-ready) or on gh/API error.
+EOF
+}
+
+require_repo() {
+  local origin
+  origin="$($GH repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)" \
+    || die "could not determine the current repo via gh" 4
+  [ "$origin" = "${ALLOWED_OWNER}/${ALLOWED_REPO}" ] \
+    || die "refusing to run: current repo is '$origin', tool is scoped to ${ALLOWED_OWNER}/${ALLOWED_REPO}" 3
+}
+
+# Count unresolved review threads via a fixed, repo+PR-scoped GraphQL read query.
+unresolved_threads() {
+  local pr="$1"
+  $GH api graphql -F owner="${ALLOWED_OWNER}" -F repo="${ALLOWED_REPO}" -F pr="$pr" -f query='
+    query($owner:String!,$repo:String!,$pr:Int!){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$pr){ reviewThreads(first:100){ nodes{ isResolved } } }
+      }
+    }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved|not)]|length' 2>/dev/null \
+    || die "gh api graphql read failed for PR ${pr}" 4
+}
+
+cmd_is_ready() {
+  local pr="$1"
+  local json state mss failed unresolved
+  json="$($GH pr view "$pr" --json state,mergeStateStatus,statusCheckRollup 2>/dev/null)" \
+    || die "gh pr view failed for PR ${pr}" 4
+  state="$(jq -r '.state' <<<"$json")"
+  mss="$(jq -r '.mergeStateStatus' <<<"$json")"
+  failed="$(jq -r '[.statusCheckRollup[]?|select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="CANCELLED" or .conclusion=="ERROR")|.name]|join(", ")' <<<"$json")"
+
+  if [ "$state" != "OPEN" ]; then
+    printf 'PR %s: %s\n' "$pr" "$state"
+    exit 30
+  fi
+  if [ -n "$failed" ]; then
+    printf 'PR %s: CI-FAILED (%s)\n' "$pr" "$failed"
+    exit 10
+  fi
+  unresolved="$(unresolved_threads "$pr")"
+  if [ "$mss" = "DIRTY" ]; then
+    printf 'PR %s: DIRTY (merge conflict); unresolved threads=%s\n' "$pr" "$unresolved"
+    exit 20
+  fi
+  if [ "$unresolved" != "0" ]; then
+    printf 'PR %s: BLOCKED — %s unresolved review thread(s); mergeStateStatus=%s\n' "$pr" "$unresolved" "$mss"
+    exit 20
+  fi
+  if [ "$mss" = "CLEAN" ]; then
+    printf 'PR %s: READY (mergeStateStatus=CLEAN, 0 unresolved threads)\n' "$pr"
+    exit 0
+  fi
+  printf 'PR %s: BLOCKED — mergeStateStatus=%s (checks pending or review required), 0 unresolved threads\n' "$pr" "$mss"
+  exit 20
+}
+
+cmd_failure_details() {
+  local pr="$1"
+  local urls runs
+  # Fetch first (so a PR with no failing checks isn't a pipeline error), then
+  # extract run ids — `|| true` because grep exits 1 on the legitimate no-match case.
+  urls="$($GH pr view "$pr" --json statusCheckRollup \
+    --jq '[.statusCheckRollup[]?|select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="ERROR")|.detailsUrl]|.[]' 2>/dev/null)" \
+    || die "gh pr view failed for PR ${pr}" 4
+  runs="$(printf '%s\n' "$urls" | grep -oE 'runs/[0-9]+' | cut -d/ -f2 | sort -u || true)"
+  if [ -z "$runs" ]; then
+    printf 'PR %s: no failing checks.\n' "$pr"
+    exit 0
+  fi
+  local run
+  for run in $runs; do
+    printf '=== failing run %s (PR %s) ===\n' "$run" "$pr"
+    $GH run view "$run" --log-failed 2>/dev/null \
+      | grep -iE 'error|fail|not found|cannot|ELIFECYCLE|Traceback|assert|✗|✖' \
+      | grep -viE '^\s*✓' \
+      | head -30 \
+      || printf '(no matching error lines; run: gh run view %s --log-failed)\n' "$run"
+    printf '\n'
+  done
+}
+
+sub="${1:-}"
+case "$sub" in
+  -h|--help) usage; exit 0 ;;
+  is-ready|get-failure-details) : ;;
+  "") usage; die "missing subcommand" 2 ;;
+  *) usage; die "unknown subcommand: $sub (expected is-ready or get-failure-details)" 2 ;;
+esac
+
+pr="${2:-}"
+[ "$#" -eq 2 ] || die "expected: gh-pr $sub <pr>" 2
+[[ "$pr" =~ ^[1-9][0-9]*$ ]] || die "PR number must be a positive integer, got: $pr" 2
+
+require_repo
+
+case "$sub" in
+  is-ready) cmd_is_ready "$pr" ;;
+  get-failure-details) cmd_failure_details "$pr" ;;
+esac

--- a/scripts/agent-tools/gh-pr
+++ b/scripts/agent-tools/gh-pr
@@ -27,7 +27,7 @@ ALLOWED_REPO="vaultkeeper"
 # A broken GITHUB_TOKEN in the environment shadows keyring auth; the gh binary
 # is invoked directly (no override indirection) so the command cannot be
 # redirected via the environment.
-unset GITHUB_TOKEN || true
+unset GITHUB_TOKEN GH_TOKEN || true
 
 die() { printf '%s\n' "gh-pr: $*" >&2; exit "${2:-2}"; }
 

--- a/scripts/agent-tools/gh-pr
+++ b/scripts/agent-tools/gh-pr
@@ -24,7 +24,8 @@ set -euo pipefail
 ALLOWED_OWNER="mike-north"
 ALLOWED_REPO="vaultkeeper"
 
-# A broken GITHUB_TOKEN in the environment shadows keyring auth; the gh binary
+# A broken GITHUB_TOKEN or GH_TOKEN in the environment shadows keyring auth (both
+# are unset below); the gh binary
 # is invoked directly (no override indirection) so the command cannot be
 # redirected via the environment.
 unset GITHUB_TOKEN GH_TOKEN || true

--- a/scripts/agent-tools/gh-pr
+++ b/scripts/agent-tools/gh-pr
@@ -133,7 +133,7 @@ cmd_failure_details() {
     printf '=== failing run %s (PR %s) ===\n' "$run" "$pr"
     gh run view "$run" --log-failed 2>/dev/null \
       | grep -iE 'error|fail|not found|cannot|ELIFECYCLE|Traceback|assert|✗|✖' \
-      | grep -viE '^\s*✓' \
+      | grep -viE '^[[:space:]]*✓' \
       | head -30 \
       || printf '(no matching error lines; run: gh run view %s --log-failed)\n' "$run"
     printf '\n'

--- a/scripts/agent-tools/gh-pr
+++ b/scripts/agent-tools/gh-pr
@@ -128,14 +128,21 @@ cmd_failure_details() {
     printf '%s\n' "$urls"
     exit 0
   fi
-  local run
+  local run lines
   for run in $runs; do
     printf '=== failing run %s (PR %s) ===\n' "$run" "$pr"
-    gh run view "$run" --log-failed 2>/dev/null \
+    # Captured (not streamed) so head's early exit can't surface as a SIGPIPE
+    # pipeline failure under pipefail; emptiness decides the fallback message.
+    lines="$(gh run view "$run" --log-failed 2>/dev/null \
       | grep -iE 'error|fail|not found|cannot|ELIFECYCLE|Traceback|assert|✗|✖' \
       | grep -viE '^[[:space:]]*✓' \
       | head -30 \
-      || printf '(no matching error lines; run: gh run view %s --log-failed)\n' "$run"
+      || true)"
+    if [ -n "$lines" ]; then
+      printf '%s\n' "$lines"
+    else
+      printf '(no matching error lines; run: gh run view %s --log-failed)\n' "$run"
+    fi
     printf '\n'
   done
 }

--- a/scripts/agent-tools/gh-pr
+++ b/scripts/agent-tools/gh-pr
@@ -23,7 +23,11 @@ set -euo pipefail
 
 ALLOWED_OWNER="mike-north"
 ALLOWED_REPO="vaultkeeper"
-GH="${GH:-gh}"
+
+# A broken GITHUB_TOKEN in the environment shadows keyring auth; the gh binary
+# is invoked directly (no override indirection) so the command cannot be
+# redirected via the environment.
+unset GITHUB_TOKEN || true
 
 die() { printf '%s\n' "gh-pr: $*" >&2; exit "${2:-2}"; }
 
@@ -43,28 +47,37 @@ EOF
 
 require_repo() {
   local origin
-  origin="$($GH repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)" \
+  origin="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)" \
     || die "could not determine the current repo via gh" 4
   [ "$origin" = "${ALLOWED_OWNER}/${ALLOWED_REPO}" ] \
     || die "refusing to run: current repo is '$origin', tool is scoped to ${ALLOWED_OWNER}/${ALLOWED_REPO}" 3
 }
 
 # Count unresolved review threads via a fixed, repo+PR-scoped GraphQL read query.
+# Fails closed if the PR has more than one page of threads, so the count is
+# never silently under-reported.
 unresolved_threads() {
-  local pr="$1"
-  $GH api graphql -F owner="${ALLOWED_OWNER}" -F repo="${ALLOWED_REPO}" -F pr="$pr" -f query='
+  local pr="$1" result
+  result="$(gh api graphql -F owner="${ALLOWED_OWNER}" -F repo="${ALLOWED_REPO}" -F pr="$pr" -f query='
     query($owner:String!,$repo:String!,$pr:Int!){
       repository(owner:$owner,name:$repo){
-        pullRequest(number:$pr){ reviewThreads(first:100){ nodes{ isResolved } } }
+        pullRequest(number:$pr){ reviewThreads(first:100){
+          pageInfo{ hasNextPage }
+          nodes{ isResolved }
+        } }
       }
-    }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved|not)]|length' 2>/dev/null \
+    }' --jq '.data.repository.pullRequest.reviewThreads
+             | "\(.pageInfo.hasNextPage) \([.nodes[]|select(.isResolved|not)]|length)"' 2>/dev/null)" \
     || die "gh api graphql read failed for PR ${pr}" 4
+  [ "${result%% *}" = "false" ] \
+    || die "PR ${pr} has more than 100 review threads; refusing to report a truncated count" 4
+  printf '%s\n' "${result#* }"
 }
 
 cmd_is_ready() {
   local pr="$1"
   local json state mss failed unresolved
-  json="$($GH pr view "$pr" --json state,mergeStateStatus,statusCheckRollup 2>/dev/null)" \
+  json="$(gh pr view "$pr" --json state,mergeStateStatus,statusCheckRollup 2>/dev/null)" \
     || die "gh pr view failed for PR ${pr}" 4
   state="$(jq -r '.state' <<<"$json")"
   mss="$(jq -r '.mergeStateStatus' <<<"$json")"
@@ -100,7 +113,7 @@ cmd_failure_details() {
   local urls runs
   # Fetch first (so a PR with no failing checks isn't a pipeline error), then
   # extract run ids — `|| true` because grep exits 1 on the legitimate no-match case.
-  urls="$($GH pr view "$pr" --json statusCheckRollup \
+  urls="$(gh pr view "$pr" --json statusCheckRollup \
     --jq '[.statusCheckRollup[]?|select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="ERROR")|.detailsUrl]|.[]' 2>/dev/null)" \
     || die "gh pr view failed for PR ${pr}" 4
   runs="$(printf '%s\n' "$urls" | grep -oE 'runs/[0-9]+' | cut -d/ -f2 | sort -u || true)"
@@ -111,7 +124,7 @@ cmd_failure_details() {
   local run
   for run in $runs; do
     printf '=== failing run %s (PR %s) ===\n' "$run" "$pr"
-    $GH run view "$run" --log-failed 2>/dev/null \
+    gh run view "$run" --log-failed 2>/dev/null \
       | grep -iE 'error|fail|not found|cannot|ELIFECYCLE|Traceback|assert|✗|✖' \
       | grep -viE '^\s*✓' \
       | head -30 \

--- a/scripts/agent-tools/gh-review-comment
+++ b/scripts/agent-tools/gh-review-comment
@@ -25,7 +25,7 @@ ALLOWED_REPO="vaultkeeper"
 # A broken GITHUB_TOKEN in the environment shadows keyring auth; the gh binary
 # is invoked directly (no override indirection) so the command cannot be
 # redirected via the environment.
-unset GITHUB_TOKEN || true
+unset GITHUB_TOKEN GH_TOKEN || true
 
 die() { printf '%s\n' "gh-review-comment: $*" >&2; exit "${2:-2}"; }
 

--- a/scripts/agent-tools/gh-review-comment
+++ b/scripts/agent-tools/gh-review-comment
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# gh-review-comment — print the FULL body of one pull-request review comment.
+#
+# Narrow, read-only slice of `gh api`. Fetches a single review comment by its
+# numeric id and prints path:line, author, and the complete body. Exists because
+# `gh-reviews threads` truncates bodies and there is no `gh` porcelain verb for
+# reading one review comment in full.
+#
+# Scope is baked in: it only ever talks to the ALLOWED repo below, only issues a
+# read-only GET to the fixed pulls/comments/<id> endpoint, and accepts nothing
+# but a positive-integer comment id. There is no way to point it at another repo,
+# another endpoint, or an arbitrary API path.
+#
+# Usage:  gh-review-comment <comment-id>
+#         gh-review-comment --help
+#
+# Exit codes: 0 ok · 2 usage error · 3 wrong repo · 4 gh/api failure
+
+set -euo pipefail
+
+ALLOWED_OWNER="mike-north"
+ALLOWED_REPO="vaultkeeper"
+GH="${GH:-gh}"
+
+die() { printf '%s\n' "gh-review-comment: $*" >&2; exit "${2:-2}"; }
+
+usage() {
+  cat <<EOF
+gh-review-comment — print the full body of one PR review comment (read-only).
+
+Usage:
+  gh-review-comment <comment-id>     Print path:line, author, and full body
+  gh-review-comment --help           Show this help
+
+Scoped to ${ALLOWED_OWNER}/${ALLOWED_REPO} only. <comment-id> must be a positive integer
+(the databaseId shown as thread_comment_id by 'gh-reviews threads').
+EOF
+}
+
+case "${1:-}" in
+  ""|-h|--help) usage; [ "${1:-}" = "" ] && exit 2 || exit 0 ;;
+esac
+
+id="$1"
+[ "$#" -eq 1 ] || die "expected exactly one argument (a comment id); got $#"
+[[ "$id" =~ ^[1-9][0-9]*$ ]] || die "comment id must be a positive integer, got: $id"
+
+# Refuse to run outside the allowed repo — scope is enforced, not assumed.
+origin="$($GH repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)" \
+  || die "could not determine the current repo via gh" 4
+[ "$origin" = "${ALLOWED_OWNER}/${ALLOWED_REPO}" ] \
+  || die "refusing to run: current repo is '$origin', tool is scoped to ${ALLOWED_OWNER}/${ALLOWED_REPO}" 3
+
+# Single read-only GET to the fixed endpoint; owner/repo/id are all constrained above.
+$GH api "repos/${ALLOWED_OWNER}/${ALLOWED_REPO}/pulls/comments/${id}" \
+  --jq '"\(.path):\(.line // .original_line)  [\(.user.login)]\n\n\(.body)"' \
+  || die "gh api read failed for comment ${id}" 4

--- a/scripts/agent-tools/gh-review-comment
+++ b/scripts/agent-tools/gh-review-comment
@@ -21,7 +21,11 @@ set -euo pipefail
 
 ALLOWED_OWNER="mike-north"
 ALLOWED_REPO="vaultkeeper"
-GH="${GH:-gh}"
+
+# A broken GITHUB_TOKEN in the environment shadows keyring auth; the gh binary
+# is invoked directly (no override indirection) so the command cannot be
+# redirected via the environment.
+unset GITHUB_TOKEN || true
 
 die() { printf '%s\n' "gh-review-comment: $*" >&2; exit "${2:-2}"; }
 
@@ -47,12 +51,12 @@ id="$1"
 [[ "$id" =~ ^[1-9][0-9]*$ ]] || die "comment id must be a positive integer, got: $id"
 
 # Refuse to run outside the allowed repo — scope is enforced, not assumed.
-origin="$($GH repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)" \
+origin="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)" \
   || die "could not determine the current repo via gh" 4
 [ "$origin" = "${ALLOWED_OWNER}/${ALLOWED_REPO}" ] \
   || die "refusing to run: current repo is '$origin', tool is scoped to ${ALLOWED_OWNER}/${ALLOWED_REPO}" 3
 
 # Single read-only GET to the fixed endpoint; owner/repo/id are all constrained above.
-$GH api "repos/${ALLOWED_OWNER}/${ALLOWED_REPO}/pulls/comments/${id}" \
+gh api "repos/${ALLOWED_OWNER}/${ALLOWED_REPO}/pulls/comments/${id}" \
   --jq '"\(.path):\(.line // .original_line)  [\(.user.login)]\n\n\(.body)"' \
   || die "gh api read failed for comment ${id}" 4

--- a/scripts/agent-tools/gh-review-comment
+++ b/scripts/agent-tools/gh-review-comment
@@ -22,7 +22,8 @@ set -euo pipefail
 ALLOWED_OWNER="mike-north"
 ALLOWED_REPO="vaultkeeper"
 
-# A broken GITHUB_TOKEN in the environment shadows keyring auth; the gh binary
+# A broken GITHUB_TOKEN or GH_TOKEN in the environment shadows keyring auth (both
+# are unset below); the gh binary
 # is invoked directly (no override indirection) so the command cannot be
 # redirected via the environment.
 unset GITHUB_TOKEN GH_TOKEN || true

--- a/scripts/agent-tools/pr-health
+++ b/scripts/agent-tools/pr-health
@@ -6,7 +6,7 @@
 # count, and Copilot-review presence, as one greppable line.
 #
 # Read-only. Repo is hardcoded; the only argument is a PR number.
-# Unsets GITHUB_TOKEN internally (a broken env token shadows keyring auth).
+# Unsets GITHUB_TOKEN and GH_TOKEN internally (a broken env token shadows keyring auth).
 set -euo pipefail
 
 REPO="mike-north/vaultkeeper"
@@ -55,6 +55,6 @@ jq -r --argjson unresolved "$threads" '
   ([$c[] | select(.status=="COMPLETED" and .conclusion=="SUCCESS")] | length) as $pass |
   ([$c[] | select(.status!="COMPLETED")] | length) as $pending |
   ([$c[] | select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="CANCELLED" or .conclusion=="ERROR") | .name] | join(",")) as $failed |
-  ([.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | length) as $copilot |
+  ([.reviews // [] | .[] | select(.author.login=="copilot-pull-request-reviewer")] | length) as $copilot |
   "PR '"$pr"' state=\(.state) mss=\(.mergeStateStatus) checks=\($pass)/\($c | length) pending=\($pending) failed=\(if $failed=="" then "-" else $failed end) unresolved=\($unresolved) copilot=\($copilot)"
 ' <<<"$json"

--- a/scripts/agent-tools/pr-health
+++ b/scripts/agent-tools/pr-health
@@ -24,9 +24,7 @@ EOF
 
 [ "${1:-}" = "--help" ] && { usage; exit 0; }
 [ $# -eq 1 ] || { usage >&2; exit 2; }
-case "$1" in
-  ''|*[!0-9]*) echo "pr-health: PR number must be a positive integer, got: $1" >&2; exit 2 ;;
-esac
+[[ "$1" =~ ^[1-9][0-9]*$ ]] || { echo "pr-health: PR number must be a positive integer, got: $1" >&2; exit 2; }
 pr="$1"
 
 unset GITHUB_TOKEN || true
@@ -36,13 +34,19 @@ json=$(gh pr view "$pr" --repo "$REPO" \
   echo "pr-health: failed to fetch PR #$pr from $REPO" >&2; exit 1; }
 
 owner="${REPO%/*}"; name="${REPO#*/}"
-threads=$(gh api graphql \
+# Fails closed if the PR has more than one page of review threads, so the
+# unresolved count is never silently under-reported.
+thread_result=$(gh api graphql \
   -F owner="$owner" -F name="$name" -F pr="$pr" \
   -f query='query($owner:String!,$name:String!,$pr:Int!){
     repository(owner:$owner,name:$name){pullRequest(number:$pr){
-      reviewThreads(first:100){nodes{isResolved}}}}}' \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length') || {
+      reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved}}}}}' \
+  --jq '.data.repository.pullRequest.reviewThreads
+        | "\(.pageInfo.hasNextPage) \([.nodes[] | select(.isResolved==false)] | length)"') || {
   echo "pr-health: failed to fetch review threads for PR #$pr" >&2; exit 1; }
+[ "${thread_result%% *}" = "false" ] || {
+  echo "pr-health: PR #$pr has more than 100 review threads; refusing to report a truncated count" >&2; exit 1; }
+threads="${thread_result#* }"
 
 jq -r --argjson unresolved "$threads" '
   (.statusCheckRollup // []) as $c |

--- a/scripts/agent-tools/pr-health
+++ b/scripts/agent-tools/pr-health
@@ -52,7 +52,7 @@ jq -r --argjson unresolved "$threads" '
   (.statusCheckRollup // []) as $c |
   ([$c[] | select(.status=="COMPLETED" and .conclusion=="SUCCESS")] | length) as $pass |
   ([$c[] | select(.status!="COMPLETED")] | length) as $pending |
-  ([$c[] | select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="CANCELLED") | .name] | join(",")) as $failed |
+  ([$c[] | select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="CANCELLED" or .conclusion=="ERROR") | .name] | join(",")) as $failed |
   ([.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | length) as $copilot |
   "PR '"$pr"' state=\(.state) mss=\(.mergeStateStatus) checks=\($pass)/\($c | length) pending=\($pending) failed=\(if $failed=="" then "-" else $failed end) unresolved=\($unresolved) copilot=\($copilot)"
 ' <<<"$json"

--- a/scripts/agent-tools/pr-health
+++ b/scripts/agent-tools/pr-health
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# pr-health — one-line health readout for a PR in mike-north/vaultkeeper.
+#
+# Collapses the gh pr view + jq + GraphQL reviewThreads pipeline agents
+# otherwise hand-assemble: CI rollup, merge state, unresolved review-thread
+# count, and Copilot-review presence, as one greppable line.
+#
+# Read-only. Repo is hardcoded; the only argument is a PR number.
+# Unsets GITHUB_TOKEN internally (a broken env token shadows keyring auth).
+set -euo pipefail
+
+REPO="mike-north/vaultkeeper"
+
+usage() {
+  cat <<'EOF'
+usage: pr-health <pr-number>
+
+Prints one line:
+  PR <n> state=<OPEN|MERGED|CLOSED> mss=<mergeStateStatus> checks=<pass>/<total> pending=<n> failed=<names|-> unresolved=<n> copilot=<n>
+
+Exit codes: 0 = fetched OK · 2 = usage error · 1 = API/network error
+EOF
+}
+
+[ "${1:-}" = "--help" ] && { usage; exit 0; }
+[ $# -eq 1 ] || { usage >&2; exit 2; }
+case "$1" in
+  ''|*[!0-9]*) echo "pr-health: PR number must be a positive integer, got: $1" >&2; exit 2 ;;
+esac
+pr="$1"
+
+unset GITHUB_TOKEN || true
+
+json=$(gh pr view "$pr" --repo "$REPO" \
+  --json state,mergeStateStatus,statusCheckRollup,reviews) || {
+  echo "pr-health: failed to fetch PR #$pr from $REPO" >&2; exit 1; }
+
+owner="${REPO%/*}"; name="${REPO#*/}"
+threads=$(gh api graphql \
+  -F owner="$owner" -F name="$name" -F pr="$pr" \
+  -f query='query($owner:String!,$name:String!,$pr:Int!){
+    repository(owner:$owner,name:$name){pullRequest(number:$pr){
+      reviewThreads(first:100){nodes{isResolved}}}}}' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length') || {
+  echo "pr-health: failed to fetch review threads for PR #$pr" >&2; exit 1; }
+
+jq -r --argjson unresolved "$threads" '
+  (.statusCheckRollup // []) as $c |
+  ([$c[] | select(.status=="COMPLETED" and .conclusion=="SUCCESS")] | length) as $pass |
+  ([$c[] | select(.status!="COMPLETED")] | length) as $pending |
+  ([$c[] | select(.conclusion=="FAILURE" or .conclusion=="TIMED_OUT" or .conclusion=="CANCELLED") | .name] | join(",")) as $failed |
+  ([.reviews[] | select(.author.login=="copilot-pull-request-reviewer")] | length) as $copilot |
+  "PR '"$pr"' state=\(.state) mss=\(.mergeStateStatus) checks=\($pass)/\($c | length) pending=\($pending) failed=\(if $failed=="" then "-" else $failed end) unresolved=\($unresolved) copilot=\($copilot)"
+' <<<"$json"

--- a/scripts/agent-tools/pr-health
+++ b/scripts/agent-tools/pr-health
@@ -29,7 +29,7 @@ EOF
 [[ "$1" =~ ^[1-9][0-9]*$ ]] || { echo "pr-health: PR number must be a positive integer, got: $1" >&2; exit 2; }
 pr="$1"
 
-unset GITHUB_TOKEN || true
+unset GITHUB_TOKEN GH_TOKEN || true
 
 json=$(gh pr view "$pr" --repo "$REPO" \
   --json state,mergeStateStatus,statusCheckRollup,reviews) || {

--- a/scripts/agent-tools/pr-health
+++ b/scripts/agent-tools/pr-health
@@ -18,7 +18,9 @@ usage: pr-health <pr-number>
 Prints one line:
   PR <n> state=<OPEN|MERGED|CLOSED> mss=<mergeStateStatus> checks=<pass>/<total> pending=<n> failed=<names|-> unresolved=<n> copilot=<n>
 
-Exit codes: 0 = fetched OK · 2 = usage error · 1 = API/network error
+Exit codes: 0 = fetched OK · 2 = usage error · 1 = could not produce a
+trustworthy readout (API/network error, or >100 review threads where the
+tool refuses to report a truncated count)
 EOF
 }
 


### PR DESCRIPTION
## Problem

The approved narrow agent tools (`scripts/agent-tools/gh-pr`, `gh-review-comment`, `pr-health`) and their toolsmith registry existed only as untracked files in one checkout. Agents working in fresh git worktrees (the standard fleet workflow) had no copy at the relative path the pre-approved permission rules reference — so they either invoked by absolute path (which the relative rules don't match) or fell back to hand-assembled `gh api` pipelines. Both paths trigger the permission prompts these tools exist to eliminate.

## Change

- Commit the three approved tools and `.claude/toolsmith/registry.json` (project-scope toolsmith design: tools are committed and PR-reviewed).
- Gitignore the toolsmith history log, local permission settings (`.claude/settings.json`), fleet role markers, and `.claude/worktrees/`.

No runtime/package changes; tooling + repo hygiene only. The tools are read-only (`pr-health`, `gh-pr`) or single-comment-scoped (`gh-review-comment`), each with hardcoded repo scope and fail-closed argument validation — see the registry entries.