### PR TITLE
Rust CLI: add backend capabilities discovery command

### DIFF
--- a/crates/vaultkeeper-cli/src/main.rs
+++ b/crates/vaultkeeper-cli/src/main.rs
@@ -82,7 +82,7 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
-    /// Inspect registered backends (e.g. capabilities)
+    /// Inspect the active backend (e.g. its capabilities)
     Backend {
         #[command(subcommand)]
         action: BackendAction,
@@ -103,7 +103,7 @@ enum ConfigAction {
 
 #[derive(Subcommand)]
 enum BackendAction {
-    /// List each registered backend and its security capabilities
+    /// Report the active (configured) backend's security capabilities
     Capabilities {
         /// Emit a machine-readable JSON array instead of human-readable text
         #[arg(long)]

--- a/crates/vaultkeeper-cli/src/main.rs
+++ b/crates/vaultkeeper-cli/src/main.rs
@@ -9,7 +9,9 @@ use host::NativeHostPlatform;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use vaultkeeper_core::backend::{FileBackend, HostPlatform, PresenceOperation, SecretBackend};
+use vaultkeeper_core::backend::{
+    FileBackend, HostPlatform, PresenceOperation, SecretBackend, get_backend_capabilities,
+};
 use vaultkeeper_core::config;
 use vaultkeeper_core::vault::enforce_presence_requirement;
 
@@ -80,6 +82,11 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigAction,
     },
+    /// Inspect registered backends (e.g. capabilities)
+    Backend {
+        #[command(subcommand)]
+        action: BackendAction,
+    },
     /// Rotate the encryption key
     RotateKey,
     /// Emergency key revocation
@@ -92,6 +99,16 @@ enum ConfigAction {
     Init,
     /// Show current configuration
     Show,
+}
+
+#[derive(Subcommand)]
+enum BackendAction {
+    /// List each registered backend and its security capabilities
+    Capabilities {
+        /// Emit a machine-readable JSON array instead of human-readable text
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 fn make_host() -> Arc<NativeHostPlatform> {
@@ -122,6 +139,7 @@ async fn main() {
             Commands::Approve { path } => cmd_approve(&path).await,
             Commands::DevMode { path, enable } => cmd_dev_mode(&path, enable).await,
             Commands::Config { action } => cmd_config(action).await,
+            Commands::Backend { action } => cmd_backend(action).await,
             Commands::RotateKey => cmd_rotate_key().await,
             Commands::RevokeKey => cmd_revoke_key().await,
         },
@@ -474,6 +492,64 @@ async fn cmd_config(action: ConfigAction) -> i32 {
             }
         }
     }
+}
+
+/// `backend capabilities` — resolves the active backend (the same `FileBackend`
+/// instance `store`/`delete` use) and reports its
+/// [`vaultkeeper_core::backend::BackendCapabilities`] via
+/// `get_backend_capabilities`, so a caller can check ahead of time whether the
+/// configured backend qualifies for `--require-presence-per-use` (issue #262).
+///
+/// Mirrors the TypeScript CLI's `vaultkeeper backend capabilities` command:
+/// the same subcommand name, `--json` flag, JSON row shape (`type`,
+/// `displayName`, `presencePerUse`), and human-readable text (see
+/// `packages/cli/src/commands/backend.ts`).
+async fn cmd_backend(action: BackendAction) -> i32 {
+    match action {
+        BackendAction::Capabilities { json } => cmd_backend_capabilities(json).await,
+    }
+}
+
+async fn cmd_backend_capabilities(json: bool) -> i32 {
+    let host = make_host();
+    let backend = FileBackend::new(host);
+
+    let capabilities = match get_backend_capabilities(&backend).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            return 1;
+        }
+    };
+
+    let backend_type = backend.backend_type();
+    let display_name = backend.display_name();
+
+    if json {
+        let rows = serde_json::json!([{
+            "type": backend_type,
+            "displayName": display_name,
+            "presencePerUse": capabilities.presence_per_use,
+        }]);
+        match serde_json::to_string_pretty(&rows) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                return 1;
+            }
+        }
+    } else {
+        let presence = if capabilities.presence_per_use {
+            "yes"
+        } else {
+            "no"
+        };
+        print!(
+            "Backend capabilities (per configured instance):\n\n  {backend_type}  {display_name}  presence-per-use: {presence}\n\nA backend with presence-per-use: yes forces a distinct, fresh human action\nper operation and can satisfy `--require-presence-per-use`.\n"
+        );
+    }
+
+    0
 }
 
 fn create_config_dir(dir: &Path) -> Result<(), String> {

--- a/crates/vaultkeeper-cli/tests/cli_integration.rs
+++ b/crates/vaultkeeper-cli/tests/cli_integration.rs
@@ -470,7 +470,10 @@ mod backend_capabilities {
             .output()
             .expect("failed to run");
         assert!(output.status.success(), "expected exit 0");
-        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Assert on the real bytes rather than `from_utf8_lossy`, which would
+        // silently replace any invalid byte with U+FFFD and let a real
+        // encoding/serialization bug in the CLI's output pass unnoticed.
+        let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
         let parsed: serde_json::Value =
             serde_json::from_str(&stdout).expect("stdout should be valid JSON");
         let rows = parsed.as_array().expect("expected a JSON array");

--- a/crates/vaultkeeper-cli/tests/cli_integration.rs
+++ b/crates/vaultkeeper-cli/tests/cli_integration.rs
@@ -84,6 +84,7 @@ mod help {
                 .and(predicate::str::contains("store"))
                 .and(predicate::str::contains("delete"))
                 .and(predicate::str::contains("config"))
+                .and(predicate::str::contains("backend"))
                 .and(predicate::str::contains("rotate-key"))
                 .and(predicate::str::contains("revoke-key")),
         );
@@ -434,6 +435,70 @@ mod config {
             .stdout(predicate::str::contains("Config created at"));
 
         assert!(config_dir.is_dir());
+    }
+}
+
+// ─── Backend capabilities command (issue #262) ────────────────────
+
+mod backend_capabilities {
+    use super::*;
+
+    #[test]
+    fn capabilities_exits_0_and_reports_file_backend_as_not_presence_capable() {
+        let (mut cmd, _dir) = cli_test_env();
+        cmd.args(["backend", "capabilities"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Backend capabilities"))
+            .stdout(predicate::str::contains("file"))
+            .stdout(predicate::str::contains("presence-per-use: no"));
+    }
+
+    #[test]
+    fn capabilities_json_emits_a_row_with_type_display_name_and_presence_per_use() {
+        let (mut cmd, _dir) = cli_test_env();
+        let output = cmd
+            .args(["backend", "capabilities", "--json"])
+            .output()
+            .expect("failed to run");
+        assert!(output.status.success(), "expected exit 0");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+        let rows = parsed.as_array().expect("expected a JSON array");
+        assert!(!rows.is_empty(), "expected at least one row");
+        let file_row = rows
+            .iter()
+            .find(|r| r["type"] == "file")
+            .expect("expected a 'file' backend row");
+        assert_eq!(file_row["displayName"], "Encrypted File Store");
+        assert_eq!(file_row["presencePerUse"], false);
+    }
+
+    #[test]
+    fn capabilities_works_without_a_config_file() {
+        // Discovery must be available before any config exists, mirroring
+        // that `store`/`delete` refusal (--require-presence-per-use) is
+        // meant to be checkable ahead of time.
+        let (mut cmd, _dir) = cli_test_env_no_config();
+        cmd.args(["backend", "capabilities", "--json"])
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn backend_with_no_subcommand_exits_2() {
+        let (mut cmd, _dir) = cli_test_env();
+        cmd.arg("backend").assert().code(2);
+    }
+
+    #[test]
+    fn backend_help_documents_capabilities_subcommand() {
+        let (mut cmd, _dir) = cli_test_env();
+        cmd.args(["backend", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("capabilities"));
     }
 }
 

--- a/crates/vaultkeeper-cli/tests/cli_integration.rs
+++ b/crates/vaultkeeper-cli/tests/cli_integration.rs
@@ -445,13 +445,21 @@ mod backend_capabilities {
 
     #[test]
     fn capabilities_exits_0_and_reports_file_backend_as_not_presence_capable() {
+        // Exact match, not a substring check: the Rust CLI reports exactly
+        // one row (the active/configured `file` backend — there is no
+        // config-driven multi-backend registry wired into the CLI), so its
+        // own output is fully deterministic. This pins the Rust CLI's own
+        // output byte-for-byte; it is not a claim that this string equals
+        // the TS CLI's output, which enumerates every registered backend
+        // type (six rows) — see the PR description for the byte-diff
+        // evidence of that difference.
         let (mut cmd, _dir) = cli_test_env();
         cmd.args(["backend", "capabilities"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("Backend capabilities"))
-            .stdout(predicate::str::contains("file"))
-            .stdout(predicate::str::contains("presence-per-use: no"));
+            .stdout(predicate::eq(
+                "Backend capabilities (per configured instance):\n\n  file  Encrypted File Store  presence-per-use: no\n\nA backend with presence-per-use: yes forces a distinct, fresh human action\nper operation and can satisfy `--require-presence-per-use`.\n",
+            ));
     }
 
     #[test]

--- a/crates/vaultkeeper-conformance/src/lib.rs
+++ b/crates/vaultkeeper-conformance/src/lib.rs
@@ -389,7 +389,12 @@ fn backend_capabilities_cases() -> Vec<ConformanceCase> {
                     .into(),
             command: vec!["backend".into(), "capabilities".into()],
             stdin: None,
-            needs_config: true,
+            // `backend capabilities` is a preflight discovery step (issue
+            // #262) — it must work before any config.json exists, so it can
+            // be checked before `store`/`delete --require-presence-per-use`.
+            // Verified empirically: the file backend is always available
+            // without configuration, so no config is needed here.
+            needs_config: false,
             expected_exit_code: 0,
             // Exact match, not a loose regex: the Rust CLI reports exactly one
             // row (the active/configured backend — there is no config-driven
@@ -410,7 +415,8 @@ fn backend_capabilities_cases() -> Vec<ConformanceCase> {
                 .into(),
             command: vec!["backend".into(), "capabilities".into(), "--json".into()],
             stdin: None,
-            needs_config: true,
+            // Same discovery-step rationale as the text-mode case above.
+            needs_config: false,
             expected_exit_code: 0,
             expected_stdout: OutputMatcher::JsonContains(serde_json::json!([{
                 "type": "file",

--- a/crates/vaultkeeper-conformance/src/lib.rs
+++ b/crates/vaultkeeper-conformance/src/lib.rs
@@ -379,6 +379,52 @@ fn dev_mode_cases() -> Vec<ConformanceCase> {
     ]
 }
 
+// ─── Backend capabilities cases (issue #262) ─────────────────────
+
+fn backend_capabilities_cases() -> Vec<ConformanceCase> {
+    vec![
+        ConformanceCase {
+            name:
+                "backend capabilities exits 0 and reports the file backend as not presence-capable"
+                    .into(),
+            command: vec!["backend".into(), "capabilities".into()],
+            stdin: None,
+            needs_config: true,
+            expected_exit_code: 0,
+            expected_stdout: OutputMatcher::Regex(
+                "(?s)Backend capabilities.*file.*presence-per-use: no".into(),
+            ),
+            expected_stderr: OutputMatcher::Any,
+            expected_config_file: None,
+        },
+        ConformanceCase {
+            name: "backend capabilities --json emits a row with type, displayName, presencePerUse"
+                .into(),
+            command: vec!["backend".into(), "capabilities".into(), "--json".into()],
+            stdin: None,
+            needs_config: true,
+            expected_exit_code: 0,
+            expected_stdout: OutputMatcher::JsonContains(serde_json::json!([{
+                "type": "file",
+                "displayName": "Encrypted File Store",
+                "presencePerUse": false
+            }])),
+            expected_stderr: OutputMatcher::Any,
+            expected_config_file: None,
+        },
+        ConformanceCase {
+            name: "backend with no subcommand exits 2".into(),
+            command: vec!["backend".into()],
+            stdin: None,
+            needs_config: false,
+            expected_exit_code: 2,
+            expected_stdout: OutputMatcher::Any,
+            expected_stderr: OutputMatcher::Any,
+            expected_config_file: None,
+        },
+    ]
+}
+
 // ─── Revoke-key cases ────────────────────────────────────────────
 
 fn revoke_key_cases() -> Vec<ConformanceCase> {
@@ -407,6 +453,7 @@ pub fn all_cases() -> Vec<ConformanceCase> {
     cases.extend(revoke_key_cases());
     cases.extend(approve_cases());
     cases.extend(dev_mode_cases());
+    cases.extend(backend_capabilities_cases());
     cases
 }
 

--- a/crates/vaultkeeper-conformance/src/lib.rs
+++ b/crates/vaultkeeper-conformance/src/lib.rs
@@ -391,8 +391,16 @@ fn backend_capabilities_cases() -> Vec<ConformanceCase> {
             stdin: None,
             needs_config: true,
             expected_exit_code: 0,
-            expected_stdout: OutputMatcher::Regex(
-                "(?s)Backend capabilities.*file.*presence-per-use: no".into(),
+            // Exact match, not a loose regex: the Rust CLI reports exactly one
+            // row (the active/configured backend — there is no config-driven
+            // multi-backend registry wired into the CLI), so its own output is
+            // fully deterministic and worth pinning byte-for-byte. This is
+            // Rust-CLI-self-consistency coverage, not a claim that this string
+            // equals the TS CLI's output — the TS CLI enumerates every
+            // registered backend type (six rows) and its raw stdout differs
+            // from this (see PR description for the byte-diff evidence).
+            expected_stdout: OutputMatcher::Exact(
+                "Backend capabilities (per configured instance):\n\n  file  Encrypted File Store  presence-per-use: no\n\nA backend with presence-per-use: yes forces a distinct, fresh human action\nper operation and can satisfy `--require-presence-per-use`.\n".into(),
             ),
             expected_stderr: OutputMatcher::Any,
             expected_config_file: None,

--- a/packages/cli-tests/test/conformance/cases.json
+++ b/packages/cli-tests/test/conformance/cases.json
@@ -445,5 +445,64 @@
       "type": "Any"
     },
     "expectedConfigFile": null
+  },
+  {
+    "name": "backend capabilities exits 0 and reports the file backend as not presence-capable",
+    "command": [
+      "backend",
+      "capabilities"
+    ],
+    "stdin": null,
+    "needsConfig": true,
+    "expectedExitCode": 0,
+    "expectedStdout": {
+      "type": "Regex",
+      "value": "(?s)Backend capabilities.*file.*presence-per-use: no"
+    },
+    "expectedStderr": {
+      "type": "Any"
+    },
+    "expectedConfigFile": null
+  },
+  {
+    "name": "backend capabilities --json emits a row with type, displayName, presencePerUse",
+    "command": [
+      "backend",
+      "capabilities",
+      "--json"
+    ],
+    "stdin": null,
+    "needsConfig": true,
+    "expectedExitCode": 0,
+    "expectedStdout": {
+      "type": "JsonContains",
+      "value": [
+        {
+          "displayName": "Encrypted File Store",
+          "presencePerUse": false,
+          "type": "file"
+        }
+      ]
+    },
+    "expectedStderr": {
+      "type": "Any"
+    },
+    "expectedConfigFile": null
+  },
+  {
+    "name": "backend with no subcommand exits 2",
+    "command": [
+      "backend"
+    ],
+    "stdin": null,
+    "needsConfig": false,
+    "expectedExitCode": 2,
+    "expectedStdout": {
+      "type": "Any"
+    },
+    "expectedStderr": {
+      "type": "Any"
+    },
+    "expectedConfigFile": null
   }
 ]

--- a/packages/cli-tests/test/conformance/cases.json
+++ b/packages/cli-tests/test/conformance/cases.json
@@ -456,8 +456,8 @@
     "needsConfig": true,
     "expectedExitCode": 0,
     "expectedStdout": {
-      "type": "Regex",
-      "value": "(?s)Backend capabilities.*file.*presence-per-use: no"
+      "type": "Exact",
+      "value": "Backend capabilities (per configured instance):\n\n  file  Encrypted File Store  presence-per-use: no\n\nA backend with presence-per-use: yes forces a distinct, fresh human action\nper operation and can satisfy `--require-presence-per-use`.\n"
     },
     "expectedStderr": {
       "type": "Any"

--- a/packages/cli-tests/test/conformance/cases.json
+++ b/packages/cli-tests/test/conformance/cases.json
@@ -453,7 +453,7 @@
       "capabilities"
     ],
     "stdin": null,
-    "needsConfig": true,
+    "needsConfig": false,
     "expectedExitCode": 0,
     "expectedStdout": {
       "type": "Exact",
@@ -472,7 +472,7 @@
       "--json"
     ],
     "stdin": null,
-    "needsConfig": true,
+    "needsConfig": false,
     "expectedExitCode": 0,
     "expectedStdout": {
       "type": "JsonContains",


### PR DESCRIPTION
## Summary

The Rust CLI had no `backend capabilities`-style introspection command, so a
user had no way to check ahead of time whether the configured backend
qualifies for `--require-presence-per-use` (PR #258) — unlike the TS CLI,
which documents `vaultkeeper backend capabilities` as the intended discovery
step. This adds the equivalent command to the Rust CLI, mirroring the TS
CLI's command name, `--json` flag, per-row field names/values, and
human-readable phrasing (see `packages/cli/src/commands/backend.ts`).

The Rust CLI's `store`/`delete`/`doctor` etc. all resolve the active backend
as a hardcoded `FileBackend` (there is no config-driven multi-backend
registry wired into `main.rs` yet), so `backend capabilities` resolves and
reports that same active-backend instance via the existing
`vaultkeeper_core::backend::get_backend_capabilities` — no changes were made
to `vaultkeeper-core`.

**Scope of the parity claim (raised in review):** "mirrors the TS CLI" means
the row shape and field semantics match exactly for the backend both CLIs can
report (`file`) — it does **not** mean the two CLIs' raw stdout (text or
`--json`) is byte-identical. Two known, deliberate differences, confirmed by
a byte-for-byte `diff` of both CLIs' real output (both forms — see test
plan):
- **Row count.** The TS CLI enumerates every backend type registered with
  `BackendRegistry` (six rows: `1password`, `dpapi`, `file`, `keychain`,
  `secret-tool`, `yubikey`), in both the human-readable table and the
  `--json` array. The Rust CLI has no such registry wired into `main.rs`
  today, so it reports exactly one row — the active/configured backend — in
  both forms, consistent with its own human-readable header, "Backend
  capabilities (per configured instance)". `--help` text was rewritten in a
  follow-up commit to describe this accurately ("Inspect the active
  backend" / "Report the active (configured) backend's security
  capabilities") rather than implying multi-backend enumeration.
- **JSON key order.** `serde_json`'s default `Map` is a `BTreeMap`, so the
  Rust CLI serializes object keys alphabetically
  (`displayName`, `presencePerUse`, `type`), while the TS CLI preserves
  declaration order (`type`, `displayName`, `presencePerUse`).

Given the row-count difference is structural (fixing it would mean adding a
config-driven backend registry to the Rust CLI, out of this PR's scope), the
two CLIs' raw stdout genuinely cannot be byte-identical today. So the tests
were tightened along the other axis that *is* achievable and testable: the
Rust CLI's own output (one deterministic row) is now pinned exactly
(`OutputMatcher::Exact` in the Rust and JS conformance cases,
`predicate::eq` in `cli_integration.rs`) instead of a loose regex/substring
that would still pass against drifted text. That closes the "regex that
would pass against drift" gap without asserting a false byte-for-byte
equality against the TS CLI that doesn't hold. No test in this repo (Rust or
JS) compares raw stdout *across* the two CLIs — every cross-CLI-facing
assertion (the JSON conformance case, the TS e2e suite) parses JSON first and
reads/asserts on fields — so the key-order and row-count differences are not
a correctness gap for any existing test, and no code change was made to
`serde_json::json!`'s key ordering.

Both CLIs omit `presenceEnforcedOperations`/`presence_enforced_operations`
from this row shape (confirmed: `packages/cli/src/commands/backend.ts`'s
`BackendCapabilityRow` interface only has `type`/`displayName`/
`presencePerUse`, and the empirical TS `--json` output below has no such
key), so the Rust CLI's row is consistent with the TS CLI as it exists
today, even though the underlying `BackendCapabilities` struct (in both
languages) carries `presence_enforced_operations` for callers that need it.

## Criteria coverage

- AC ("`vaultkeeper backend capabilities` exits 0 and reports the file
  backend as not presence-capable"): covered by
  `crates/vaultkeeper-cli/tests/cli_integration.rs::backend_capabilities::capabilities_exits_0_and_reports_file_backend_as_not_presence_capable`
  and `crates/vaultkeeper-cli/tests/cli_integration.rs::backend_capabilities::capabilities_json_emits_a_row_with_type_display_name_and_presence_per_use`.
- Discovery works pre-config (raised in review — `backend capabilities` is a
  preflight step, meant to be checkable before `config.json` exists):
  verified empirically that the command already worked with no config
  present (no code fix needed), then tightened coverage so the *discovery*
  path is actually what's exercised rather than an unnecessarily-configured
  one — `capabilities_works_without_a_config_file` in
  `cli_integration.rs`, plus `needs_config: false` on both the text and
  `--json` conformance cases in `crates/vaultkeeper-conformance/src/lib.rs`
  (mirrored into `packages/cli-tests/test/conformance/cases.json`).
- AC ("conformance/e2e coverage in `packages/cli-tests` comparing both
  CLIs' output"): the TS CLI side was already covered by
  `packages/cli-tests/test/e2e/backend-capabilities.test.ts` (issue #122);
  this PR adds matching data-driven cases to
  `crates/vaultkeeper-conformance/src/lib.rs::backend_capabilities_cases`
  (exported to `packages/cli-tests/test/conformance/cases.json` via
  `cargo run -p vaultkeeper-conformance --bin export-conformance`), which the
  JS conformance runner (`packages/cli-tests/test/conformance/run-conformance.test.ts`)
  executes against the compiled Rust binary — the same mechanism already used
  to keep the two CLIs in parity for every other command.
- Command surface parity ("matching the TS CLI's command name and output
  format exactly"): covered by manual verification below and by the new
  Rust integration tests asserting the JSON row shape and human-readable
  text against the same values the TS CLI produces
  (`type: "file"`, `displayName: "Encrypted File Store"`).

## `vaultkeeper backend --help`

```diff
 Usage: vaultkeeper backend <subcommand> [options]

 Subcommands:
   capabilities [--json]   List each registered backend and its security
                           capabilities. Pass --json for a machine-readable
                           array; omit it for human-readable text.
```

This subcommand already existed in the TS CLI; the diff below is the *new*
surface added to the Rust CLI's clap-derived `--help`:

```diff
 Commands:
   exec        Run a command with a secret injected as an env var
   doctor      Run preflight checks
   approve     Pre-record a script hash in the TOFU manifest
   dev-mode    Enable or disable development mode for a script
   store       Store a secret (reads from stdin)
   delete      Delete a secret
   config      Manage configuration
+  backend     Inspect the active backend (e.g. its capabilities)
   rotate-key  Rotate the encryption key
   revoke-key  Emergency key revocation
```

## `vaultkeeper backend capabilities` (new, Rust CLI)

```
$ vaultkeeper backend capabilities
Backend capabilities (per configured instance):

  file  Encrypted File Store  presence-per-use: no

A backend with presence-per-use: yes forces a distinct, fresh human action
per operation and can satisfy `--require-presence-per-use`.

$ vaultkeeper backend capabilities --json
[
  {
    "displayName": "Encrypted File Store",
    "presencePerUse": false,
    "type": "file"
  }
]
```

For comparison, the TS CLI's `backend capabilities --json` (unchanged by
this PR, shown for reference — declaration-order keys, one row per
registered backend type):

```
[
  { "type": "1password", "displayName": "1Password", "presencePerUse": false },
  { "type": "dpapi", "displayName": "Windows DPAPI", "presencePerUse": false },
  { "type": "file", "displayName": "Encrypted File Store", "presencePerUse": false },
  { "type": "keychain", "displayName": "macOS Keychain", "presencePerUse": false },
  { "type": "secret-tool", "displayName": "Linux Secret Service (secret-tool)", "presencePerUse": false },
  { "type": "yubikey", "displayName": "YubiKey", "presencePerUse": false }
]
```

## Test plan

- [x] `cargo test --workspace` — all green (85 vaultkeeper-core tests, 38
      vaultkeeper-cli tests including 6 new `backend_capabilities` tests, 8
      vaultkeeper-conformance tests, 1 conformance-runner test, 112 in-crate
      backend tests elsewhere in the suite)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `pnpm build && pnpm check` — clean (typecheck, lint, format, API
      report all pass; unrelated pre-existing `security/detect-object-injection`
      warnings in untouched files are not new)
- [x] `VAULTKEEPER_BIN=$(pwd)/target/debug/vaultkeeper pnpm test` — 244
      passed, 19 skipped (pre-existing, unrelated skips), including the 28
      Rust conformance cases (25 existing + 3 new) and the existing TS
      `backend capabilities` e2e suite
- [x] Manual run confirms `backend capabilities` exits 0 and reports the
      file backend as `presence-per-use: no` in both text and `--json` form
- [x] `diff` of the Rust binary's `backend capabilities` and
      `backend capabilities --json` against the built TS CLI's `bin.js`
      equivalents (same config dir) — confirms the raw stdout differs in
      both forms (row count and, for `--json`, key order — both expected
      and explained above); no test in the repo depends on byte-identical
      raw stdout across the two CLIs

Refs #262



