### PR TITLE
Emit backend capabilities --json keys in the TS CLI's declaration order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "async-trait",
  "clap",
  "predicates",
+ "serde",
  "serde_json",
  "tempfile",
  "tokio",

--- a/crates/vaultkeeper-cli/Cargo.toml
+++ b/crates/vaultkeeper-cli/Cargo.toml
@@ -15,6 +15,7 @@ vaultkeeper-core = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/vaultkeeper-cli/src/main.rs
+++ b/crates/vaultkeeper-cli/src/main.rs
@@ -513,9 +513,11 @@ async fn cmd_backend(action: BackendAction) -> i32 {
 /// One row of `backend capabilities --json` output. Field declaration order
 /// matches the TypeScript CLI's `BackendCapabilityRow` (`type`,
 /// `displayName`, `presencePerUse` — see
-/// `packages/cli/src/commands/backend.ts`) so both CLIs emit byte-identical
-/// JSON; a `serde_json::Value` object built with `json!` would instead emit
-/// keys in the `BTreeMap`'s alphabetical order.
+/// `packages/cli/src/commands/backend.ts`) so a row shared by both CLIs
+/// serializes byte-identically (the TS CLI still emits more rows — it
+/// enumerates every registered backend type, while this CLI reports only the
+/// active backend); a `serde_json::Value` object built with `json!` would
+/// instead emit keys in the `BTreeMap`'s alphabetical order.
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct BackendCapabilityRow<'a> {

--- a/crates/vaultkeeper-cli/src/main.rs
+++ b/crates/vaultkeeper-cli/src/main.rs
@@ -510,6 +510,21 @@ async fn cmd_backend(action: BackendAction) -> i32 {
     }
 }
 
+/// One row of `backend capabilities --json` output. Field declaration order
+/// matches the TypeScript CLI's `BackendCapabilityRow` (`type`,
+/// `displayName`, `presencePerUse` — see
+/// `packages/cli/src/commands/backend.ts`) so both CLIs emit byte-identical
+/// JSON; a `serde_json::Value` object built with `json!` would instead emit
+/// keys in the `BTreeMap`'s alphabetical order.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BackendCapabilityRow<'a> {
+    #[serde(rename = "type")]
+    backend_type: &'a str,
+    display_name: &'a str,
+    presence_per_use: bool,
+}
+
 async fn cmd_backend_capabilities(json: bool) -> i32 {
     let host = make_host();
     let backend = FileBackend::new(host);
@@ -526,11 +541,11 @@ async fn cmd_backend_capabilities(json: bool) -> i32 {
     let display_name = backend.display_name();
 
     if json {
-        let rows = serde_json::json!([{
-            "type": backend_type,
-            "displayName": display_name,
-            "presencePerUse": capabilities.presence_per_use,
-        }]);
+        let rows = [BackendCapabilityRow {
+            backend_type,
+            display_name,
+            presence_per_use: capabilities.presence_per_use,
+        }];
         match serde_json::to_string_pretty(&rows) {
             Ok(s) => println!("{s}"),
             Err(e) => {

--- a/crates/vaultkeeper-cli/tests/cli_integration.rs
+++ b/crates/vaultkeeper-cli/tests/cli_integration.rs
@@ -474,6 +474,15 @@ mod backend_capabilities {
         // silently replace any invalid byte with U+FFFD and let a real
         // encoding/serialization bug in the CLI's output pass unnoticed.
         let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+        // Byte-exact pin, deliberately order-sensitive: the row struct's
+        // field declaration order must keep matching the TS CLI's
+        // (`type`, `displayName`, `presencePerUse`). A parse-then-compare
+        // assertion alone would keep passing if the serialization ever
+        // regressed to serde_json's alphabetical map order.
+        assert_eq!(
+            stdout,
+            "[\n  {\n    \"type\": \"file\",\n    \"displayName\": \"Encrypted File Store\",\n    \"presencePerUse\": false\n  }\n]\n",
+        );
         let parsed: serde_json::Value =
             serde_json::from_str(&stdout).expect("stdout should be valid JSON");
         let rows = parsed.as_array().expect("expected a JSON array");

--- a/crates/vaultkeeper-cli/tests/cli_integration.rs
+++ b/crates/vaultkeeper-cli/tests/cli_integration.rs
@@ -491,10 +491,29 @@ mod backend_capabilities {
         // Discovery must be available before any config exists, mirroring
         // that `store`/`delete` refusal (--require-presence-per-use) is
         // meant to be checkable ahead of time.
+        //
+        // The command is intentionally config-independent today: it always
+        // reports the hardcoded active `FileBackend`, the same way every
+        // other command does (see PR #266 discussion) — so the row content
+        // here matches `capabilities_json_emits_a_row_with_type_display_name_and_presence_per_use`
+        // exactly, config file or not.
         let (mut cmd, _dir) = cli_test_env_no_config();
-        cmd.args(["backend", "capabilities", "--json"])
-            .assert()
-            .success();
+        let output = cmd
+            .args(["backend", "capabilities", "--json"])
+            .output()
+            .expect("failed to run");
+        assert!(output.status.success(), "expected exit 0");
+        let stdout = String::from_utf8(output.stdout).expect("stdout should be valid UTF-8");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+        let rows = parsed.as_array().expect("expected a JSON array");
+        assert!(!rows.is_empty(), "expected at least one row");
+        let file_row = rows
+            .iter()
+            .find(|r| r["type"] == "file")
+            .expect("expected a 'file' backend row");
+        assert_eq!(file_row["displayName"], "Encrypted File Store");
+        assert_eq!(file_row["presencePerUse"], false);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Review follow-up to #266 (the review's fix batch was in flight when #266 merged). Two changes:

- **JSON key-order parity.** `backend capabilities --json` built its row with `serde_json::json!`, whose `BTreeMap` serializes keys alphabetically (`displayName`, `presencePerUse`, `type`), while the TS CLI emits declaration order (`type`, `displayName`, `presencePerUse` — `packages/cli/src/commands/backend.ts`). The row is now a `#[derive(Serialize)]` `BackendCapabilityRow` struct with fields in the TS order, so both CLIs emit byte-identical JSON for the same row. No conformance pins needed updating: the JSON cases use `JsonContains` (parse-then-compare), which was always order-independent.
- **No-config test content assertion.** `capabilities_works_without_a_config_file` only asserted exit 0 — since the command never reads config, it could not fail meaningfully. It now asserts the actual row content (`type: "file"`, `displayName: "Encrypted File Store"`, `presencePerUse: false`) and carries a comment noting the command is intentionally config-independent today.

### `vaultkeeper backend capabilities --json`

```diff
 [
   {
+    "type": "file",
     "displayName": "Encrypted File Store",
-    "presencePerUse": false,
-    "type": "file"
+    "presencePerUse": false
   }
 ]
```

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p vaultkeeper-cli -p vaultkeeper-conformance --all-targets -- -D warnings`
- [x] `cargo test -p vaultkeeper-cli -p vaultkeeper-conformance` — 61 tests pass
- [x] Committed `cases.json` verified byte-identical to a fresh `export-conformance` run (JsonContains cases are order-independent)
- [x] JS conformance suite 28/28 against a release build (run in the review worktree with the identical diff)