### PR TITLE
Send DpapiBackend secrets over stdin, not the PowerShell argv

### DIFF
--- a/packages/vaultkeeper/src/backend/dpapi-backend.ts
+++ b/packages/vaultkeeper/src/backend/dpapi-backend.ts
@@ -96,8 +96,14 @@ export class DpapiBackend implements ListableBackend {
       `[System.IO.File]::WriteAllBytes(${JSON.stringify(entryPath)}, $encrypted)`,
     ].join('; ')
 
+    // Zero the plaintext intermediate once the stdin payload is derived
+    // (security rule: zero Buffer instances containing secrets after use).
+    const secretBuf = Buffer.from(secret, 'utf8')
+    const stdinPayload = secretBuf.toString('base64')
+    secretBuf.fill(0)
+
     await execCommand('powershell', ['-NoProfile', '-Command', script], {
-      stdin: Buffer.from(secret, 'utf8').toString('base64'),
+      stdin: stdinPayload,
     })
   }
 

--- a/packages/vaultkeeper/src/backend/dpapi-backend.ts
+++ b/packages/vaultkeeper/src/backend/dpapi-backend.ts
@@ -80,16 +80,25 @@ export class DpapiBackend implements ListableBackend {
     await fs.mkdir(storageDir, { recursive: true })
     const entryPath = getEntryPath(storageDir, id)
 
+    // The secret is never embedded in the script text (which becomes a
+    // `-Command` argv element, and therefore visible to any other process
+    // that can list this process's command line, e.g. `ps`/Task Manager).
+    // Instead it is piped over stdin, base64-encoded so the transfer is
+    // immune to console/pipe text-encoding and newline-translation
+    // differences between Node and PowerShell (issue #269).
     const script = [
       'Add-Type -AssemblyName System.Security',
-      `$bytes = [System.Text.Encoding]::UTF8.GetBytes(${JSON.stringify(secret)})`,
+      '$b64 = [Console]::In.ReadToEnd()',
+      '$bytes = [System.Convert]::FromBase64String($b64.Trim())',
       '$entropy = $null',
       '$scope = [System.Security.Cryptography.DataProtectionScope]::CurrentUser',
       '$encrypted = [System.Security.Cryptography.ProtectedData]::Protect($bytes, $entropy, $scope)',
       `[System.IO.File]::WriteAllBytes(${JSON.stringify(entryPath)}, $encrypted)`,
     ].join('; ')
 
-    await execCommand('powershell', ['-NoProfile', '-Command', script])
+    await execCommand('powershell', ['-NoProfile', '-Command', script], {
+      stdin: Buffer.from(secret, 'utf8').toString('base64'),
+    })
   }
 
   async retrieve(id: string): Promise<string> {

--- a/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
@@ -99,8 +99,13 @@ describe('DpapiBackend', () => {
       const sentinel = 'sentinel-269-topsecret-value'
       await backend.store('test-id', sentinel)
 
+      // Guard against vacuous passes: if store() ever stopped invoking
+      // execCommand, an empty-argv fallback would let the loop below pass
+      // without asserting anything.
+      expect(mockExecCommand).toHaveBeenCalledTimes(1)
       const callArgs = mockExecCommand.mock.calls[0]
       const argv = callArgs?.[1] ?? []
+      expect(argv.length).toBeGreaterThan(0)
       for (const arg of argv) {
         expect(arg).not.toContain(sentinel)
       }

--- a/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/dpapi-backend.test.ts
@@ -80,23 +80,48 @@ describe('DpapiBackend', () => {
         expect.stringContaining('.vaultkeeper'),
         expect.objectContaining({ recursive: true }),
       )
-      expect(mockExecCommand).toHaveBeenCalledWith(
-        'powershell',
-        expect.arrayContaining(['-NoProfile', '-Command']),
-      )
+      const call = mockExecCommand.mock.calls[0]
+      expect(call?.[0]).toBe('powershell')
+      expect(call?.[1]).toEqual(expect.arrayContaining(['-NoProfile', '-Command']))
+      expect(typeof call?.[2]?.stdin).toBe('string')
     })
 
-    it('should include the secret in the powershell script', async () => {
+    // Regression for issue #269: the plaintext secret must never appear in
+    // argv passed to the child process (visible to `ps`/Task Manager on the
+    // host). It must be delivered over stdin instead. This test fails
+    // against the pre-fix implementation, which embedded
+    // `JSON.stringify(secret)` directly into the `-Command` script string —
+    // see the issue for the captured pre-fix failure output.
+    it('never places the secret value in the powershell argv (issue #269)', async () => {
       mockFs.mkdir.mockResolvedValue(undefined)
       mockExecCommand.mockResolvedValue('')
 
-      await backend.store('test-id', 'my-secret-value')
+      const sentinel = 'sentinel-269-topsecret-value'
+      await backend.store('test-id', sentinel)
 
       const callArgs = mockExecCommand.mock.calls[0]
-      const script = callArgs?.[1]?.find(
-        (arg) => typeof arg === 'string' && arg.includes('my-secret-value'),
-      )
-      expect(script).toBeDefined()
+      const argv = callArgs?.[1] ?? []
+      for (const arg of argv) {
+        expect(arg).not.toContain(sentinel)
+      }
+      // Also assert against the base64 encoding of the sentinel, in case a
+      // future implementation encodes the secret before embedding it in argv
+      // rather than eliminating argv exposure entirely.
+      const encodedSentinel = Buffer.from(sentinel, 'utf8').toString('base64')
+      for (const arg of argv) {
+        expect(arg).not.toContain(encodedSentinel)
+      }
+    })
+
+    it('passes the secret to powershell via stdin, base64-encoded', async () => {
+      mockFs.mkdir.mockResolvedValue(undefined)
+      mockExecCommand.mockResolvedValue('')
+
+      const sentinel = 'sentinel-269-topsecret-value'
+      await backend.store('test-id', sentinel)
+
+      const callOptions = mockExecCommand.mock.calls[0]?.[2]
+      expect(callOptions?.stdin).toBe(Buffer.from(sentinel, 'utf8').toString('base64'))
     })
 
     // Regression: issue #60 — BackendConfig.path was silently ignored.
@@ -116,6 +141,40 @@ describe('DpapiBackend', () => {
         (arg) => typeof arg === 'string' && arg.includes(customDir),
       )
       expect(writePathArg).toBeDefined()
+    })
+  })
+
+  describe('store/retrieve round trip (stdin encoding, issue #269)', () => {
+    // The live DPAPI encrypt/decrypt round trip only runs on Windows (see
+    // the PR description); this unit test instead pins down the JS-side
+    // contract the stdin rewrite must preserve: base64-encoding a secret and
+    // decoding it back must reproduce the exact original bytes for the
+    // characters `JSON.stringify` used to escape directly (quotes, newlines,
+    // backslashes, non-ASCII).
+    it.each([
+      ['plain ascii', 'secret-value'],
+      ['double quotes', 'value with "quotes" inside'],
+      ['single quotes', "value with 'quotes' inside"],
+      ['newlines', 'line one\nline two\r\nline three'],
+      ['backslashes', 'C:\\Users\\me\\secret\\path'],
+      ['non-ascii', 'pässwörd-日本語-emoji-🔒'],
+      ['mixed', "\"quoted \\ backslash\nnewline\r\ncrlf 日本語 🔒 'single'"],
+    ])('round-trips a secret containing %s through the stdin channel', async (_label, secret) => {
+      mockFs.mkdir.mockResolvedValue(undefined)
+      mockExecCommand.mockResolvedValue('')
+
+      await backend.store('test-id', secret)
+
+      const stdinPayload = mockExecCommand.mock.calls[0]?.[2]?.stdin
+      expect(typeof stdinPayload).toBe('string')
+      const decoded = Buffer.from(stdinPayload ?? '', 'base64').toString('utf8')
+      expect(decoded).toBe(secret)
+
+      // The argv must still contain none of the raw secret text.
+      const argv = mockExecCommand.mock.calls[0]?.[1] ?? []
+      for (const arg of argv) {
+        expect(arg).not.toContain(secret)
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

`DpapiBackend.store()` (`packages/vaultkeeper/src/backend/dpapi-backend.ts`) embedded the plaintext
secret via `JSON.stringify(secret)` directly inside the PowerShell `-Command` script string, which
lands in that child process's argv — visible to any other local process that can list this
process's command line (`ps`, Task Manager, `/proc`-equivalents on the host running the DPAPI
backend). This PR removes the secret from argv entirely: `store()` now base64-encodes the secret
and sends it to PowerShell over **stdin**, and the script reads it back with
`[Console]::In.ReadToEnd()` before decoding and DPAPI-encrypting it. No other part of the argv
carries secret material.

## Acceptance criteria mapping

1. **No secret value in any child-process argv from `DpapiBackend`; delivered via stdin instead.**
   Covered by `dpapi-backend.test.ts > store > never places the secret value in the powershell argv (issue #269)`
   and `dpapi-backend.test.ts > store > passes the secret to powershell via stdin, base64-encoded`.
2. **Audit + fix every `execCommand`/`execCommandFull` call site in `dpapi-backend.ts`.** Audited all
   five call sites (`isAvailable`, `store`, `retrieve`, plus the two `execCommandFull` calls that
   only ever pass fixed flags). Only `store()` placed the secret in argv; `retrieve()`'s only argv
   content is the (non-secret) storage-file path, and the decrypted secret comes back over stdout,
   not argv, unchanged by this PR.
3. **Audit `keychain-backend.ts`, `yubikey-backend.ts`, `secret-tool-backend.ts` for the same
   pattern.**
   - `secret-tool-backend.ts`: **clean** — `store()` already passes the secret via
     `execCommand(..., { stdin: secret })`, matching `secret-tool store`'s documented stdin input;
     no other call site touches the secret.
   - `yubikey-backend.ts`: **clean** — the secret is never sent to `ykman`; the `challengeResponse`
     helper's `ykman otp calculate` argv only ever carries a hex encoding of `vaultkeeper:<id>`
     (id-derived, not secret-derived), used to derive a local AES-256-GCM key that encrypts the
     secret entirely within the TS process. No `execCommand*` call ever receives the secret.
   - `keychain-backend.ts`: **NOT clean** — `store()` passes the base64-encoded secret as the `-w`
     argument to `security add-generic-password`, which is the same argv-exposure pattern. This
     was **not** fixed here: live testing confirmed the macOS `security` CLI has no non-interactive
     stdin channel for the password (`-w` with no value falls back to an interactive TTY prompt via
     `getpass()`, which does not consume piped stdin). Fixing it requires a different approach
     (e.g. binding to Keychain Services natively) that's out of scope for this minimal, decoupled
     fix. Filed as a follow-up: mike-north/vaultkeeper#270.
4. **Regression test asserting no secret material in argv, proven to fail pre-fix.** Covered by
   `dpapi-backend.test.ts > store > never places the secret value in the powershell argv (issue #269)`.
   Confirmed failing against the pre-fix implementation (temporarily reverted the source change and
   re-ran):
   ```
   × DpapiBackend > store > never places the secret value in the powershell argv (issue #269) 4ms
     → expected 'Add-Type -AssemblyName System.Securit…' not to contain 'sentinel-269-topsecret-value'
   Received: "Add-Type -AssemblyName System.Security; $bytes = [System.Text.Encoding]::UTF8.GetBytes(\"sentinel-269-topsecret-value\"); ..."
   ```
   Passes with the fix applied (25/25 tests green in the file).
5. **Round-trip behavior unchanged, including quotes/newlines/backslashes/non-ASCII.** The DPAPI
   encrypt/decrypt round trip itself only runs on Windows, so it can't be exercised live in this
   (macOS/Linux) CI — this is a pre-existing constraint of the backend, not something this PR
   changes. Covered cross-platform at the JS/mocked-exec boundary by the parametrized
   `dpapi-backend.test.ts > store/retrieve round trip (stdin encoding, issue #269)` suite, which
   proves the base64 encode step used for the stdin transfer reproduces the exact original secret
   bytes for ASCII, double/single quotes, embedded `\n`/`\r\n`, backslashes, and non-ASCII
   (CJK + emoji) payloads, and that none of that raw secret text ever appears in argv.

## Notes

- Scope is intentionally minimal per the issue: TS-only, no Rust changes, no broader backend
  consolidation (see mike-north/vaultkeeper#245 for that separate effort).
- `packages/vaultkeeper/src/util/exec.ts` already supported an `ExecCommandOptions.stdin` channel
  (used by `secret-tool-backend.ts`); no changes were needed there.
- Follow-up filed for the `keychain-backend.ts` finding: mike-north/vaultkeeper#270.

Refs #269
