### PR TITLE
Migrate npm publishing to GitHub Actions OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,10 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     outputs:
       published: ${{ steps.changesets.outputs.published }}
     steps:
@@ -108,11 +112,16 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 22
-          cache: pnpm
+          # Pin and update this intentionally. Trusted publishing currently
+          # requires Node >=22.14.0 and npm >=11.5.1.
+          node-version: '24.14.0'
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Show release toolchain
+        run: node --version && npm --version && pnpm --version
 
       - run: pnpm install --frozen-lockfile
 
@@ -125,7 +134,6 @@ jobs:
           publish: pnpm exec changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
   publish-crates:
     name: Publish to crates.io


### PR DESCRIPTION
## Summary

Migrates vaultkeeper's npm publishing from a long-lived `NODE_AUTH_TOKEN` secret to GitHub Actions OIDC trusted publishing, per the standardized identity below. This PR covers the repository side only (Phase 1 audit + Phase 2 workflow/manifest changes). **npm-side trust record creation (Phase 3) requires interactive 2FA and must be run by a human** — exact commands are included below for copy/paste.

**Standardized identity:**

| Field | Value |
| --- | --- |
| Workflow | `release.yml` |
| Environment | `npm-publish` |
| Allowed operation | `npm publish` (not stage) |
| Repository | `mike-north/vaultkeeper` |

## What changed

`.github/workflows/release.yml`, `release` job only (rust/ci/publish-crates jobs untouched):

- Added job-level `permissions: { contents: write, pull-requests: write, id-token: write }` — the new `id-token: write` is what lets npm exchange a GitHub OIDC token for a short-lived publish credential. This is a job-level override rather than a workflow-level permission, so `rust`/`ci`/`publish-crates` are unaffected.
- Bumped `actions/setup-node` from `v4` to `v7` and pinned `node-version: '24.14.0'` (previous pin was Node 22, below the `>=22.14.0` trusted-publishing floor; 24.x is the currently recommended release line).
- Replaced `cache: pnpm` with `package-manager-cache: false` on the publish job specifically — `actions/setup-node`'s own docs warn that its GitHub Actions cache can expose OIDC tokens to a poisoned cache, so publish-time caching is disabled while the `ci` job's cache is left alone.
- Added a "Show release toolchain" step (`node --version && npm --version && pnpm --version`) so the exact publish-time toolchain is visible in every release run's logs.
- **Removed `NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}` from the Changesets publish step.** `GITHUB_TOKEN` remains — it's unrelated to npm auth; it's what `changesets/action` uses to open the version PR and create tags/releases.

**Package manifests:** audited, no changes needed. All 5 publishable packages already had exact `repository.url`/`repository.directory` metadata and `publishConfig.access: "public"`.

**Root `package.json`:** audited, no changes needed. Already uses the safe top-level `"packageManager": "pnpm@10.12.1"` field rather than the `devEngines.packageManager` shape that npm 11 rejects with `EBADDEVENGINES` when Changesets invokes `npm info`/`npm publish` from the workspace root.

## Audit findings (Phase 1)

| package | repository | current version | repo/directory metadata | publishConfig.access | devEngines trap | trust_status |
| --- | --- | --- | --- | --- | --- | --- |
| `vaultkeeper` | mike-north/vaultkeeper (packages/vaultkeeper) | 0.7.0 | correct | public | none | unknown (human must check) |
| `@vaultkeeper/cli` | mike-north/vaultkeeper (packages/cli) | 0.2.0 | correct | public | none | unknown |
| `@vaultkeeper/wasm` | mike-north/vaultkeeper (packages/vaultkeeper-wasm) | 0.3.0 | correct | public | none | unknown |
| `@vaultkeeper/test-helpers` | mike-north/vaultkeeper (packages/test-helpers) | 0.3.0 | correct | public | none | unknown |
| `@vaultkeeper/cli-test-helpers` | mike-north/vaultkeeper (packages/cli-test-helpers) | 0.3.0 | correct | public | none | unknown |

No package currently shows an `npm view ... dist.attestations` entry — expected, since none has ever published via OIDC.

**Note (not a blocker):** `vaultkeeper@1.0.0`/`1.0.1` exist on the npm registry (published 2026-03-02/04) but are not `latest` — they're remnants of the "DX round 4" release that was subsequently reverted (see `Revert "DX round 4..." (#51)` / `Revert "Version Packages (#49)"` in git history). The registry's `latest` dist-tag (`0.7.0`) correctly matches `main`. No action needed, just worth knowing when reading version history.

## Fleet manifest (TSV)

```
package	repository	workflow	environment	action	package_manager	release_tool	current_version	trust_status	migration_pr	canary_version	attestation
vaultkeeper	mike-north/vaultkeeper	release.yml	npm-publish	publish	pnpm	Changesets	0.7.0	unknown	<this PR>	pending	missing
@vaultkeeper/cli	mike-north/vaultkeeper	release.yml	npm-publish	publish	pnpm	Changesets	0.2.0	unknown	<this PR>	pending	missing
@vaultkeeper/wasm	mike-north/vaultkeeper	release.yml	npm-publish	publish	pnpm	Changesets	0.3.0	unknown	<this PR>	pending	missing
@vaultkeeper/test-helpers	mike-north/vaultkeeper	release.yml	npm-publish	publish	pnpm	Changesets	0.3.0	unknown	<this PR>	pending	missing
@vaultkeeper/cli-test-helpers	mike-north/vaultkeeper	release.yml	npm-publish	publish	pnpm	Changesets	0.3.0	unknown	<this PR>	pending	missing
```

## Definition of done

- [x] Every package already exists on npm.
- [x] `package.json` names the correct package and source repository (exact case/directory) for all 5 packages.
- [x] The publishing job uses a GitHub-hosted runner (`ubuntu-latest`, unchanged).
- [x] The publishing job has `id-token: write` (this PR).
- [x] The publishing runtime satisfies current Node/npm minimums (Node 24.14.0 pinned, this PR).
- [x] The publishing job no longer provides a write-capable `NPM_TOKEN`/`NODE_AUTH_TOKEN` (this PR).
- [ ] **npm's trust record exactly matches owner/repo/workflow/environment/action** — HUMAN-ONLY, see below.
- [ ] A canary release was published through OIDC — pending, blocked on the trust record.
- [ ] npm reports a provenance attestation for the canary version — pending.
- [ ] The expected Git tag and GitHub release exist for the canary — pending.
- [ ] Traditional token-based publishing is disabled/restricted after OIDC is proven — pending, human-only, **only after** the canary succeeds.
- [ ] Obsolete automation tokens (`NODE_AUTH_TOKEN` repo/environment secret) are revoked — pending, human-only, **only after** the canary succeeds.

## HUMAN-ONLY: Phase 3 — npm trust records

These require an interactive browser/2FA approval and **cannot be run by an agent**. Run from a terminal where you can complete the npm 2FA browser prompt. Use a newer npm CLI ephemerally (`npm exec --yes --package=npm@11.18.0 -- ...`) — do not change the repo's own npm/pnpm toolchain to do this.

**Step 1 — audit first, for every package** (read-only; do this before creating anything):

```sh
npm exec --yes --package=npm@11.18.0 -- npm trust list vaultkeeper --json
npm exec --yes --package=npm@11.18.0 -- npm trust list @vaultkeeper/cli --json
npm exec --yes --package=npm@11.18.0 -- npm trust list @vaultkeeper/wasm --json
npm exec --yes --package=npm@11.18.0 -- npm trust list @vaultkeeper/test-helpers --json
npm exec --yes --package=npm@11.18.0 -- npm trust list @vaultkeeper/cli-test-helpers --json
```

**If any of these returns an existing record you did not expect, stop and do not overwrite it automatically** — figure out where it came from first. If a record is genuinely stale/wrong, replace it explicitly with `npm trust revoke --id <id>` before creating the new one (list → revoke → create), never blind-create over an existing record.

**Step 2 — create the trust record for each package that has none** (only after Step 1 confirms it's empty):

```sh
npm exec --yes --package=npm@11.18.0 -- \
  npm trust github vaultkeeper \
  --file release.yml \
  --repo mike-north/vaultkeeper \
  --environment npm-publish \
  --allow-publish \
  --yes \
  --json

npm exec --yes --package=npm@11.18.0 -- \
  npm trust github @vaultkeeper/cli \
  --file release.yml \
  --repo mike-north/vaultkeeper \
  --environment npm-publish \
  --allow-publish \
  --yes \
  --json

npm exec --yes --package=npm@11.18.0 -- \
  npm trust github @vaultkeeper/wasm \
  --file release.yml \
  --repo mike-north/vaultkeeper \
  --environment npm-publish \
  --allow-publish \
  --yes \
  --json

npm exec --yes --package=npm@11.18.0 -- \
  npm trust github @vaultkeeper/test-helpers \
  --file release.yml \
  --repo mike-north/vaultkeeper \
  --environment npm-publish \
  --allow-publish \
  --yes \
  --json

npm exec --yes --package=npm@11.18.0 -- \
  npm trust github @vaultkeeper/cli-test-helpers \
  --file release.yml \
  --repo mike-north/vaultkeeper \
  --environment npm-publish \
  --allow-publish \
  --yes \
  --json
```

**Step 3 — list again after every creation and compare every field** (`file`, `repository`, `environment`, `permissions`) against the table above. Record each package's opaque trust `id` somewhere durable (not in this PR) in case a later replacement is needed.

Never print a token, OTP, or browser-auth URL into this PR, a commit, or any durable log.

## Canary + verification plan (Phase 4)

Recommend **`@vaultkeeper/cli-test-helpers`** as the canary: it's a dev-only test-utility package with no runtime consumers outside this repo's own test packages, so a bad canary publish has essentially no blast radius.

1. After this PR merges and Step 1–3 above are done for at least `@vaultkeeper/cli-test-helpers`, land a trivial patch changeset touching only that package on `main` (e.g. `pnpm changeset` → patch bump, changelog line "Verify OIDC trusted publishing end-to-end").
2. `changesets/action` opens/refreshes the version PR. Merge it — this bumps `@vaultkeeper/cli-test-helpers`'s version in git but does not publish yet.
3. The next push to `main` (the version-PR merge itself) triggers another `release` job run. Watch it in the Actions tab — confirm the "Show release toolchain" step shows Node 24.14.0 / npm ≥11.5.1, and that the Changesets publish step succeeds without any `NODE_AUTH_TOKEN` present.
4. Verify against the registry:
   ```sh
   npm view @vaultkeeper/cli-test-helpers version dist-tags dist.attestations --json
   ```
   Confirm the version matches the canary bump and `dist.attestations` includes a provenance entry with `"predicateType": "https://slsa.dev/provenance/v1"`.
5. Verify the tag and release (this repo's tag convention, confirmed from existing tags, is `<package>@<version>`, e.g. `@vaultkeeper/cli-test-helpers@0.3.1`):
   ```sh
   git ls-remote --tags origin '@vaultkeeper/cli-test-helpers@<version>'
   env -u GITHUB_TOKEN gh release view '@vaultkeeper/cli-test-helpers@<version>'
   ```
6. Optional consumer-side check: install the released version in a scratch project and run `npm audit signatures`.

If the canary publish fails, treat any `E404`/`404 Not Found` from Changesets as an OIDC identity mismatch (package name / owner-repo case / workflow filename / environment / permission) until disproven via `npm trust list` — **not** as a signal to add a token back. Do not bump the version again until the failure is understood; rerun the same failed job at the same commit after fixing the external npm-side config.

## Post-canary hardening (Phase 5 — human-only, only after the canary succeeds)

1. Repeat Steps 1–3 above for the remaining 4 packages (`vaultkeeper`, `@vaultkeeper/cli`, `@vaultkeeper/wasm`, `@vaultkeeper/test-helpers`).
2. For each package: npm Settings → Publishing access → **Require two-factor authentication and disallow tokens**.
3. Revoke the `NODE_AUTH_TOKEN` value at its npm source and remove the `NODE_AUTH_TOKEN` secret from the `npm-publish` GitHub environment (it's already unused by the workflow after this PR, but the secret itself should still be deleted so it can't be silently reintroduced).
4. Confirm the very next real release (any package) still publishes cleanly through OIDC with no manual intervention.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm build` — all 5 publishable projects build clean
- [x] `pnpm check` (typecheck, lint, format, api-report) — clean (pre-existing `security/detect-object-injection` warnings only, no errors, no new findings)
- [x] `pnpm test` — 24 test files passed, 1 skipped (rust-binary-dependent, expected without the binary present), 216 tests passed / 44 skipped; includes `packaging.test.ts`, which packs and inspects the tarball for all 5 publishable packages as a pack-dry-run-equivalent sanity check
- [x] `npm info vaultkeeper version` from the workspace root — succeeds (`0.7.0`), confirming no `EBADDEVENGINES` trap
- [ ] Phase 3 (npm trust records) and Phase 4 (canary) — human-only, see above
