### PR TITLE
Create native CLI config/key storage directories 0o700

### DIFF
--- a/crates/vaultkeeper-cli/src/host.rs
+++ b/crates/vaultkeeper-cli/src/host.rs
@@ -42,6 +42,36 @@ fn dirs_fallback() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from("/tmp"))
 }
 
+/// Create a directory (and any missing parents) with owner-only (`0o700`)
+/// permissions on Unix, mirroring the TS library's
+/// `fs.mkdir(dir, { recursive: true, mode: 0o700 })` contract (see #255) so
+/// config/key/secret storage directories created by the native CLI are never
+/// left group/world-listable under a permissive umask.
+///
+/// If `path` already exists, it is left completely untouched — including its
+/// permissions — matching the TS side's behavior (`fs.mkdir` with
+/// `recursive: true` is a no-op on an existing path) and avoiding a
+/// chmod-on-startup surprise for a directory an operator deliberately made
+/// more permissive.
+///
+/// On non-Unix platforms (Windows), only directory creation happens; POSIX
+/// mode bits do not apply there.
+pub(crate) fn create_dir_all_secure(path: &Path) -> std::io::Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(path)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+
+    Ok(())
+}
+
 #[async_trait::async_trait]
 impl HostPlatform for NativeHostPlatform {
     async fn exec(
@@ -111,9 +141,11 @@ impl HostPlatform for NativeHostPlatform {
     }
 
     async fn write_file(&self, path: &Path, content: &[u8], mode: u32) -> Result<(), VaultError> {
-        // Ensure parent directory exists
+        // Ensure parent directory exists, created owner-only (0o700) on Unix
+        // per #255 — matches the TS library's `fs.mkdir(dir, { mode: 0o700 })`
+        // contract for config/key/secret storage directories.
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| VaultError::Filesystem {
+            create_dir_all_secure(parent).map_err(|e| VaultError::Filesystem {
                 message: format!("Failed to create directory {}: {e}", parent.display()),
                 path: parent.display().to_string(),
                 permission: "write".to_string(),
@@ -375,5 +407,85 @@ mod tests {
             Err(VaultError::Exec { command, .. }) => assert_eq!(command, "echo"),
             other => panic!("expected VaultError::Exec, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #255: config/key/secret storage directories must be created
+    // 0o700 (owner-only), matching the TS library's
+    // `fs.mkdir(dir, { recursive: true, mode: 0o700 })` contract.
+    // -----------------------------------------------------------------
+
+    /// AC1 + AC3: a directory implicitly created by `write_file` (via its
+    /// parent-directory mkdir step) must end up `0o700` on Unix, not
+    /// whatever the umask would otherwise produce (e.g. `0o755`).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_file_creates_missing_parent_dir_as_0700() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let host = NativeHostPlatform::new(dir.path().to_path_buf());
+        let nested = dir.path().join("fresh-config-dir");
+        let target = nested.join("keys.enc");
+
+        host.write_file(&target, b"secret", 0o600).await.unwrap();
+
+        let mode = fs::metadata(&nested).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o700, "freshly created parent dir must be 0o700");
+    }
+
+    /// AC2: an already-existing directory with broader permissions must be
+    /// left untouched by `write_file` — no chmod-on-startup surprise for a
+    /// directory an operator deliberately made more permissive.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_file_leaves_existing_wider_permission_dir_untouched() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let host = NativeHostPlatform::new(dir.path().to_path_buf());
+        let existing = dir.path().join("already-here");
+        fs::create_dir(&existing).unwrap();
+        fs::set_permissions(&existing, fs::Permissions::from_mode(0o755)).unwrap();
+        let target = existing.join("keys.enc");
+
+        host.write_file(&target, b"secret", 0o600).await.unwrap();
+
+        let mode = fs::metadata(&existing).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o755,
+            "pre-existing directory permissions must be left untouched"
+        );
+    }
+
+    /// Non-Unix (Windows) sanity check: `create_dir_all_secure` still
+    /// creates the directory even though POSIX mode bits don't apply there.
+    #[cfg(not(unix))]
+    #[tokio::test]
+    async fn write_file_creates_missing_parent_dir_on_non_unix() {
+        let dir = tempfile::tempdir().unwrap();
+        let host = NativeHostPlatform::new(dir.path().to_path_buf());
+        let nested = dir.path().join("fresh-config-dir");
+        let target = nested.join("keys.enc");
+
+        host.write_file(&target, b"secret", 0o600).await.unwrap();
+
+        assert!(nested.is_dir());
+    }
+
+    /// AC2 on non-Unix: an already-existing directory is left alone (no
+    /// error, no attempted recreation) by `create_dir_all_secure`.
+    #[cfg(not(unix))]
+    #[tokio::test]
+    async fn write_file_leaves_existing_dir_untouched_on_non_unix() {
+        let dir = tempfile::tempdir().unwrap();
+        let host = NativeHostPlatform::new(dir.path().to_path_buf());
+        let existing = dir.path().join("already-here");
+        fs::create_dir(&existing).unwrap();
+        let target = existing.join("keys.enc");
+
+        host.write_file(&target, b"secret", 0o600).await.unwrap();
+
+        assert!(existing.is_dir());
     }
 }

--- a/crates/vaultkeeper-cli/src/host.rs
+++ b/crates/vaultkeeper-cli/src/host.rs
@@ -42,34 +42,73 @@ fn dirs_fallback() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from("/tmp"))
 }
 
-/// Create a directory (and any missing parents) with owner-only (`0o700`)
-/// permissions on Unix, mirroring the TS library's
+/// Create a directory (and any missing parents), setting owner-only
+/// (`0o700`) permissions atomically at creation time on every directory this
+/// call actually creates — mirroring the TS library's
 /// `fs.mkdir(dir, { recursive: true, mode: 0o700 })` contract (see #255) so
 /// config/key/secret storage directories created by the native CLI are never
 /// left group/world-listable under a permissive umask.
 ///
-/// If `path` already exists, it is left completely untouched — including its
-/// permissions — matching the TS side's behavior (`fs.mkdir` with
-/// `recursive: true` is a no-op on an existing path) and avoiding a
-/// chmod-on-startup surprise for a directory an operator deliberately made
-/// more permissive.
+/// The mode is passed to the `mkdir(2)` syscall itself (via
+/// `DirBuilderExt::mode`), not applied afterward with a separate
+/// `set_permissions` call, so there is no create-then-chmod window: no other
+/// process can observe (or race to widen) the directory between creation and
+/// its final permissions.
+///
+/// Any directory in the path that **already exists** — the target itself or
+/// an intermediate parent — is left completely untouched, including its
+/// permissions. This is deliberately not a preceding `path.exists()` check
+/// (which would itself be a TOCTOU race against a concurrent creator);
+/// instead, each `mkdir` attempt is made directly and an `AlreadyExists`
+/// error is treated as success without ever touching that directory's mode.
+/// This matches the TS side's behavior (`fs.mkdir` with `recursive: true` is
+/// a no-op on an existing path) and avoids a chmod-on-startup surprise for a
+/// directory an operator deliberately made more permissive.
 ///
 /// On non-Unix platforms (Windows), only directory creation happens; POSIX
 /// mode bits do not apply there.
 pub(crate) fn create_dir_all_secure(path: &Path) -> std::io::Result<()> {
-    if path.exists() {
-        return Ok(());
-    }
-
-    std::fs::create_dir_all(path)?;
-
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+        create_dir_all_secure_unix(path)
     }
 
-    Ok(())
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(path)
+    }
+}
+
+/// Unix implementation of [`create_dir_all_secure`]: recursively creates
+/// missing ancestors (also at `0o700`) before retrying the target, and
+/// treats `AlreadyExists` at any level as success without touching that
+/// directory's permissions.
+#[cfg(unix)]
+fn create_dir_all_secure_unix(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    match std::fs::DirBuilder::new().mode(0o700).create(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // A missing parent is the only other reason plain `mkdir` (no
+            // `-p`) fails this way; create it first, then retry — treating a
+            // second `AlreadyExists` (e.g. a concurrent creator winning the
+            // race) as success too.
+            match path.parent() {
+                Some(parent) => {
+                    create_dir_all_secure_unix(parent)?;
+                    match std::fs::DirBuilder::new().mode(0o700).create(path) {
+                        Ok(()) => Ok(()),
+                        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+                        Err(e) => Err(e),
+                    }
+                }
+                None => Err(e),
+            }
+        }
+        Err(e) => Err(e),
+    }
 }
 
 #[async_trait::async_trait]
@@ -437,6 +476,11 @@ mod tests {
     /// AC2: an already-existing directory with broader permissions must be
     /// left untouched by `write_file` — no chmod-on-startup surprise for a
     /// directory an operator deliberately made more permissive.
+    ///
+    /// With the atomic `DirBuilder`-based implementation, this exercises the
+    /// `AlreadyExists` branch of `create_dir_all_secure` directly (there is
+    /// no longer a separate `exists()` pre-check to short-circuit through),
+    /// so it genuinely proves the guard, not just an early return.
     #[cfg(unix)]
     #[tokio::test]
     async fn write_file_leaves_existing_wider_permission_dir_untouched() {
@@ -456,6 +500,131 @@ mod tests {
             mode, 0o755,
             "pre-existing directory permissions must be left untouched"
         );
+    }
+
+    /// AC1 regression for review feedback on #255: when multiple levels are
+    /// missing, *every* directory the call creates must land `0o700`, not
+    /// just the immediate (leaf) parent. The original implementation ran
+    /// plain `create_dir_all` (all missing levels at the umask default) and
+    /// then `set_permissions` on only the final path component, so an
+    /// intermediate directory like `grandparent` here could be left at
+    /// e.g. `0o755` under a permissive umask.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn create_dir_all_secure_tightens_every_newly_created_level() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("grandparent").join("parent").join("leaf");
+
+        super::create_dir_all_secure(&target).unwrap();
+
+        for level in [
+            dir.path().join("grandparent"),
+            dir.path().join("grandparent").join("parent"),
+            target.clone(),
+        ] {
+            let mode = fs::metadata(&level).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode,
+                0o700,
+                "every newly created directory (not just the leaf) must be 0o700: {}",
+                level.display()
+            );
+        }
+    }
+
+    /// AC1 + AC2 regression: when an intermediate ancestor already exists
+    /// with broader permissions, it must be left untouched while the
+    /// directories actually created underneath it are still tightened to
+    /// `0o700`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn create_dir_all_secure_preserves_existing_ancestor_while_tightening_new_ones() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ancestor = dir.path().join("existing-ancestor");
+        fs::create_dir(&ancestor).unwrap();
+        fs::set_permissions(&ancestor, fs::Permissions::from_mode(0o755)).unwrap();
+        let target = ancestor.join("new-parent").join("leaf");
+
+        super::create_dir_all_secure(&target).unwrap();
+
+        let ancestor_mode = fs::metadata(&ancestor).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            ancestor_mode, 0o755,
+            "pre-existing ancestor permissions must be left untouched"
+        );
+        let new_parent_mode = fs::metadata(ancestor.join("new-parent"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            new_parent_mode, 0o700,
+            "newly created directory under an existing ancestor must still be 0o700"
+        );
+    }
+
+    /// Regression test for the TOCTOU race flagged in #255 review: a
+    /// `path.exists()` pre-check followed by an unconditional
+    /// `set_permissions` after `create_dir_all` leaves a window in which a
+    /// concurrent actor can create the target directory (with whatever
+    /// permissions it chooses) between the check and the create/chmod —
+    /// and the old code would then unconditionally chmod that
+    /// concurrently-created directory to `0o700`, silently overriding
+    /// permissions someone else deliberately set (an AC2 violation that
+    /// only manifests under real concurrency, not in a single-threaded
+    /// call). The atomic `DirBuilder::mode` + `AlreadyExists`-as-no-op
+    /// implementation has no such window: mode is set atomically at
+    /// creation, and losing the creation race never triggers a
+    /// `set_permissions` call at all. This test races many iterations of
+    /// "concurrent creator wins" against `create_dir_all_secure` and
+    /// asserts the concurrent creator's permissions always survive.
+    #[cfg(unix)]
+    #[test]
+    fn create_dir_all_secure_never_reclaims_a_concurrently_created_directory() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::Barrier;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        for _ in 0..25 {
+            let dir = tempfile::tempdir().unwrap();
+            let target = dir.path().join("racing-dir");
+            let barrier = Barrier::new(2);
+            let concurrent_actor_won = AtomicBool::new(false);
+
+            std::thread::scope(|scope| {
+                scope.spawn(|| {
+                    barrier.wait();
+                    // Simulate a concurrent actor racing to create the same
+                    // directory with deliberately wider permissions.
+                    if fs::create_dir(&target).is_ok() {
+                        fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).unwrap();
+                        concurrent_actor_won.store(true, Ordering::SeqCst);
+                    }
+                });
+
+                barrier.wait();
+                let _ = super::create_dir_all_secure(&target);
+            });
+
+            let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+            if concurrent_actor_won.load(Ordering::SeqCst) {
+                assert_eq!(
+                    mode, 0o755,
+                    "a directory created concurrently by another actor must never be \
+                     reclaimed/re-chmodded by create_dir_all_secure"
+                );
+            } else {
+                assert_eq!(
+                    mode, 0o700,
+                    "when create_dir_all_secure wins the creation race it must still \
+                     produce 0o700"
+                );
+            }
+        }
     }
 
     /// Non-Unix (Windows) sanity check: `create_dir_all_secure` still

--- a/crates/vaultkeeper-cli/src/main.rs
+++ b/crates/vaultkeeper-cli/src/main.rs
@@ -7,7 +7,7 @@ mod host;
 use clap::{Parser, Subcommand};
 use host::NativeHostPlatform;
 use std::io::{self, Read};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use vaultkeeper_core::backend::{FileBackend, HostPlatform, PresenceOperation, SecretBackend};
 use vaultkeeper_core::config;
@@ -476,18 +476,13 @@ async fn cmd_config(action: ConfigAction) -> i32 {
     }
 }
 
-fn create_config_dir(dir: &PathBuf) -> Result<(), String> {
-    std::fs::create_dir_all(dir).map_err(|e| format!("Failed to create config directory: {e}"))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o700);
-        std::fs::set_permissions(dir, perms)
-            .map_err(|e| format!("Failed to set permissions on config directory: {e}"))?;
-    }
-
-    Ok(())
+fn create_config_dir(dir: &Path) -> Result<(), String> {
+    // Delegates to the same owner-only (0o700) directory creation
+    // `NativeHostPlatform::write_file` uses (see #255), so `config init` and
+    // every other write path agree on the contract: freshly created
+    // directories are 0o700 on Unix, and an already-existing directory
+    // (regardless of its current permissions) is left untouched.
+    host::create_dir_all_secure(dir).map_err(|e| format!("Failed to create config directory: {e}"))
 }
 
 fn write_config_file(path: &PathBuf, json: &str) -> Result<(), String> {

--- a/crates/vaultkeeper-cli/tests/cli_integration.rs
+++ b/crates/vaultkeeper-cli/tests/cli_integration.rs
@@ -360,6 +360,81 @@ mod config {
         // Clap shows usage info and exits 2 for missing required subcommand
         cmd.arg("config").assert().code(2);
     }
+
+    // -----------------------------------------------------------------
+    // Issue #255: `config init` must create the config directory 0o700
+    // (owner-only), matching the TS library's contract.
+    // -----------------------------------------------------------------
+
+    /// AC1 + AC3: `config init` creating the config directory from scratch
+    /// (a `VAULTKEEPER_CONFIG_DIR` that doesn't exist yet) must leave it
+    /// `0o700` on Unix. Skipped on Windows, where POSIX mode bits don't
+    /// apply.
+    #[test]
+    #[cfg(unix)]
+    fn config_init_creates_fresh_config_dir_as_0700() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let parent = TempDir::new().expect("failed to create temp dir");
+        let config_dir = parent.path().join("vk-config");
+        assert!(!config_dir.exists(), "config dir must not pre-exist");
+
+        let mut cmd = Command::cargo_bin("vaultkeeper").expect("binary not found");
+        cmd.env("VAULTKEEPER_CONFIG_DIR", &config_dir);
+        cmd.args(["config", "init"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Config created at"));
+
+        let mode = fs::metadata(&config_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "freshly created config dir must be 0o700, got {mode:o}"
+        );
+    }
+
+    /// AC2: if the config directory already exists with broader
+    /// permissions, `config init` must leave those permissions untouched —
+    /// no chmod-on-startup surprise.
+    #[test]
+    #[cfg(unix)]
+    fn config_init_leaves_existing_wider_permission_dir_untouched() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let parent = TempDir::new().expect("failed to create temp dir");
+        let config_dir = parent.path().join("vk-config");
+        fs::create_dir(&config_dir).unwrap();
+        fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut cmd = Command::cargo_bin("vaultkeeper").expect("binary not found");
+        cmd.env("VAULTKEEPER_CONFIG_DIR", &config_dir);
+        cmd.args(["config", "init"]).assert().success();
+
+        let mode = fs::metadata(&config_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o755,
+            "pre-existing config dir permissions must be left untouched"
+        );
+    }
+
+    /// AC3 on non-Unix: `config init` still creates the directory (mode
+    /// bits are a Unix-only concept, so there's nothing to assert there).
+    #[test]
+    #[cfg(not(unix))]
+    fn config_init_creates_fresh_config_dir_on_non_unix() {
+        let parent = TempDir::new().expect("failed to create temp dir");
+        let config_dir = parent.path().join("vk-config");
+        assert!(!config_dir.exists(), "config dir must not pre-exist");
+
+        let mut cmd = Command::cargo_bin("vaultkeeper").expect("binary not found");
+        cmd.env("VAULTKEEPER_CONFIG_DIR", &config_dir);
+        cmd.args(["config", "init"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Config created at"));
+
+        assert!(config_dir.is_dir());
+    }
 }
 
 // ─── Argument validation ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

`NativeHostPlatform::write_file` and the `config init` CLI command each independently used `std::fs::create_dir_all` to implicitly create missing config/key storage directories, which leaves the newly-created directory with default (umask-derived) permissions rather than the owner-only `0o700` the TS library guarantees via `fs.mkdir(dir, { recursive: true, mode: 0o700 })`. On a from-scratch install under a permissive umask, `~/.config/vaultkeeper` (which now holds real key material after #252) could end up group/world-listable.

Both call sites now go through a single `create_dir_all_secure` helper in `crates/vaultkeeper-cli/src/host.rs`:
- Creates missing directories `0o700` on Unix.
- Leaves an already-existing directory's permissions completely untouched (no chmod-on-startup surprise for a directory an operator deliberately made more permissive).
- On non-Unix (Windows), only performs directory creation — POSIX mode bits don't apply there.

**Scope note:** this PR covers the native Rust CLI (`NativeHostPlatform` + `config init`), which is what was free to work given #259 just merged. The WASM Node bridge (`packages/vaultkeeper-wasm/src/node-host.ts`) mentioned in the issue's AC1 is out of scope here — it currently overlaps with concurrent work on issue #241/#247 in `packages/vaultkeeper-wasm/**`, so fixing it here would risk a collision. Recommend a narrow follow-up issue scoped just to the WASM Node bridge's `mkdir` call.

## Acceptance criteria mapping

1. *Directories created by `NativeHostPlatform` ... are created `0o700`* — covered by `host::tests::write_file_creates_missing_parent_dir_as_0700` and `config::config_init_creates_fresh_config_dir_as_0700` (native Rust CLI side only; see scope note above for the WASM Node bridge half of this criterion).
2. *Existing directories with broader permissions are left untouched* — covered by `host::tests::write_file_leaves_existing_wider_permission_dir_untouched` and `config::config_init_leaves_existing_wider_permission_dir_untouched`.
3. *A regression test per host proves the mode of a freshly created config directory (skipped on Windows)* — the Unix-only tests above are `#[cfg(unix)]`; `host::tests::write_file_creates_missing_parent_dir_on_non_unix` / `write_file_leaves_existing_dir_untouched_on_non_unix` and `config::config_init_creates_fresh_config_dir_on_non_unix` are `#[cfg(not(unix))]` companions that keep the non-Unix path exercised (directory creation still happens; no mode assertion, since POSIX modes don't apply).

## Changes

- `crates/vaultkeeper-cli/src/host.rs`: added `create_dir_all_secure`, used by `write_file`'s parent-directory creation step; added regression tests.
- `crates/vaultkeeper-cli/src/main.rs`: `create_config_dir` now delegates to `host::create_dir_all_secure` instead of its own separate `create_dir_all` + unconditional `set_permissions` (which previously re-chmodded an *existing* config dir to `0o700` on every `config init`, violating AC2). Also narrowed its parameter from `&PathBuf` to `&Path` per `clippy::ptr_arg`.
- `crates/vaultkeeper-cli/tests/cli_integration.rs`: added `config init` regression tests (fresh dir → `0o700`; pre-existing wider-permission dir → untouched; non-Unix directory creation).

Refs #255

## Test plan

- [x] `cargo test --workspace` — all suites green (host.rs unit: 9 passed; cli_integration: 35 passed; core: 85 passed; others: 0/skip as before).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `pnpm check` — exit 0.
- [x] `pnpm test` — 241 passed, 19 skipped (pre-existing Rust-binary-conformance skips), 0 failed.
