### PR TITLE
Handle-table review follow-ups: wasm changeset, doc precision, coverage

### DIFF
--- a/.changeset/capability-handle-table.md
+++ b/.changeset/capability-handle-table.md
@@ -1,0 +1,9 @@
+---
+'@vaultkeeper/wasm': minor
+---
+
+Additive handle-based capability surface for the `authorize()` result (issue #241): `WasmAuthorization` gains a `handleId` getter exposing the underlying core capability handle id, and `WasmVaultKeeper` gains `resolveSecretClaims(handleId)` and `releaseHandle(handleId)`.
+
+`authorize()`'s existing public shape (`claims`, `response`, `secretAvailable`, `readSecret()`) is unchanged and continues to work exactly as before — internally it now mints a core-side `HandleTable` entry, performs the one-time `read_secret` against it immediately, and caches the result on the returned `WasmAuthorization`, so `claims` no longer carries the raw secret (`val`) across the WASM boundary at all; the secret was already redacted from the observable `claims` shape before this change, and still is.
+
+`resolveSecretClaims(handleId)` lets a caller re-fetch the same non-secret claims later from the retained handle (refusing a signing-key handle with `AuthorizationDenied`), and `releaseHandle(handleId)` lets a caller evict the handle explicitly once done with it rather than waiting on expiry or the table's FIFO size cap. These are the primitives a future handle-based engine swap builds on directly instead of the eager `authorize()` wrapper; no existing caller needs to change.

--- a/crates/vaultkeeper-core/src/identity/handles.rs
+++ b/crates/vaultkeeper-core/src/identity/handles.rs
@@ -53,9 +53,17 @@
 //!
 //! As a defense-in-depth backstop against unbounded growth from callers that
 //! never release and never expire, [`HANDLE_TABLE_MAX_SIZE`] caps the table
-//! at 10,000 live entries with FIFO eviction of the oldest handle — mirroring
-//! the TypeScript `usageCounts` map's `USAGE_MAP_MAX_SIZE` guard
-//! (`packages/vaultkeeper/src/vault.ts`) exactly.
+//! at 10,000 live entries with FIFO eviction of the oldest handle — the same
+//! intent as the TypeScript `usageCounts` map's `USAGE_MAP_MAX_SIZE` guard
+//! (`packages/vaultkeeper/src/vault.ts`), though not byte-for-byte identical:
+//! this table evicts the oldest entry *before* inserting once
+//! `len() >= HANDLE_TABLE_MAX_SIZE`, so it never holds more than 10,000
+//! entries, whereas the TypeScript map inserts first and evicts only once
+//! `size > USAGE_MAP_MAX_SIZE`, so it can momentarily hold 10,001 entries
+//! before trimming back down. The one-entry threshold difference is
+//! immaterial to the guard's purpose (bounding otherwise-unbounded growth);
+//! it is called out here only so a reader diffing the two implementations
+//! line-by-line does not mistake it for a bug.
 //!
 //! ## Why `expires_at` must stay caller-supplied, not hardcoded
 //!
@@ -121,11 +129,12 @@ use crate::util::time::now_secs;
 
 /// Maximum number of live entries [`HandleTable`] (both the handle map and
 /// the JTI usage-count map) will retain. When the cap is reached, the oldest
-/// inserted entry is evicted (FIFO) to make room. Mirrors the TypeScript
-/// `USAGE_MAP_MAX_SIZE` guard (`packages/vaultkeeper/src/vault.ts`) — this is
-/// the defense-in-depth backstop against unbounded growth described in the
-/// module docs, not the primary eviction mechanism (release/expiry/usage-limit
-/// are).
+/// inserted entry is evicted (FIFO) to make room. Same intent as the
+/// TypeScript `USAGE_MAP_MAX_SIZE` guard (`packages/vaultkeeper/src/vault.ts`)
+/// — see the module docs for the one-entry eviction-threshold difference
+/// between the two — this is the defense-in-depth backstop against unbounded
+/// growth described in the module docs, not the primary eviction mechanism
+/// (release/expiry/usage-limit are).
 pub const HANDLE_TABLE_MAX_SIZE: usize = 10_000;
 
 /// Opaque handle identifier returned by [`HandleTable::insert_secret`] /
@@ -329,10 +338,45 @@ impl HandleTable {
     /// `VaultKeeper::usage_counts` field's read-then-increment pattern —
     /// `authorize()` already calls [`HandleTable::current_usage`] before
     /// `validate_claims`, then this, exactly as it did with the bare
-    /// `HashMap` before. Bounded by [`HANDLE_TABLE_MAX_SIZE`] with FIFO
-    /// eviction of the oldest tracked `jti` (see the module doc's
-    /// process-global-vs-per-instance note for why this per-instance map
-    /// still needs its own bound even though it is not shared globally).
+    /// `HashMap` before. **Unlike** the TypeScript reference's `authorize()`
+    /// (`packages/vaultkeeper/src/vault.ts`), which only tracks usage for a
+    /// token whose `use` claim is non-null (an unlimited token is never
+    /// recorded, since it never needs a count check), `VaultKeeper::authorize`
+    /// calls this unconditionally for every token, unlimited or not — see
+    /// the caller in `VaultKeeper::authorize`. That means, unlike the TS
+    /// reference, an unlimited-use token here does occupy a `usage_counts`
+    /// slot for as long as it keeps getting presented. Bounded by
+    /// [`HANDLE_TABLE_MAX_SIZE`] with FIFO eviction of the oldest tracked
+    /// `jti` (see the module doc's process-global-vs-per-instance note for
+    /// why this per-instance map still needs its own bound even though it is
+    /// not shared globally).
+    ///
+    /// **Residual risk: FIFO eviction resets a count, it does not block the
+    /// evicted `jti`.** When `usage_counts` is at its cap and a new `jti`
+    /// arrives, the oldest tracked `jti`'s entry is dropped from the map
+    /// (below) — but that `jti` itself is not blocked here. If it is
+    /// presented to `authorize()` again afterward, [`HandleTable::current_usage`]
+    /// reports `0` for it once more, i.e. its use-limit count has been reset
+    /// rather than durably enforced. In principle, an actor holding 10,000+
+    /// distinct *valid, decryptable* tokens could deliberately cycle through
+    /// them to evict a specific limited token's entry and reset its count.
+    /// This is bounded by requiring possession of that many tokens the
+    /// vault's own key can decrypt (forging or guessing a valid JWE is not
+    /// feasible). Note this is **not** identical to the TypeScript
+    /// reference's `usageCounts` eviction (`packages/vaultkeeper/src/vault.ts`):
+    /// TS additionally calls `blockToken(oldest)` on the evicted `jti` at the
+    /// moment it is dropped, closing this residual gap outright rather than
+    /// merely bounding it. This module has no access to `crate::jwe::block_token`
+    /// (that call lives in `VaultKeeper::authorize`, which owns both this
+    /// table and the blocklist) — porting that same block-on-evict behavior
+    /// here would need a caller-supplied callback or moving the eviction call
+    /// up into `VaultKeeper::authorize`. Until that is done, the real
+    /// revocation mechanism for a token that must never be usable again,
+    /// regardless of count, is still the JWE blocklist
+    /// (`crate::jwe::block_token`) via the *use-limit-exhaustion* path —
+    /// `authorize()` already calls `block_token` once a tracked count reaches
+    /// its `use_limit` (see the caller in `VaultKeeper::authorize`) — but that
+    /// path is distinct from, and does not cover, this FIFO-eviction path.
     pub fn record_usage(&mut self, jti: &str) -> u64 {
         if !self.usage_counts.contains_key(jti) {
             if self.usage_counts.len() >= HANDLE_TABLE_MAX_SIZE
@@ -711,6 +755,25 @@ mod tests {
         assert_eq!(table.len(), 0);
         let err = table.resolve_secret_claims(&id).unwrap_err();
         assert!(matches!(err, VaultError::AuthorizationDenied { .. }));
+    }
+
+    /// AC4: `ensure_live`'s boundary check is `now_secs() >= exp`, i.e.
+    /// inclusive of the exact expiry second — a handle whose `expires_at` is
+    /// exactly the current second must already be treated as expired, not
+    /// live for one more tick. Regression guard against an off-by-one that
+    /// would flip the comparison to strictly-greater-than (`>`), which would
+    /// let a handle remain resolvable during the very second it was
+    /// documented to expire.
+    #[test]
+    fn handle_expiring_at_exactly_now_is_treated_as_expired_inclusive_boundary() {
+        let mut table = HandleTable::new();
+        let now = now_secs();
+        let id = table.insert_secret(secret_claims("jti-1", "s3cret"), Some(now));
+        let err = table.resolve_secret_claims(&id).unwrap_err();
+        assert!(
+            matches!(err, VaultError::TokenExpired { .. }),
+            "a handle expiring at exactly the current second must be treated as expired, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/vaultkeeper-core/tests/unit_tests.rs
+++ b/crates/vaultkeeper-core/tests/unit_tests.rs
@@ -1333,6 +1333,57 @@ mod vault_keeper {
         );
     }
 
+    /// Regression test for the documented invariant that use-limit
+    /// exhaustion governs the *token's* ability to mint new handles, not the
+    /// liveness of handles already minted: a handle returned by an earlier,
+    /// successful `authorize()` call must keep resolving and reading its
+    /// secret even after the token itself has been refused for exceeding its
+    /// `use_limit`. `HandleTable`'s eviction policy (see
+    /// `crates/vaultkeeper-core/src/identity/handles.rs` module docs) lists
+    /// usage-limit exhaustion as a path that evicts handles going forward —
+    /// it must not retroactively evict a handle already handed out.
+    #[tokio::test]
+    async fn handles_already_minted_survive_use_limit_exhaustion_of_their_token() {
+        let host = TestHost::with_config();
+        let mut vault = VaultKeeper::init(
+            &host,
+            Some(VaultKeeperOptions {
+                skip_doctor: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let opts = vaultkeeper_core::vault::SetupOptions {
+            use_limit: Some(1),
+            skip_trust: Some(true),
+            ..Default::default()
+        };
+        let token = vault
+            .setup(&host, "limited-once", "val", Some(&opts))
+            .await
+            .unwrap();
+
+        // The one permitted authorization mints a handle...
+        let (handle, claims, _) = vault.authorize(&token).unwrap();
+        assert_eq!(claims.val, "");
+
+        // ...and further presentations of the same token are refused: the
+        // token's use-budget is exhausted.
+        let err = vault.authorize(&token).unwrap_err();
+        assert!(
+            matches!(err, VaultError::UsageLimitExceeded { .. })
+                || matches!(err, VaultError::TokenRevoked { .. }),
+            "Expected UsageLimitExceeded or TokenRevoked, got: {err}"
+        );
+
+        // The original handle — minted before exhaustion — is untouched by
+        // the token being refused going forward: it still resolves and its
+        // secret is still readable exactly once.
+        assert_eq!(vault.read_secret(&handle).unwrap().as_str(), "val");
+    }
+
     // -----------------------------------------------------------------
     // Issue #238: key-state persistence across process lifetimes.
     //

--- a/crates/vaultkeeper-core/tests/unit_tests.rs
+++ b/crates/vaultkeeper-core/tests/unit_tests.rs
@@ -1338,10 +1338,10 @@ mod vault_keeper {
     /// liveness of handles already minted: a handle returned by an earlier,
     /// successful `authorize()` call must keep resolving and reading its
     /// secret even after the token itself has been refused for exceeding its
-    /// `use_limit`. `HandleTable`'s eviction policy (see
-    /// `crates/vaultkeeper-core/src/identity/handles.rs` module docs) lists
-    /// usage-limit exhaustion as a path that evicts handles going forward —
-    /// it must not retroactively evict a handle already handed out.
+    /// `use_limit`. Exhaustion blocks *future* `authorize()` calls on the
+    /// token (no new handles are minted); it neither evicts nor otherwise
+    /// invalidates a handle already handed out — see the eviction-policy
+    /// section of `crates/vaultkeeper-core/src/identity/handles.rs`.
     #[tokio::test]
     async fn handles_already_minted_survive_use_limit_exhaustion_of_their_token() {
         let host = TestHost::with_config();
@@ -1382,6 +1382,15 @@ mod vault_keeper {
         // the token being refused going forward: it still resolves and its
         // secret is still readable exactly once.
         assert_eq!(vault.read_secret(&handle).unwrap().as_str(), "val");
+
+        // "Exactly once" pinned from both sides: the second read is refused
+        // as consumed, proving exhaustion did not somehow reset the
+        // one-time-read state either.
+        let err = vault.read_secret(&handle).unwrap_err();
+        assert!(
+            matches!(err, VaultError::AccessorConsumed { .. }),
+            "Expected AccessorConsumed on second read, got: {err}"
+        );
     }
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the review items that were still in flight when #268 merged:

- **Missing changeset** for `@vaultkeeper/wasm` (minor): #268 added `WasmAuthorization.handleId`, `WasmVaultKeeper.resolveSecretClaims`, and `WasmVaultKeeper.releaseHandle` to the published wasm surface with no changeset — the next `changeset version` run would have skipped the bump.
- **Doc precision, FIFO cap**: the module docs claimed the 10,000-entry cap mirrors the TS reference "exactly"; Rust evicts at `len() >= cap` while TS trims only above it (momentary 10,001). Intent matches; the one-entry threshold difference is now stated rather than papered over.
- **Doc correction, count-eviction semantics**: the docs now state accurately that Rust's `record_usage` FIFO eviction only drops the oldest JTI's count, whereas the TS reference's `usageCounts` eviction calls `blockToken` on the evicted JTI. That's a real residual divergence (see the follow-up issue), not parity — the previous wording implied parity.
- **Coverage**: `handle_expiring_at_exactly_now_is_treated_as_expired_inclusive_boundary` (pins the inclusive `>=` boundary) and `handles_already_minted_survive_use_limit_exhaustion_of_their_token` (pins the documented invariant that use-limit exhaustion blocks new `authorize()` calls without invalidating existing handles).

Two review items originally slated for porting were dropped as already covered on `main` under different names (`expired_handle_is_rejected_and_evicted`, `handle_related_errors_never_leak_the_full_bearer_id`).

Doc comments, tests, and a changeset only — no behavioral code changes, no wasm rebuild needed.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p vaultkeeper-core` — 87 passed incl. both new tests
- [x] `pnpm check`
- [x] `pnpm exec changeset status` — `@vaultkeeper/wasm` minor confirmed