### PR TITLE
Port presence/capability model to vaultkeeper-core

### DIFF
--- a/crates/vaultkeeper-cli/src/main.rs
+++ b/crates/vaultkeeper-cli/src/main.rs
@@ -59,7 +59,7 @@ enum Commands {
         #[arg(long)]
         name: String,
         /// Require the active backend to force a fresh, per-use human presence
-        /// action for this store. Refuses with a `NotCapable` error — before
+        /// action for this store. Refuses with a NotCapable error — before
         /// the backend is touched — if it cannot guarantee one.
         #[arg(long)]
         require_presence_per_use: bool,
@@ -70,7 +70,7 @@ enum Commands {
         #[arg(long)]
         name: String,
         /// Require the active backend to force a fresh, per-use human presence
-        /// action for this delete. Refuses with a `NotCapable` error — before
+        /// action for this delete. Refuses with a NotCapable error — before
         /// the backend is touched — if it cannot guarantee one.
         #[arg(long)]
         require_presence_per_use: bool,

--- a/crates/vaultkeeper-cli/src/main.rs
+++ b/crates/vaultkeeper-cli/src/main.rs
@@ -9,8 +9,9 @@ use host::NativeHostPlatform;
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::sync::Arc;
-use vaultkeeper_core::backend::{FileBackend, HostPlatform, SecretBackend};
+use vaultkeeper_core::backend::{FileBackend, HostPlatform, PresenceOperation, SecretBackend};
 use vaultkeeper_core::config;
+use vaultkeeper_core::vault::enforce_presence_requirement;
 
 #[derive(Parser)]
 #[command(
@@ -57,12 +58,22 @@ enum Commands {
         /// Secret name
         #[arg(long)]
         name: String,
+        /// Require the active backend to force a fresh, per-use human presence
+        /// action for this store. Refuses with a `NotCapable` error — before
+        /// the backend is touched — if it cannot guarantee one.
+        #[arg(long)]
+        require_presence_per_use: bool,
     },
     /// Delete a secret
     Delete {
         /// Secret name
         #[arg(long)]
         name: String,
+        /// Require the active backend to force a fresh, per-use human presence
+        /// action for this delete. Refuses with a `NotCapable` error — before
+        /// the backend is touched — if it cannot guarantee one.
+        #[arg(long)]
+        require_presence_per_use: bool,
     },
     /// Manage configuration
     Config {
@@ -98,8 +109,14 @@ async fn main() {
             0
         }
         Some(cmd) => match cmd {
-            Commands::Store { name } => cmd_store(&name).await,
-            Commands::Delete { name } => cmd_delete(&name).await,
+            Commands::Store {
+                name,
+                require_presence_per_use,
+            } => cmd_store(&name, require_presence_per_use).await,
+            Commands::Delete {
+                name,
+                require_presence_per_use,
+            } => cmd_delete(&name, require_presence_per_use).await,
             Commands::Exec { token, command } => cmd_exec(&token, &command).await,
             Commands::Doctor => cmd_doctor().await,
             Commands::Approve { path } => cmd_approve(&path).await,
@@ -118,7 +135,7 @@ fn print_help() {
     Cli::command().print_help().ok();
 }
 
-async fn cmd_store(name: &str) -> i32 {
+async fn cmd_store(name: &str, require_presence_per_use: bool) -> i32 {
     // Read secret from stdin
     let mut secret = String::new();
     if let Err(e) = io::stdin().read_to_string(&mut secret) {
@@ -135,6 +152,20 @@ async fn cmd_store(name: &str) -> i32 {
     let host = make_host();
     let backend = FileBackend::new(host.clone());
 
+    // Non-bypassable presence gate (issue #242): refuses before the backend is
+    // ever touched when the flag is set and the active backend can't force a
+    // fresh per-use action for `store`. A no-op when the flag is unset.
+    if let Err(e) = enforce_presence_requirement(
+        &backend,
+        PresenceOperation::Store,
+        Some(require_presence_per_use),
+    )
+    .await
+    {
+        eprintln!("Error: {e}");
+        return 1;
+    }
+
     if let Err(e) = backend.store(name, secret).await {
         eprintln!("Error: {e}");
         return 1;
@@ -144,9 +175,21 @@ async fn cmd_store(name: &str) -> i32 {
     0
 }
 
-async fn cmd_delete(name: &str) -> i32 {
+async fn cmd_delete(name: &str, require_presence_per_use: bool) -> i32 {
     let host = make_host();
     let backend = FileBackend::new(host);
+
+    // Non-bypassable presence gate (issue #242): see cmd_store.
+    if let Err(e) = enforce_presence_requirement(
+        &backend,
+        PresenceOperation::Delete,
+        Some(require_presence_per_use),
+    )
+    .await
+    {
+        eprintln!("Error: {e}");
+        return 1;
+    }
 
     match backend.delete(name).await {
         Ok(()) => {}

--- a/crates/vaultkeeper-cli/tests/cli_integration.rs
+++ b/crates/vaultkeeper-cli/tests/cli_integration.rs
@@ -222,6 +222,51 @@ mod store_delete {
             .success()
             .stdout(predicate::str::contains("Secret \"some-key\" deleted"));
     }
+
+    // ─── Presence-per-use enforcement (issue #242) ───────────────
+    //
+    // The `file` backend never implements `PresenceCapableBackend`, so it is
+    // never presence-per-use capable — `--require-presence-per-use` must
+    // refuse with a `NotCapable` error before the backend is touched at all.
+
+    #[test]
+    fn store_with_require_presence_per_use_refuses_before_touching_backend() {
+        let (mut cmd, _dir) = cli_test_env();
+        cmd.args(["store", "--name", "api-key", "--require-presence-per-use"])
+            .write_stdin("sk-live-abc123")
+            .assert()
+            .code(1)
+            .stderr(predicate::str::contains("active backend ('file')"))
+            .stderr(predicate::str::contains("YubiKey"))
+            .stderr(predicate::str::contains("1Password"));
+    }
+
+    #[test]
+    fn store_without_the_flag_is_not_gated() {
+        let (mut cmd, _dir) = cli_test_env();
+        cmd.args(["store", "--name", "api-key"])
+            .write_stdin("sk-live-abc123")
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn delete_with_require_presence_per_use_refuses_before_touching_backend() {
+        // Note: this CLI's `delete` is deliberately idempotent for a missing
+        // secret (see cmd_delete), so a follow-up unflagged `delete` can't be
+        // used as after-the-fact proof the backend was untouched — that
+        // guarantee is structural (the presence check runs before
+        // `backend.delete()` is ever called) and is covered directly by the
+        // `fresh_action_demands` assertions in
+        // `crates/vaultkeeper-core/tests/presence_capability.rs`.
+        let (mut cmd, _dir) = cli_test_env();
+        cmd.args(["delete", "--name", "api-key", "--require-presence-per-use"])
+            .assert()
+            .code(1)
+            .stderr(predicate::str::contains("active backend ('file')"))
+            .stderr(predicate::str::contains("YubiKey"))
+            .stderr(predicate::str::contains("1Password"));
+    }
 }
 
 // ─── Config command ──────────────────────────────────────────────

--- a/crates/vaultkeeper-core/src/backend/mod.rs
+++ b/crates/vaultkeeper-core/src/backend/mod.rs
@@ -11,4 +11,8 @@ mod types;
 pub use file::FileBackend;
 pub use in_memory::InMemoryBackend;
 pub use registry::BackendRegistry;
-pub use types::{ExecOutput, HostPlatform, ListableBackend, Platform, SecretBackend};
+pub use types::{
+    BackendCapabilities, ExecOutput, HostPlatform, ListableBackend, Platform,
+    PresenceCapableBackend, PresenceOperation, SecretBackend, get_backend_capabilities,
+    is_presence_capable_backend,
+};

--- a/crates/vaultkeeper-core/src/backend/types.rs
+++ b/crates/vaultkeeper-core/src/backend/types.rs
@@ -98,6 +98,21 @@ pub trait SecretBackend: Send + Sync {
 
     /// Check whether a secret exists for the given id.
     async fn exists(&self, id: &str) -> Result<bool, VaultError>;
+
+    /// Returns this backend's presence-capability view when it implements
+    /// [`PresenceCapableBackend`], or `None` otherwise.
+    ///
+    /// Mirrors the TypeScript library's `isPresenceCapableBackend` runtime
+    /// duck-type check (`packages/vaultkeeper/src/backend/types.ts`) via a
+    /// static probe, since Rust has no structural interface check on trait
+    /// objects: a backend that implements [`PresenceCapableBackend`] MUST
+    /// override this to return `Some(self)`. The default `None` is what makes
+    /// [`get_backend_capabilities`] safely report `presence_per_use: false`
+    /// for a backend that never opted in — an unknown backend never silently
+    /// claims presence.
+    fn as_presence_capable(&self) -> Option<&dyn PresenceCapableBackend> {
+        None
+    }
 }
 
 /// Backend that can enumerate stored secret IDs.
@@ -106,4 +121,190 @@ pub trait SecretBackend: Send + Sync {
 pub trait ListableBackend: SecretBackend {
     /// List IDs of all secrets managed by this backend.
     async fn list(&self) -> Result<Vec<String>, VaultError>;
+}
+
+/// A keyed backend operation that a presence-per-use requirement can gate.
+///
+/// Mirrors the TypeScript library's `PresenceOperation`
+/// (`packages/vaultkeeper/src/backend/types.ts`). Used by
+/// [`BackendCapabilities::presence_enforced_operations`] to express that an
+/// instance forces a fresh per-use action for only *some* operations. `Read`
+/// covers the secret read behind `setup`/`exec`; `Store`, `Delete`, and `Sign`
+/// are the write, removal, and signing paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PresenceOperation {
+    Read,
+    Store,
+    Delete,
+    Sign,
+}
+
+impl PresenceOperation {
+    /// Stable lowercase name matching the TypeScript `PresenceOperation`
+    /// string-literal union (`'read' | 'store' | 'delete' | 'sign'`), used in
+    /// `NotCapable` error messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PresenceOperation::Read => "read",
+            PresenceOperation::Store => "store",
+            PresenceOperation::Delete => "delete",
+            PresenceOperation::Sign => "sign",
+        }
+    }
+}
+
+impl std::fmt::Display for PresenceOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The set of security capabilities a configured backend instance advertises.
+///
+/// Mirrors the TypeScript library's `BackendCapabilities`
+/// (`packages/vaultkeeper/src/backend/types.ts`).
+///
+/// Capabilities describe what a **specific configured instance** guarantees,
+/// not what its backend *type* is generally able to do. Two instances of the
+/// same backend type can report different capabilities depending on their
+/// configuration (e.g. a YubiKey slot with a touch policy vs. one without, or
+/// 1Password in `per-access` vs. `session` mode). Never derive a capability
+/// from [`SecretBackend::backend_type`] alone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendCapabilities {
+    /// `true` when this configured instance can force a distinct, fresh
+    /// physical human action (e.g. a YubiKey touch, a gpg-smartcard tap, or a
+    /// 1Password per-use biometric approval) — a deliberate action taken *for
+    /// this operation, right now*, not merely "a vault was unlocked at some
+    /// point."
+    ///
+    /// The guarantee is **operation-scoped**, not blanket: see
+    /// [`BackendCapabilities::presence_enforced_operations`] and
+    /// [`BackendCapabilities::enforces`].
+    ///
+    /// Backends that do not implement [`PresenceCapableBackend`] are treated
+    /// as `false` by [`get_backend_capabilities`] — an unknown backend never
+    /// silently claims presence.
+    pub presence_per_use: bool,
+
+    /// The keyed operations for which this instance actually forces a fresh
+    /// per-use human action. When `None`, a `presence_per_use: true` instance
+    /// is taken to force presence for **all** keyed operations — the default
+    /// for a touch device (e.g. a YubiKey whose challenge-response touch fires
+    /// on every `store`/`retrieve`/`delete`).
+    ///
+    /// A backend that can force presence for only *some* operations must list
+    /// exactly those, so a presence-per-use request for an **uncovered**
+    /// operation fails closed with [`VaultError::NotCapable`] rather than
+    /// silently passing without a fresh action. For example, 1Password
+    /// `per-access` forces a fresh biometric on reads (`setup`/`exec`) but
+    /// routes `store`/`delete` through the cached session client, so it
+    /// reports `Some(vec![PresenceOperation::Read])` — a flagged
+    /// `store`/`delete` is then correctly refused.
+    ///
+    /// Ignored when [`BackendCapabilities::presence_per_use`] is `false`.
+    pub presence_enforced_operations: Option<Vec<PresenceOperation>>,
+}
+
+impl BackendCapabilities {
+    /// The safe default reported for a backend that does not implement
+    /// [`PresenceCapableBackend`] — never silently claims presence.
+    pub fn none() -> Self {
+        Self {
+            presence_per_use: false,
+            presence_enforced_operations: None,
+        }
+    }
+
+    /// Whether this capability report forces a fresh per-use human action for
+    /// `operation`.
+    ///
+    /// `false` whenever [`BackendCapabilities::presence_per_use`] is `false`.
+    /// When `presence_per_use` is `true` and
+    /// [`BackendCapabilities::presence_enforced_operations`] is `None`, every
+    /// keyed operation is covered (a touch device). Otherwise only the listed
+    /// operations are covered.
+    pub fn enforces(&self, operation: PresenceOperation) -> bool {
+        if !self.presence_per_use {
+            return false;
+        }
+        match &self.presence_enforced_operations {
+            None => true,
+            Some(ops) => ops.contains(&operation),
+        }
+    }
+}
+
+/// Backend that can report its security [`BackendCapabilities`] for its
+/// configured instance.
+///
+/// Mirrors the TypeScript library's `PresenceCapableBackend`
+/// (`packages/vaultkeeper/src/backend/types.ts`).
+///
+/// This is an optional extension interface, mirroring [`ListableBackend`]: it
+/// is **not** a required member of [`SecretBackend`]. Prefer
+/// [`get_backend_capabilities`] over calling
+/// [`PresenceCapableBackend::get_capabilities`] directly, so a backend that
+/// does not implement the interface safely defaults to no capabilities rather
+/// than being assumed to have them.
+///
+/// [`PresenceCapableBackend::get_capabilities`] must reflect the **current
+/// configured/live state** of the instance (configuration, or a live
+/// device/session probe) rather than a hardcoded per-type answer, and must
+/// not itself trigger a human-presence prompt.
+///
+/// # Capability self-report trust limit (issue #242 AC5)
+///
+/// [`BackendCapabilities`] is **host-attested**: the core trusts the value a
+/// backend implementation chooses to report rather than independently
+/// verifying it. Core-owned backends (e.g. [`super::FileBackend`],
+/// [`super::InMemoryBackend`], and other backends implemented directly in
+/// this crate) are trustworthy self-reporters because their
+/// `get_capabilities` bodies ship as part of this codebase and are reviewed
+/// like any other core logic. A backend bridged from a **dishonest host**
+/// (for example, a JS-callback backend running under a compromised embedder)
+/// that falsely reports `presence_per_use: true` could defeat this guarantee.
+/// Defending against a dishonest host is explicitly out of scope — the trust
+/// boundary is the host itself, which is assumed to be the trusted embedder
+/// (see `docs/specs/005-single-core-consolidation.md`).
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait PresenceCapableBackend: SecretBackend {
+    /// Report the capabilities of this configured instance.
+    async fn get_capabilities(&self) -> Result<BackendCapabilities, VaultError>;
+}
+
+/// Type-level probe for backends that implement the capability-reporting
+/// contract, mirroring the TypeScript library's `isPresenceCapableBackend`.
+///
+/// Prefer [`get_backend_capabilities`] for actually reading capabilities;
+/// this is exposed for parity with the TS API and for callers that only need
+/// the yes/no answer.
+pub fn is_presence_capable_backend(backend: &dyn SecretBackend) -> bool {
+    backend.as_presence_capable().is_some()
+}
+
+/// Resolve a backend's [`BackendCapabilities`], defaulting safely for
+/// backends that do not implement [`PresenceCapableBackend`].
+///
+/// Mirrors the TypeScript library's `getBackendCapabilities`
+/// (`packages/vaultkeeper/src/backend/types.ts`).
+///
+/// A backend without the capability interface reports
+/// [`BackendCapabilities::none`] (`presence_per_use: false`) — an unknown
+/// backend never silently claims a security guarantee it cannot prove. This
+/// is the only supported way to query capabilities; callers must not assume a
+/// capability from [`SecretBackend::backend_type`] alone.
+///
+/// Propagates whatever error a capable backend's own `get_capabilities()`
+/// call returns, so a backend whose capability probe itself fails is refused
+/// by callers (see [`crate::vault::enforce_presence_requirement`]) rather
+/// than silently treated as either capable or non-capable.
+pub async fn get_backend_capabilities(
+    backend: &dyn SecretBackend,
+) -> Result<BackendCapabilities, VaultError> {
+    match backend.as_presence_capable() {
+        Some(capable) => capable.get_capabilities().await,
+        None => Ok(BackendCapabilities::none()),
+    }
 }

--- a/crates/vaultkeeper-core/src/backend/types.rs
+++ b/crates/vaultkeeper-core/src/backend/types.rs
@@ -129,8 +129,18 @@ pub trait ListableBackend: SecretBackend {
 /// (`packages/vaultkeeper/src/backend/types.ts`). Used by
 /// [`BackendCapabilities::presence_enforced_operations`] to express that an
 /// instance forces a fresh per-use action for only *some* operations. `Read`
-/// covers the secret read behind `setup`/`exec`; `Store`, `Delete`, and `Sign`
-/// are the write, removal, and signing paths.
+/// covers a backend retrieve; `Store`, `Delete`, and `Sign` are the write,
+/// removal, and signing paths.
+///
+/// In the TypeScript library, `Read` gates the secret read behind
+/// `setup`/`exec` (`setup` fetches the secret from the backend before minting
+/// the token). `vaultkeeper-core`'s `VaultKeeper::setup()` does not — it mints
+/// a token directly from the caller-supplied secret value with no backend
+/// read, and its CLI `exec` gets the secret from the JWE claims rather than a
+/// live retrieve (see the seam note on
+/// [`crate::vault::enforce_presence_requirement`]). `Read` here names the
+/// backend operation the capability model gates, independent of which
+/// caller-facing operation eventually performs it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PresenceOperation {
     Read,

--- a/crates/vaultkeeper-core/src/lib.rs
+++ b/crates/vaultkeeper-core/src/lib.rs
@@ -16,11 +16,14 @@ pub(crate) mod util;
 pub mod vault;
 
 // Re-export key public types at crate root for convenience.
-pub use backend::InMemoryBackend;
+pub use backend::{
+    BackendCapabilities, InMemoryBackend, PresenceCapableBackend, PresenceOperation,
+    get_backend_capabilities, is_presence_capable_backend,
+};
 pub use errors::{ExecutableTrustRequiredReason, VaultError};
 pub use types::{
     BackendConfig, ExecRequest, ExecResult, FetchRequest, KeyStatus, PreflightCheck,
     PreflightCheckStatus, PreflightResult, ScopedPreflightCheck, SecretAccessor, SignRequest,
     SignResult, TrustTier, VaultClaims, VaultConfig, VaultResponse, VerifyRequest,
 };
-pub use vault::VaultKeeper;
+pub use vault::{VaultKeeper, enforce_presence_requirement};

--- a/crates/vaultkeeper-core/src/vault.rs
+++ b/crates/vaultkeeper-core/src/vault.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use crate::backend::{HostPlatform, SecretBackend};
+use crate::backend::{HostPlatform, PresenceOperation, SecretBackend, get_backend_capabilities};
 use crate::config;
 use crate::errors::{ExecutableTrustRequiredReason, VaultError};
 use crate::jwe::{
@@ -10,6 +10,111 @@ use crate::jwe::{
 };
 use crate::keys::KeyManager;
 use crate::types::{KeyStatus, PreflightResult, VaultClaims, VaultConfig, VaultResponse};
+
+/// A qualifying description of backends that can satisfy a presence-per-use
+/// requirement. Surfaced in [`VaultError::NotCapable`] messages so a caller
+/// whose configured backend cannot provide the guarantee is pointed at ones
+/// that can. Deliberately describes qualifying *configurations* (not a fixed
+/// type list), since the capability is per configured instance — a custom
+/// backend may also qualify. Mirrors the TypeScript library's
+/// `PRESENCE_PER_USE_QUALIFYING_BACKENDS` (`packages/vaultkeeper/src/vault.ts`).
+const PRESENCE_PER_USE_QUALIFYING_BACKENDS: &str = "A qualifying backend forces a distinct, fresh human action per operation — \
+     e.g. a YubiKey slot with a touch-per-operation policy or a gpg smartcard with \
+     touch-to-sign (both cover every operation), or 1Password in per-access mode \
+     (which enforces presence for reads only today, not writes). Switch to (or \
+     reconfigure) such a backend, or drop the presence requirement.";
+
+/// Shared enforcement for a presence-per-use requirement.
+///
+/// Mirrors the TypeScript library's `VaultKeeper.#enforcePresenceRequirement`
+/// (`packages/vaultkeeper/src/vault.ts`) exactly. This is meant to be the
+/// single, non-bypassable point of enforcement for every backend-touching
+/// core operation — not duplicated per caller.
+///
+/// **Seam note (issue #242 AC3):** `vaultkeeper-core`'s [`VaultKeeper`] does
+/// not yet have backend-touching `store`/`retrieve`/`delete`/`sign` methods —
+/// today the native CLI calls a [`SecretBackend`] directly (pre-dating the
+/// single-core consolidation, see issue #234 Phases 2–3), and the signing
+/// path is landing concurrently in issue #237. This function is the ported,
+/// fully-tested enforcement primitive those future call sites must invoke
+/// before touching their backend, exactly as `store`/`delete`/`setup`/`sign`
+/// do in the TS reference; wiring it into new core methods is left to the PRs
+/// that add them so this issue does not block on or duplicate that work.
+///
+/// When `require` is not `Some(true)` this is a no-op. Otherwise it queries
+/// the backend's capabilities **fresh on every call** (never cached across
+/// operations, so a prior satisfied call can never satisfy a later one — see
+/// [`get_backend_capabilities`]) and returns [`VaultError::NotCapable`] —
+/// before the caller performs any credential/session/device operation — when
+/// the configured instance does not advertise
+/// [`crate::backend::BackendCapabilities::presence_per_use`], **or**
+/// advertises it but does not force a fresh action for **this** `operation`
+/// (see [`crate::backend::BackendCapabilities::presence_enforced_operations`]).
+/// This makes enforcement operation-aware and fail-closed: e.g. 1Password
+/// `per-access` forces presence for reads but not `store`/`delete`, so a
+/// flagged write is refused here rather than silently passing through the
+/// cached session client.
+///
+/// A capability report that itself errors (e.g. a live device probe that
+/// fails) also fails closed: the error propagates from here rather than being
+/// treated as either capable or non-capable.
+///
+/// When the backend *is* capable for this operation, this returns `Ok(())`
+/// and the caller proceeds to the backend's ordinary operation, which by the
+/// meaning of the capability forces a distinct fresh human action for this
+/// specific call. The presence action itself (and any
+/// [`VaultError::PresenceDeclined`]/[`VaultError::PresenceTimeout`]) therefore
+/// surfaces from that backend operation, not from here — so two consecutive
+/// required-presence operations each drive their own backend call and each
+/// demand their own fresh action.
+pub async fn enforce_presence_requirement(
+    backend: &dyn SecretBackend,
+    operation: PresenceOperation,
+    require: Option<bool>,
+) -> Result<(), VaultError> {
+    if require != Some(true) {
+        return Ok(());
+    }
+    let capabilities = get_backend_capabilities(backend).await?;
+    if !capabilities.presence_per_use {
+        return Err(VaultError::NotCapable {
+            message: format!(
+                "This operation required presence-per-use, but the active backend \
+                 ('{}') cannot guarantee it. {PRESENCE_PER_USE_QUALIFYING_BACKENDS}",
+                backend.backend_type(),
+            ),
+            backend_type: backend.backend_type().to_string(),
+            capability: "presencePerUse".to_string(),
+        });
+    }
+    // Operation-aware, fail-closed: a capable instance that only forces presence
+    // for some operations (an explicit `presence_enforced_operations` list) must
+    // refuse a flagged operation it does not cover, rather than passing without a
+    // fresh action. A `None` list means "all keyed operations" (a touch device).
+    if !capabilities.enforces(operation) {
+        let enforced_list = capabilities
+            .presence_enforced_operations
+            .as_ref()
+            .map(|ops| {
+                ops.iter()
+                    .map(|op| op.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .unwrap_or_default();
+        return Err(VaultError::NotCapable {
+            message: format!(
+                "This '{operation}' operation required presence-per-use, but the active backend \
+                 ('{}') only enforces a fresh per-use action for [{enforced_list}] — not \
+                 '{operation}'. {PRESENCE_PER_USE_QUALIFYING_BACKENDS}",
+                backend.backend_type(),
+            ),
+            backend_type: backend.backend_type().to_string(),
+            capability: "presencePerUse".to_string(),
+        });
+    }
+    Ok(())
+}
 
 /// Options for initializing VaultKeeper.
 #[derive(Debug, Default)]

--- a/crates/vaultkeeper-core/tests/presence_capability.rs
+++ b/crates/vaultkeeper-core/tests/presence_capability.rs
@@ -1,0 +1,467 @@
+//! Tests for the presence/capability model (issue #242).
+//!
+//! Ports the TypeScript reference test suites for this contract:
+//! `packages/vaultkeeper/test/unit/backend/capabilities.test.ts` (AC1) and
+//! `packages/vaultkeeper/test/integration/presence-enforcement.test.ts`
+//! (AC2/AC4). `vaultkeeper-core`'s `VaultKeeper` does not yet have
+//! backend-touching `store`/`retrieve`/`delete`/`sign` methods (see the seam
+//! note on `enforce_presence_requirement`), so these tests drive
+//! `enforce_presence_requirement` directly against a mock presence backend —
+//! the same shared primitive those future methods must call — rather than
+//! through `VaultKeeper`.
+//!
+//! @see https://github.com/mike-north/vaultkeeper/issues/242
+//! @see https://github.com/mike-north/vaultkeeper/issues/122
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vaultkeeper_core::InMemoryBackend;
+use vaultkeeper_core::backend::{
+    BackendCapabilities, PresenceCapableBackend, PresenceOperation, SecretBackend,
+    get_backend_capabilities, is_presence_capable_backend,
+};
+use vaultkeeper_core::errors::VaultError;
+use vaultkeeper_core::vault::enforce_presence_requirement;
+
+/// A scheduled human response to an upcoming fresh-presence demand.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PresenceResponse {
+    Approve,
+    Decline,
+}
+
+/// A mock presence-per-use backend, mirroring the TypeScript reference's
+/// `MockPresenceBackend` (`packages/vaultkeeper/test/helpers/presence-backend.ts`).
+///
+/// Models a touch/biometric device: every *keyed* operation
+/// (`store`/`retrieve`/`delete`) demands a distinct, fresh human action that
+/// must be primed with [`MockPresenceBackend::arm`] beforehand. An unprimed
+/// demand raises [`VaultError::PresenceTimeout`]; a demand primed to decline
+/// raises [`VaultError::PresenceDeclined`]. `exists` is a probe (no keyed
+/// material) and does not demand presence.
+struct MockPresenceBackend {
+    presence_per_use: bool,
+    enforced_operations: Option<Vec<PresenceOperation>>,
+    /// When `true`, `get_capabilities` itself fails instead of reporting.
+    capabilities_error: bool,
+    get_capabilities_calls: AtomicUsize,
+    fresh_action_demands: AtomicUsize,
+    armed: Mutex<VecDeque<PresenceResponse>>,
+    secrets: Mutex<HashMap<String, String>>,
+}
+
+impl MockPresenceBackend {
+    fn new(presence_per_use: bool) -> Self {
+        Self {
+            presence_per_use,
+            enforced_operations: None,
+            capabilities_error: false,
+            get_capabilities_calls: AtomicUsize::new(0),
+            fresh_action_demands: AtomicUsize::new(0),
+            armed: Mutex::new(VecDeque::new()),
+            secrets: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn with_enforced_operations(mut self, ops: Vec<PresenceOperation>) -> Self {
+        self.enforced_operations = Some(ops);
+        self
+    }
+
+    fn with_capabilities_error(mut self) -> Self {
+        self.capabilities_error = true;
+        self
+    }
+
+    /// Prime `count` upcoming fresh-presence demands with `response`.
+    fn arm(&self, response: PresenceResponse, count: usize) {
+        let mut armed = self.armed.lock().expect("armed lock poisoned");
+        for _ in 0..count {
+            armed.push_back(response);
+        }
+    }
+
+    fn get_capabilities_calls(&self) -> usize {
+        self.get_capabilities_calls.load(Ordering::SeqCst)
+    }
+
+    fn fresh_action_demands(&self) -> usize {
+        self.fresh_action_demands.load(Ordering::SeqCst)
+    }
+
+    /// Demand one distinct fresh human action, consuming a single primed response.
+    fn demand_presence(&self) -> Result<(), VaultError> {
+        self.fresh_action_demands.fetch_add(1, Ordering::SeqCst);
+        let next = self.armed.lock().expect("armed lock poisoned").pop_front();
+        match next {
+            None => Err(VaultError::PresenceTimeout {
+                message: "No fresh presence action within 1000ms".to_string(),
+                backend_type: self.backend_type().to_string(),
+                timeout_ms: 1000,
+            }),
+            Some(PresenceResponse::Decline) => Err(VaultError::PresenceDeclined {
+                message: "Human declined the fresh presence action".to_string(),
+                backend_type: self.backend_type().to_string(),
+            }),
+            Some(PresenceResponse::Approve) => Ok(()),
+        }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl SecretBackend for MockPresenceBackend {
+    fn backend_type(&self) -> &str {
+        "mock-presence"
+    }
+
+    fn display_name(&self) -> &str {
+        "Mock Presence Backend"
+    }
+
+    async fn is_available(&self) -> bool {
+        true
+    }
+
+    async fn store(&self, id: &str, secret: &str) -> Result<(), VaultError> {
+        self.demand_presence()?;
+        self.secrets
+            .lock()
+            .expect("secrets lock poisoned")
+            .insert(id.to_string(), secret.to_string());
+        Ok(())
+    }
+
+    async fn retrieve(&self, id: &str) -> Result<String, VaultError> {
+        self.demand_presence()?;
+        self.secrets
+            .lock()
+            .expect("secrets lock poisoned")
+            .get(id)
+            .cloned()
+            .ok_or_else(|| VaultError::SecretNotFound {
+                message: format!("Secret not found: {id}"),
+            })
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), VaultError> {
+        self.demand_presence()?;
+        self.secrets
+            .lock()
+            .expect("secrets lock poisoned")
+            .remove(id);
+        Ok(())
+    }
+
+    async fn exists(&self, id: &str) -> Result<bool, VaultError> {
+        Ok(self
+            .secrets
+            .lock()
+            .expect("secrets lock poisoned")
+            .contains_key(id))
+    }
+
+    fn as_presence_capable(&self) -> Option<&dyn PresenceCapableBackend> {
+        Some(self)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl PresenceCapableBackend for MockPresenceBackend {
+    async fn get_capabilities(&self) -> Result<BackendCapabilities, VaultError> {
+        self.get_capabilities_calls.fetch_add(1, Ordering::SeqCst);
+        if self.capabilities_error {
+            return Err(VaultError::Other(
+                "capability probe failed: device unreachable".to_string(),
+            ));
+        }
+        Ok(BackendCapabilities {
+            presence_per_use: self.presence_per_use,
+            presence_enforced_operations: self.enforced_operations.clone(),
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AC1: backend capability contract
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn plain_backend_reports_no_capability_via_helper() {
+    // A backend that never implements PresenceCapableBackend never silently
+    // claims presence.
+    let backend = InMemoryBackend::new();
+    let caps = get_backend_capabilities(&backend).await.unwrap();
+    assert_eq!(caps, BackendCapabilities::none());
+}
+
+#[tokio::test]
+async fn is_presence_capable_backend_false_for_plain_backend() {
+    let backend = InMemoryBackend::new();
+    assert!(!is_presence_capable_backend(&backend));
+}
+
+#[tokio::test]
+async fn is_presence_capable_backend_true_for_capable_backend() {
+    let backend = MockPresenceBackend::new(true);
+    assert!(is_presence_capable_backend(&backend));
+}
+
+#[tokio::test]
+async fn helper_delegates_to_get_capabilities_when_present() {
+    let backend = MockPresenceBackend::new(true);
+    let caps = get_backend_capabilities(&backend).await.unwrap();
+    assert_eq!(
+        caps,
+        BackendCapabilities {
+            presence_per_use: true,
+            presence_enforced_operations: None,
+        }
+    );
+}
+
+#[tokio::test]
+async fn helper_propagates_error_from_erroring_capability_report() {
+    let backend = MockPresenceBackend::new(true).with_capabilities_error();
+    let err = get_backend_capabilities(&backend).await.unwrap_err();
+    assert!(matches!(err, VaultError::Other(_)));
+}
+
+// ---------------------------------------------------------------------------
+// AC2/AC4: enforce_presence_requirement — fail-closed refusal
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn no_op_when_require_is_not_true() {
+    let backend = MockPresenceBackend::new(false);
+    enforce_presence_requirement(&backend, PresenceOperation::Store, None)
+        .await
+        .unwrap();
+    enforce_presence_requirement(&backend, PresenceOperation::Store, Some(false))
+        .await
+        .unwrap();
+    // Capabilities were never even queried — a pure no-op.
+    assert_eq!(backend.get_capabilities_calls(), 0);
+}
+
+#[tokio::test]
+async fn refuses_before_any_backend_touch_when_not_capable() {
+    let backend = MockPresenceBackend::new(false);
+    let err = enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, VaultError::NotCapable { .. }));
+    // The backend's keyed path was never reached — refusal happened first.
+    assert_eq!(backend.fresh_action_demands(), 0);
+}
+
+#[tokio::test]
+async fn not_capable_error_carries_machine_readable_fields_and_qualifying_backends() {
+    let backend = MockPresenceBackend::new(false);
+    let err = enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap_err();
+    match err {
+        VaultError::NotCapable {
+            message,
+            backend_type,
+            capability,
+        } => {
+            assert_eq!(backend_type, "mock-presence");
+            assert_eq!(capability, "presencePerUse");
+            assert!(message.contains("YubiKey"));
+            assert!(message.contains("1Password"));
+        }
+        other => panic!("expected NotCapable, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn delete_also_refused_before_touching_backend() {
+    let backend = MockPresenceBackend::new(false);
+    let err = enforce_presence_requirement(&backend, PresenceOperation::Delete, Some(true))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, VaultError::NotCapable { .. }));
+    assert_eq!(backend.fresh_action_demands(), 0);
+}
+
+#[tokio::test]
+async fn erroring_capability_report_fails_closed_without_touching_backend() {
+    // AC2/AC4: an absent-or-erroring capability report must never be silently
+    // treated as capable — the error propagates and the backend is untouched.
+    let backend = MockPresenceBackend::new(true).with_capabilities_error();
+    let err = enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, VaultError::Other(_)));
+    assert_eq!(backend.fresh_action_demands(), 0);
+}
+
+#[tokio::test]
+async fn permits_and_backend_proceeds_when_covered() {
+    let backend = MockPresenceBackend::new(true);
+    backend.arm(PresenceResponse::Approve, 1);
+    enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap();
+    // Enforcement passing doesn't itself demand the action — the caller's
+    // subsequent backend call does.
+    assert_eq!(backend.fresh_action_demands(), 0);
+    backend.store("k", "v").await.unwrap();
+    assert_eq!(backend.fresh_action_demands(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// AC4: capabilities queried fresh per call, non-bypassability
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn two_operations_each_query_capabilities_and_force_a_fresh_action() {
+    let backend = MockPresenceBackend::new(true);
+    backend.arm(PresenceResponse::Approve, 2);
+
+    enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap();
+    backend.store("a", "1").await.unwrap();
+
+    enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap();
+    backend.store("b", "2").await.unwrap();
+
+    // No caching across operations: capabilities re-queried for each call.
+    assert_eq!(backend.get_capabilities_calls(), 2);
+    // Each call forced its own fresh action regardless of the first's state.
+    assert_eq!(backend.fresh_action_demands(), 2);
+}
+
+#[tokio::test]
+async fn declined_presence_action_surfaces_presence_declined() {
+    let backend = MockPresenceBackend::new(true);
+    backend.arm(PresenceResponse::Decline, 1);
+    enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap();
+    let err = backend.store("k", "v").await.unwrap_err();
+    match err {
+        VaultError::PresenceDeclined { backend_type, .. } => {
+            assert_eq!(backend_type, "mock-presence");
+        }
+        other => panic!("expected PresenceDeclined, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn timed_out_presence_action_surfaces_presence_timeout() {
+    let backend = MockPresenceBackend::new(true);
+    // Not armed → the demand times out.
+    enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap();
+    let err = backend.store("k", "v").await.unwrap_err();
+    match err {
+        VaultError::PresenceTimeout {
+            backend_type,
+            timeout_ms,
+            ..
+        } => {
+            assert_eq!(backend_type, "mock-presence");
+            assert_eq!(timeout_ms, 1000);
+        }
+        other => panic!("expected PresenceTimeout, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn two_consecutive_required_presence_operations_each_demand_a_distinct_fresh_action() {
+    // Non-bypassability (mirrors the TS AC6 test): only ONE fresh action is
+    // primed, so the second operation must not be satisfied by the first's
+    // resolution or any cached material.
+    let backend = MockPresenceBackend::new(true);
+    backend.arm(PresenceResponse::Approve, 1);
+
+    enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap();
+    backend.store("a", "1").await.unwrap();
+
+    enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap();
+    let err = backend.store("b", "2").await.unwrap_err();
+    assert!(matches!(err, VaultError::PresenceTimeout { .. }));
+
+    // Both operations reached the fresh-action demand independently.
+    assert_eq!(backend.fresh_action_demands(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Operation-aware, fail-closed enforcement (1Password per-access shape)
+// ---------------------------------------------------------------------------
+
+/// Models 1Password per-access: presence-capable, but only the `Read`
+/// operation forces a fresh action — store/delete route through a cached
+/// session. A flagged store/delete must fail closed (NotCapable), never
+/// silently pass without a fresh action.
+fn read_only_presence_backend() -> MockPresenceBackend {
+    MockPresenceBackend::new(true).with_enforced_operations(vec![PresenceOperation::Read])
+}
+
+#[tokio::test]
+async fn flagged_store_refused_with_not_capable_before_any_fresh_action() {
+    let backend = read_only_presence_backend();
+    let err = enforce_presence_requirement(&backend, PresenceOperation::Store, Some(true))
+        .await
+        .unwrap_err();
+    match err {
+        VaultError::NotCapable {
+            message,
+            backend_type,
+            ..
+        } => {
+            assert_eq!(backend_type, "mock-presence");
+            // The message names the covered operation and the refused one.
+            assert!(message.contains("read"));
+            assert!(message.contains("store"));
+        }
+        other => panic!("expected NotCapable, got {other:?}"),
+    }
+    // Fail closed: no fresh action was demanded.
+    assert_eq!(backend.fresh_action_demands(), 0);
+}
+
+#[tokio::test]
+async fn flagged_delete_refused_with_not_capable() {
+    let backend = read_only_presence_backend();
+    let err = enforce_presence_requirement(&backend, PresenceOperation::Delete, Some(true))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, VaultError::NotCapable { .. }));
+    assert_eq!(backend.fresh_action_demands(), 0);
+}
+
+#[tokio::test]
+async fn flagged_read_is_covered_and_forces_a_fresh_action() {
+    let backend = read_only_presence_backend();
+    // Seed the secret through an unflagged store — still needs a primed
+    // action (the mock is a touch device), but no presence *requirement* is
+    // asserted for it.
+    backend.arm(PresenceResponse::Approve, 1);
+    backend.store("k", "v").await.unwrap();
+
+    // The read IS covered, so enforcement passes and the retrieve forces its
+    // own fresh action.
+    backend.arm(PresenceResponse::Approve, 1);
+    enforce_presence_requirement(&backend, PresenceOperation::Read, Some(true))
+        .await
+        .unwrap();
+    let value = backend.retrieve("k").await.unwrap();
+    assert_eq!(value, "v");
+    // One action for the seed store, one for the presence-gated read.
+    assert_eq!(backend.fresh_action_demands(), 2);
+}

--- a/crates/vaultkeeper-core/tests/presence_capability.rs
+++ b/crates/vaultkeeper-core/tests/presence_capability.rs
@@ -379,9 +379,10 @@ async fn timed_out_presence_action_surfaces_presence_timeout() {
 
 #[tokio::test]
 async fn two_consecutive_required_presence_operations_each_demand_a_distinct_fresh_action() {
-    // Non-bypassability (mirrors the TS AC6 test): only ONE fresh action is
-    // primed, so the second operation must not be satisfied by the first's
-    // resolution or any cached material.
+    // Non-bypassability (mirrors the TS reference's "non-bypassability across
+    // consecutive operations" test in presence-enforcement.test.ts): only ONE
+    // fresh action is primed, so the second operation must not be satisfied
+    // by the first's resolution or any cached material.
     let backend = MockPresenceBackend::new(true);
     backend.arm(PresenceResponse::Approve, 1);
 

--- a/crates/vaultkeeper-core/tests/presence_capability.rs
+++ b/crates/vaultkeeper-core/tests/presence_capability.rs
@@ -3,7 +3,7 @@
 //! Ports the TypeScript reference test suites for this contract:
 //! `packages/vaultkeeper/test/unit/backend/capabilities.test.ts` (AC1) and
 //! `packages/vaultkeeper/test/integration/presence-enforcement.test.ts`
-//! (AC2/AC4). `vaultkeeper-core`'s `VaultKeeper` does not yet have
+//! (AC3/AC4/AC5/AC6). `vaultkeeper-core`'s `VaultKeeper` does not yet have
 //! backend-touching `store`/`retrieve`/`delete`/`sign` methods (see the seam
 //! note on `enforce_presence_requirement`), so these tests drive
 //! `enforce_presence_requirement` directly against a mock presence backend —


### PR DESCRIPTION
Refs #242

## Summary

Ports the presence-per-use capability model from the TypeScript reference (`packages/vaultkeeper/src/backend/types.ts`, `packages/vaultkeeper/src/vault.ts`) to `crates/vaultkeeper-core`:

- `BackendCapabilities` struct and `PresenceOperation` enum (`Read`/`Store`/`Delete`/`Sign`), plus the `PresenceCapableBackend` trait using the existing dual-mode `#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]` pattern (`crates/vaultkeeper-core/src/backend/types.rs`).
- A static-probe capability check (`SecretBackend::as_presence_capable`, defaulting to `None`) standing in for TypeScript's structural `isPresenceCapableBackend` duck-type check, since Rust trait objects have no runtime "has-trait" reflection. `get_backend_capabilities()` and `is_presence_capable_backend()` mirror the TS helpers.
- `enforce_presence_requirement(backend, operation, require)` in `crates/vaultkeeper-core/src/vault.rs`, porting `VaultKeeper.#enforcePresenceRequirement`'s semantics exactly: no-op when `require` isn't `Some(true)`; refuses with `VaultError::NotCapable` when the backend doesn't report `presence_per_use: true`, or reports it but doesn't cover the operation (`presence_enforced_operations`); propagates (fails closed) if the capability report itself errors; queries capabilities fresh on every call (no caching across operations).
- Doc comments on `PresenceCapableBackend` describe the AC5 capability-trust limit: reports are host-attested; core-owned backends are trustworthy self-reporters; a dishonest host is out of scope.
- **Wired into the native CLI's real backend-touching call sites (added in response to review):** `crates/vaultkeeper-cli/src/main.rs`'s `store` and `delete` commands now take `--require-presence-per-use` and call `enforce_presence_requirement` before touching the backend, so the flag genuinely refuses (with `NotCapable`) before any credential/session/device operation, for the two call sites that exist in the Rust CLI today.

## Architectural seam (sign, retrieve, wasm)

`vaultkeeper-core::vault::VaultKeeper` itself still has no backend-touching `store`/`retrieve`/`delete`/`sign` methods — before this PR, the CLI called a `SecretBackend` directly rather than through `VaultKeeper`, pre-dating the single-core consolidation (issue #234, Phases 2–3: backend inversion / engine swap). This PR wires enforcement into the CLI's existing direct backend calls rather than inventing those `VaultKeeper` methods now, since that's a larger architectural undertaking that collides with #237's ownership of the signing stack.

Remaining gaps, left as documented seams (see the doc comment on `enforce_presence_requirement` in `vault.rs`):
- **`sign`**: no signing exists in `vaultkeeper-core`/`vaultkeeper-cli` yet — issue #237 is landing it concurrently and owns that call site.
- **`retrieve`**: the Rust CLI's `exec` command gets the secret directly from the JWE token's claims (minted at `setup` time), not from a live backend read — there is no `retrieve` call site to wire today.
- **wasm**: explicitly out of scope per the issue's own non-goals (`#239`'s `HostSecretBackend` bridge hasn't merged).

## AC mapping

1. `BackendCapabilities` + `PresenceCapableBackend` (dual-mode async_trait), capability-probed via `as_presence_capable`/`get_backend_capabilities` — `backend/types.rs`.
2. `enforce_presence_requirement` ports the TS semantics exactly (fail-closed `NotCapable`, operation-aware, fresh-per-call) — `vault.rs`.
3. Enforcement is wired into every backend-touching path that exists in `vaultkeeper-core`/`vaultkeeper-cli` today (native CLI `store`/`delete`); `sign`/`retrieve`/wasm are documented seams (see above), not silent gaps.
4. Integration tests with a mock backend (`crates/vaultkeeper-core/tests/presence_capability.rs`, 18 tests) covering: refusal on `presence_per_use: false`, refusal on an uncovered operation, refusal (propagation) on an erroring capability report, permission when covered, capabilities queried fresh per call, and two-consecutive-ops non-bypassability. Plus CLI integration tests (`crates/vaultkeeper-cli/tests/cli_integration.rs`) covering the `--require-presence-per-use` refusal and no-op paths end-to-end.
5. Capability self-report trust limit documented in `PresenceCapableBackend`'s doc comment.

## Test plan

- [x] `cargo test --workspace` — all green (includes 18 new core tests + 4 new CLI integration tests)
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `pnpm check` — green
- [x] `pnpm test` — 241 passed / 19 skipped (pre-existing), green, including the JS conformance runner against the compiled Rust binary
- [x] Rebased onto `origin/main` after PR #250 merged (touched the same `cli_integration.rs` file) — no conflicts, full gates re-run green after rebase