### PR TITLE
Port SecretToolBackend to vaultkeeper-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,6 +1309,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "uuid",
+ "vaultkeeper-conformance",
  "zeroize",
 ]
 

--- a/crates/vaultkeeper-core/Cargo.toml
+++ b/crates/vaultkeeper-core/Cargo.toml
@@ -27,3 +27,8 @@ js-sys = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 assert_matches = { workspace = true }
 serial_test = { workspace = true }
+# Reuses the shared `store`/`delete` case data (issue #291 AC5) so the
+# real-`secret-tool` conformance test asserts against the exact same
+# name/secret fixture the CLI-level conformance suite already checks,
+# instead of a hand-duplicated approximation.
+vaultkeeper-conformance = { path = "../vaultkeeper-conformance" }

--- a/crates/vaultkeeper-core/src/backend/mod.rs
+++ b/crates/vaultkeeper-core/src/backend/mod.rs
@@ -6,11 +6,13 @@
 pub mod file;
 pub mod in_memory;
 mod registry;
+pub mod secret_tool;
 mod types;
 
 pub use file::FileBackend;
 pub use in_memory::InMemoryBackend;
 pub use registry::BackendRegistry;
+pub use secret_tool::SecretToolBackend;
 pub use types::{
     ApprovalContext, BackendCapabilities, ExecOptions, ExecOutput, HostPlatform, HttpRequest,
     HttpResponse, ListableBackend, Platform, PresenceCapableBackend, PresenceOperation,

--- a/crates/vaultkeeper-core/src/backend/secret_tool.rs
+++ b/crates/vaultkeeper-core/src/backend/secret_tool.rs
@@ -93,11 +93,14 @@ impl SecretBackend for SecretToolBackend {
             )
             .await?;
         if output.exit_code != 0 {
-            return Err(VaultError::Other(format!(
-                "secret-tool store failed with exit code {}: {}",
-                output.exit_code,
-                String::from_utf8_lossy(&output.stderr)
-            )));
+            return Err(VaultError::Exec {
+                message: format!(
+                    "secret-tool store failed with exit code {}: {}",
+                    output.exit_code,
+                    String::from_utf8_lossy(&output.stderr)
+                ),
+                command: "secret-tool".to_string(),
+            });
         }
         Ok(())
     }
@@ -541,8 +544,8 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            matches!(err, VaultError::Other(_)),
-            "expected a typed VaultError, got {err:?}"
+            matches!(err, VaultError::Exec { ref command, .. } if command == "secret-tool"),
+            "expected VaultError::Exec carrying the failing command, got {err:?}"
         );
     }
 

--- a/crates/vaultkeeper-core/src/backend/secret_tool.rs
+++ b/crates/vaultkeeper-core/src/backend/secret_tool.rs
@@ -1,0 +1,677 @@
+//! Linux Secret Service backend, driven via the `secret-tool(1)` CLI.
+//!
+//! Ports the TypeScript `SecretToolBackend`
+//! (`packages/vaultkeeper/src/backend/secret-tool-backend.ts`) into
+//! `vaultkeeper-core`, unchanged in wire behavior: same attribute/collection
+//! schema, same four `secret-tool` verbs (`store`, `lookup`, `clear`,
+//! `search`), same argv-safe stdin handoff for the secret value. Entries
+//! written by either implementation are mutually readable because the
+//! attribute schema below is byte-for-byte identical to the TS backend's.
+//!
+//! No filesystem persistence and no crypto in this backend — the Secret
+//! Service daemon (GNOME Keyring, KWallet's Secret Service plugin, etc.) owns
+//! storage; this is purely a [`HostPlatform::exec`] orchestration layer.
+
+use crate::backend::types::{ExecOptions, HostPlatform, ListableBackend, Platform, SecretBackend};
+use crate::errors::VaultError;
+use std::sync::Arc;
+
+/// Attribute key used to tag every vaultkeeper-managed Secret Service entry.
+/// Must match the TS backend's `ATTRIBUTE_KEY` exactly.
+const ATTRIBUTE_KEY: &str = "vaultkeeper-id";
+
+/// Label prefix applied to entries created via `store`. Must match the TS
+/// backend's `LABEL_PREFIX` exactly.
+const LABEL_PREFIX: &str = "vaultkeeper: ";
+
+/// Linux Secret Service (`secret-tool`) backend.
+///
+/// Only meaningfully available on Linux with `secret-tool` installed and a
+/// running Secret Service (e.g. GNOME Keyring or KWallet with the Secret
+/// Service plugin) reachable over D-Bus.
+pub struct SecretToolBackend {
+    host: Arc<dyn HostPlatform>,
+}
+
+impl SecretToolBackend {
+    /// Create a new `SecretToolBackend` using the given host for subprocess
+    /// orchestration.
+    pub fn new(host: Arc<dyn HostPlatform>) -> Self {
+        Self { host }
+    }
+
+    /// Parse `attribute.vaultkeeper-id = <id>` lines out of `secret-tool
+    /// search` output — the same line-oriented parse the TS backend performs
+    /// via its `attribute\.vaultkeeper-id = (.+)` regex.
+    fn parse_search_ids(stdout: &str) -> Vec<String> {
+        let prefix = format!("attribute.{ATTRIBUTE_KEY} = ");
+        stdout
+            .lines()
+            .filter_map(|line| line.strip_prefix(prefix.as_str()))
+            .map(|id| id.to_string())
+            .collect()
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl SecretBackend for SecretToolBackend {
+    fn backend_type(&self) -> &str {
+        "secret-tool"
+    }
+
+    fn display_name(&self) -> &str {
+        "Linux Secret Service (secret-tool)"
+    }
+
+    async fn is_available(&self) -> bool {
+        if self.host.platform() != Platform::Linux {
+            return false;
+        }
+        match self
+            .host
+            .exec("secret-tool", &["--version"], ExecOptions::default())
+            .await
+        {
+            Ok(output) => output.exit_code == 0,
+            Err(_) => false,
+        }
+    }
+
+    async fn store(&self, id: &str, secret: &str) -> Result<(), VaultError> {
+        let label = format!("{LABEL_PREFIX}{id}");
+        let args = ["store", "--label", label.as_str(), ATTRIBUTE_KEY, id];
+        let output = self
+            .host
+            .exec(
+                "secret-tool",
+                &args,
+                ExecOptions {
+                    stdin: Some(secret.as_bytes()),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        if output.exit_code != 0 {
+            return Err(VaultError::Other(format!(
+                "secret-tool store failed with exit code {}: {}",
+                output.exit_code,
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+        Ok(())
+    }
+
+    async fn retrieve(&self, id: &str) -> Result<String, VaultError> {
+        let output = self
+            .host
+            .exec(
+                "secret-tool",
+                &["lookup", ATTRIBUTE_KEY, id],
+                ExecOptions::default(),
+            )
+            .await?;
+        let stdout = String::from_utf8(output.stdout).map_err(|e| {
+            VaultError::Other(format!("secret-tool lookup returned non-UTF-8 output: {e}"))
+        })?;
+        if output.exit_code != 0 || stdout.trim().is_empty() {
+            return Err(VaultError::SecretNotFound {
+                message: format!("Secret not found in Secret Service: {id}"),
+            });
+        }
+        Ok(stdout.trim().to_string())
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), VaultError> {
+        let output = self
+            .host
+            .exec(
+                "secret-tool",
+                &["clear", ATTRIBUTE_KEY, id],
+                ExecOptions::default(),
+            )
+            .await?;
+        if output.exit_code != 0 {
+            return Err(VaultError::SecretNotFound {
+                message: format!("Secret not found in Secret Service: {id}"),
+            });
+        }
+        Ok(())
+    }
+
+    async fn exists(&self, id: &str) -> Result<bool, VaultError> {
+        let output = self
+            .host
+            .exec(
+                "secret-tool",
+                &["lookup", ATTRIBUTE_KEY, id],
+                ExecOptions::default(),
+            )
+            .await?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(output.exit_code == 0 && !stdout.trim().is_empty())
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ListableBackend for SecretToolBackend {
+    async fn list(&self) -> Result<Vec<String>, VaultError> {
+        let output = self
+            .host
+            .exec(
+                "secret-tool",
+                &["search", ATTRIBUTE_KEY, ""],
+                ExecOptions::default(),
+            )
+            .await?;
+        if output.exit_code != 0 {
+            return Ok(Vec::new());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(Self::parse_search_ids(&stdout))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::ExecOutput;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    /// Records every `exec` invocation (command, args, stdin) so tests can
+    /// assert on exactly what was shelled out — in particular, the
+    /// argv-sentinel assertion for AC1.
+    #[derive(Debug, Clone)]
+    struct RecordedExec {
+        cmd: String,
+        args: Vec<String>,
+        stdin: Option<Vec<u8>>,
+    }
+
+    /// Test double for `HostPlatform` that fakes a Secret Service store in
+    /// memory, keyed by the `vaultkeeper-id` attribute value, and records
+    /// every subprocess invocation for argv inspection.
+    struct TestHost {
+        config_dir: PathBuf,
+        /// id -> (label, secret)
+        entries: Mutex<std::collections::HashMap<String, (String, String)>>,
+        calls: Mutex<Vec<RecordedExec>>,
+        /// When true, `--version` reports secret-tool as unavailable.
+        version_unavailable: bool,
+        platform: Platform,
+    }
+
+    impl TestHost {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                config_dir: PathBuf::from("/test/config"),
+                entries: Mutex::new(std::collections::HashMap::new()),
+                calls: Mutex::new(Vec::new()),
+                version_unavailable: false,
+                platform: Platform::Linux,
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HostPlatform for TestHost {
+        async fn exec(
+            &self,
+            cmd: &str,
+            args: &[&str],
+            options: ExecOptions<'_>,
+        ) -> Result<ExecOutput, VaultError> {
+            self.calls.lock().unwrap().push(RecordedExec {
+                cmd: cmd.to_string(),
+                args: args.iter().map(|s| s.to_string()).collect(),
+                stdin: options.stdin.map(|s| s.to_vec()),
+            });
+
+            match args.first().copied() {
+                Some("--version") => {
+                    if self.version_unavailable {
+                        return Ok(ExecOutput {
+                            stdout: Vec::new(),
+                            stderr: b"command not found".to_vec(),
+                            exit_code: 127,
+                        });
+                    }
+                    Ok(ExecOutput {
+                        stdout: b"secret-tool 0.21".to_vec(),
+                        stderr: Vec::new(),
+                        exit_code: 0,
+                    })
+                }
+                Some("store") => {
+                    // ["store", "--label", label, ATTRIBUTE_KEY, id]
+                    let label = args.get(2).expect("label arg").to_string();
+                    let id = args.get(4).expect("id arg").to_string();
+                    let secret = options
+                        .stdin
+                        .map(|b| String::from_utf8_lossy(b).to_string())
+                        .unwrap_or_default();
+                    self.entries.lock().unwrap().insert(id, (label, secret));
+                    Ok(ExecOutput {
+                        stdout: Vec::new(),
+                        stderr: Vec::new(),
+                        exit_code: 0,
+                    })
+                }
+                Some("lookup") => {
+                    // ["lookup", ATTRIBUTE_KEY, id]
+                    let id = args.get(2).expect("id arg").to_string();
+                    match self.entries.lock().unwrap().get(&id) {
+                        Some((_, secret)) => Ok(ExecOutput {
+                            stdout: format!("{secret}\n").into_bytes(),
+                            stderr: Vec::new(),
+                            exit_code: 0,
+                        }),
+                        None => Ok(ExecOutput {
+                            stdout: Vec::new(),
+                            stderr: b"No matching items found".to_vec(),
+                            exit_code: 1,
+                        }),
+                    }
+                }
+                Some("clear") => {
+                    // ["clear", ATTRIBUTE_KEY, id]
+                    let id = args.get(2).expect("id arg").to_string();
+                    let removed = self.entries.lock().unwrap().remove(&id).is_some();
+                    Ok(ExecOutput {
+                        stdout: Vec::new(),
+                        stderr: if removed {
+                            Vec::new()
+                        } else {
+                            b"No matching items found".to_vec()
+                        },
+                        exit_code: if removed { 0 } else { 1 },
+                    })
+                }
+                Some("search") => {
+                    let entries = self.entries.lock().unwrap();
+                    let mut stdout = String::new();
+                    for (id, (label, _)) in entries.iter() {
+                        stdout.push_str(&format!(
+                            "[/org/freedesktop/secrets/collection/login/{id}]\n"
+                        ));
+                        stdout.push_str(&format!("label = {label}\n"));
+                        stdout.push_str("secret = \n");
+                        stdout.push_str("schema: org.freedesktop.Secret.Generic\n");
+                        stdout.push_str(&format!("attribute.{ATTRIBUTE_KEY} = {id}\n"));
+                        stdout.push('\n');
+                    }
+                    Ok(ExecOutput {
+                        stdout: stdout.into_bytes(),
+                        stderr: Vec::new(),
+                        exit_code: 0,
+                    })
+                }
+                other => panic!("unexpected secret-tool invocation: {other:?}"),
+            }
+        }
+        async fn read_file(&self, _path: &Path) -> Result<Vec<u8>, VaultError> {
+            panic!("SecretToolBackend must not touch the filesystem")
+        }
+        async fn write_file(
+            &self,
+            _path: &Path,
+            _content: &[u8],
+            _mode: u32,
+        ) -> Result<(), VaultError> {
+            panic!("SecretToolBackend must not touch the filesystem")
+        }
+        async fn file_exists(&self, _path: &Path) -> Result<bool, VaultError> {
+            panic!("SecretToolBackend must not touch the filesystem")
+        }
+        async fn delete_file(&self, _path: &Path) -> Result<(), VaultError> {
+            panic!("SecretToolBackend must not touch the filesystem")
+        }
+        async fn list_dir(&self, _path: &Path) -> Result<Vec<String>, VaultError> {
+            panic!("SecretToolBackend must not touch the filesystem")
+        }
+        fn platform(&self) -> Platform {
+            self.platform
+        }
+        fn config_dir(&self) -> &Path {
+            &self.config_dir
+        }
+    }
+
+    // ── AC4: attribute schema parity with the TS backend ──────────────────
+
+    #[test]
+    fn attribute_key_matches_ts_backend() {
+        // packages/vaultkeeper/src/backend/secret-tool-backend.ts: ATTRIBUTE_KEY
+        assert_eq!(ATTRIBUTE_KEY, "vaultkeeper-id");
+    }
+
+    #[test]
+    fn label_prefix_matches_ts_backend() {
+        // packages/vaultkeeper/src/backend/secret-tool-backend.ts: LABEL_PREFIX
+        assert_eq!(LABEL_PREFIX, "vaultkeeper: ");
+    }
+
+    #[tokio::test]
+    async fn store_uses_attribute_key_and_label_prefix_in_argv() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        backend.store("my-secret", "secret-value").await.unwrap();
+
+        let calls = host.calls.lock().unwrap();
+        let store_call = calls.iter().find(|c| c.cmd == "secret-tool").unwrap();
+        assert_eq!(
+            store_call.args,
+            vec![
+                "store",
+                "--label",
+                "vaultkeeper: my-secret",
+                "vaultkeeper-id",
+                "my-secret",
+            ]
+        );
+    }
+
+    // ── AC1: store is argv-safe — the secret only ever travels on stdin ───
+
+    #[tokio::test]
+    async fn store_passes_secret_on_stdin_not_argv() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        const SENTINEL: &str = "argv-sentinel-should-never-appear-in-args";
+        backend.store("sentinel-id", SENTINEL).await.unwrap();
+
+        let calls = host.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "store should issue exactly one exec call");
+        let call = &calls[0];
+        assert!(
+            call.args.iter().all(|a| !a.contains(SENTINEL)),
+            "the secret must never appear in child process argv: {:?}",
+            call.args
+        );
+        assert_eq!(
+            call.stdin.as_deref(),
+            Some(SENTINEL.as_bytes()),
+            "the secret must be delivered on stdin"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_argv_sentinel_survives_full_round_trip() {
+        // Broader regression: run store -> retrieve -> delete and assert the
+        // sentinel never leaked into argv at any step, not just store.
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        const SENTINEL: &str = "super-secret-value-42";
+
+        backend.store("rt-id", SENTINEL).await.unwrap();
+        let retrieved = backend.retrieve("rt-id").await.unwrap();
+        assert_eq!(retrieved, SENTINEL);
+        backend.delete("rt-id").await.unwrap();
+
+        let calls = host.calls.lock().unwrap();
+        for call in calls.iter() {
+            assert!(
+                call.args.iter().all(|a| !a.contains(SENTINEL)),
+                "the secret must never appear in child process argv at any step: {:?}",
+                call.args
+            );
+        }
+    }
+
+    // ── AC2: byte-for-byte round trip of spaces/quotes/newlines/non-ASCII ──
+
+    #[tokio::test]
+    async fn round_trips_secret_with_spaces_quotes_and_embedded_newlines() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        // Newline is embedded (not leading/trailing) since `secret-tool
+        // lookup` output is trimmed on both ends, matching the TS backend's
+        // `.trim()` — a leading/trailing newline is not preserved by design,
+        // matching the TS semantics this port must replicate faithfully.
+        let secret = "hello \"world\" 'quoted'\nmiddle line\nend";
+        backend.store("spaces-quotes-id", secret).await.unwrap();
+        let retrieved = backend.retrieve("spaces-quotes-id").await.unwrap();
+        assert_eq!(retrieved, secret);
+    }
+
+    #[tokio::test]
+    async fn round_trips_non_ascii_secret_byte_for_byte() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        let secret = "pässwörd-日本語-emoji-🔐-Ñoño";
+        backend.store("non-ascii-id", secret).await.unwrap();
+        let retrieved = backend.retrieve("non-ascii-id").await.unwrap();
+        assert_eq!(retrieved, secret);
+    }
+
+    // ── AC3: not-found semantics for retrieve/delete never panic ──────────
+
+    #[tokio::test]
+    async fn retrieve_missing_returns_secret_not_found() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host);
+        let err = backend.retrieve("nonexistent").await.unwrap_err();
+        assert!(
+            matches!(err, VaultError::SecretNotFound { .. }),
+            "expected SecretNotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_missing_returns_secret_not_found() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host);
+        let err = backend.delete("nonexistent").await.unwrap_err();
+        assert!(
+            matches!(err, VaultError::SecretNotFound { .. }),
+            "expected SecretNotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exists_returns_false_for_missing_and_true_for_present() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host);
+        assert!(!backend.exists("nonexistent").await.unwrap());
+        backend.store("present-id", "value").await.unwrap();
+        assert!(backend.exists("present-id").await.unwrap());
+    }
+
+    // ── Additional coverage: store/list/is_available/display ──────────────
+
+    #[tokio::test]
+    async fn store_and_retrieve_round_trip() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host);
+        backend.store("my-key", "my-secret").await.unwrap();
+        let retrieved = backend.retrieve("my-key").await.unwrap();
+        assert_eq!(retrieved, "my-secret");
+    }
+
+    #[tokio::test]
+    async fn store_failure_surfaces_typed_error_not_panic() {
+        struct FailingHost {
+            inner: Arc<TestHost>,
+        }
+
+        #[async_trait::async_trait]
+        impl HostPlatform for FailingHost {
+            async fn exec(
+                &self,
+                _cmd: &str,
+                _args: &[&str],
+                _options: ExecOptions<'_>,
+            ) -> Result<ExecOutput, VaultError> {
+                Ok(ExecOutput {
+                    stdout: Vec::new(),
+                    stderr: b"secret-tool: dbus connection failed".to_vec(),
+                    exit_code: 1,
+                })
+            }
+            async fn read_file(&self, p: &Path) -> Result<Vec<u8>, VaultError> {
+                self.inner.read_file(p).await
+            }
+            async fn write_file(&self, p: &Path, c: &[u8], m: u32) -> Result<(), VaultError> {
+                self.inner.write_file(p, c, m).await
+            }
+            async fn file_exists(&self, p: &Path) -> Result<bool, VaultError> {
+                self.inner.file_exists(p).await
+            }
+            async fn delete_file(&self, p: &Path) -> Result<(), VaultError> {
+                self.inner.delete_file(p).await
+            }
+            async fn list_dir(&self, p: &Path) -> Result<Vec<String>, VaultError> {
+                self.inner.list_dir(p).await
+            }
+            fn platform(&self) -> Platform {
+                self.inner.platform()
+            }
+            fn config_dir(&self) -> &Path {
+                self.inner.config_dir()
+            }
+        }
+
+        let host = Arc::new(FailingHost {
+            inner: TestHost::new(),
+        });
+        let err = SecretToolBackend::new(host)
+            .store("id", "secret")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, VaultError::Other(_)),
+            "expected a typed VaultError, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_parses_attribute_lines_from_search_output() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host);
+        backend.store("alpha", "val-a").await.unwrap();
+        backend.store("beta", "val-b").await.unwrap();
+        let mut ids = backend.list().await.unwrap();
+        ids.sort();
+        assert_eq!(ids, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn parse_search_ids_matches_ts_backend_output_shape() {
+        // Mirrors the fixture in
+        // packages/vaultkeeper/test/unit/backend/secret-tool-backend.test.ts
+        let stdout = [
+            "[/org/freedesktop/secrets/collection/login/1]",
+            "label = vaultkeeper: my-secret",
+            "secret = ",
+            "created = 2024-01-01 00:00:00",
+            "modified = 2024-01-01 00:00:00",
+            "schema: org.freedesktop.Secret.Generic",
+            "attribute.vaultkeeper-id = my-secret",
+            "",
+            "[/org/freedesktop/secrets/collection/login/2]",
+            "label = vaultkeeper: another-secret",
+            "secret = ",
+            "attribute.vaultkeeper-id = another-secret",
+        ]
+        .join("\n");
+
+        let ids = SecretToolBackend::parse_search_ids(&stdout);
+        assert_eq!(ids, vec!["my-secret", "another-secret"]);
+    }
+
+    #[tokio::test]
+    async fn list_returns_empty_when_search_fails() {
+        struct FailingSearchHost {
+            inner: Arc<TestHost>,
+        }
+
+        #[async_trait::async_trait]
+        impl HostPlatform for FailingSearchHost {
+            async fn exec(
+                &self,
+                cmd: &str,
+                args: &[&str],
+                options: ExecOptions<'_>,
+            ) -> Result<ExecOutput, VaultError> {
+                if args.first().copied() == Some("search") {
+                    return Ok(ExecOutput {
+                        stdout: Vec::new(),
+                        stderr: b"No matching items found".to_vec(),
+                        exit_code: 1,
+                    });
+                }
+                self.inner.exec(cmd, args, options).await
+            }
+            async fn read_file(&self, p: &Path) -> Result<Vec<u8>, VaultError> {
+                self.inner.read_file(p).await
+            }
+            async fn write_file(&self, p: &Path, c: &[u8], m: u32) -> Result<(), VaultError> {
+                self.inner.write_file(p, c, m).await
+            }
+            async fn file_exists(&self, p: &Path) -> Result<bool, VaultError> {
+                self.inner.file_exists(p).await
+            }
+            async fn delete_file(&self, p: &Path) -> Result<(), VaultError> {
+                self.inner.delete_file(p).await
+            }
+            async fn list_dir(&self, p: &Path) -> Result<Vec<String>, VaultError> {
+                self.inner.list_dir(p).await
+            }
+            fn platform(&self) -> Platform {
+                self.inner.platform()
+            }
+            fn config_dir(&self) -> &Path {
+                self.inner.config_dir()
+            }
+        }
+
+        let host = Arc::new(FailingSearchHost {
+            inner: TestHost::new(),
+        });
+        let backend = SecretToolBackend::new(host);
+        assert_eq!(backend.list().await.unwrap(), Vec::<String>::new());
+    }
+
+    #[tokio::test]
+    async fn is_available_false_on_non_linux_platform() {
+        let host = Arc::new(TestHost {
+            config_dir: PathBuf::from("/test/config"),
+            entries: Mutex::new(std::collections::HashMap::new()),
+            calls: Mutex::new(Vec::new()),
+            version_unavailable: false,
+            platform: Platform::Darwin,
+        });
+        let backend = SecretToolBackend::new(host);
+        assert!(!backend.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn is_available_true_on_linux_when_secret_tool_responds() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host);
+        assert!(backend.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn is_available_false_when_secret_tool_not_installed() {
+        let host = Arc::new(TestHost {
+            config_dir: PathBuf::from("/test/config"),
+            entries: Mutex::new(std::collections::HashMap::new()),
+            calls: Mutex::new(Vec::new()),
+            version_unavailable: true,
+            platform: Platform::Linux,
+        });
+        let backend = SecretToolBackend::new(host);
+        assert!(!backend.is_available().await);
+    }
+
+    #[test]
+    fn backend_type_and_display_name() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host);
+        assert_eq!(backend.backend_type(), "secret-tool");
+        assert_eq!(backend.display_name(), "Linux Secret Service (secret-tool)");
+    }
+}

--- a/crates/vaultkeeper-core/tests/secret_tool_conformance.rs
+++ b/crates/vaultkeeper-core/tests/secret_tool_conformance.rs
@@ -1,0 +1,246 @@
+//! Linux conformance test for [`vaultkeeper_core::backend::SecretToolBackend`]
+//! against the *real* `secret-tool(1)` binary and a live D-Bus Secret Service
+//! session (issue #291, AC5).
+//!
+//! # Why this lives here, not in `vaultkeeper-conformance`
+//!
+//! The `vaultkeeper-conformance` crate's cases are CLI-level: each case
+//! spawns the `vaultkeeper` binary with a fixed argv and asserts on its
+//! stdout/stderr/exit code. The native CLI does not yet support selecting a
+//! backend at the command line (`--backend secret-tool`) — that wiring is a
+//! separate, not-yet-landed epic item (`vaultkeeper-core` issue #273,
+//! "fail-closed config-driven backend registry"). Until that lands there is
+//! no CLI invocation this test could shell out to that would exercise
+//! `SecretToolBackend` specifically, so this test instead drives the backend
+//! directly (the same shape the doctor and unit-test suites already use for
+//! host-platform-dependent checks) while still sharing assertion *data* with
+//! the CLI-level conformance suite: the id/secret pair below is read
+//! straight out of `vaultkeeper_conformance::all_cases()`'s
+//! `"store succeeds with valid secret"` case rather than being duplicated by
+//! hand, so a change to that shared fixture updates both suites together.
+//!
+//! # Gating
+//!
+//! This test talks to a *real* Secret Service daemon over D-Bus and is only
+//! meaningful on Linux with `secret-tool` installed and a session bus
+//! reachable (in CI: `dbus-run-session -- cargo test -p vaultkeeper-core
+//! --test secret_tool_conformance`, which exports `DBUS_SESSION_BUS_ADDRESS`
+//! for the duration of the session). Everywhere else — this sandboxed
+//! development environment included, which is macOS — the test detects the
+//! missing prerequisite and skips itself with a clear message rather than
+//! failing or silently vanishing, mirroring the existing
+//! `describe.skipIf(RUST_BIN === null)` pattern the JS conformance runner
+//! uses when the Rust binary isn't available
+//! (`packages/cli-tests/test/conformance/run-conformance.test.ts`).
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use vaultkeeper_core::backend::{
+    ExecOptions, ExecOutput, HostPlatform, ListableBackend, Platform, SecretBackend,
+    SecretToolBackend,
+};
+use vaultkeeper_core::errors::VaultError;
+
+/// Minimal real `HostPlatform` sufficient for `SecretToolBackend`, which
+/// never touches the filesystem. File methods are unreachable in practice —
+/// they panic instead of silently doing the wrong thing if that assumption
+/// ever changes.
+struct RealLinuxHost {
+    config_dir: PathBuf,
+}
+
+#[async_trait::async_trait]
+impl HostPlatform for RealLinuxHost {
+    async fn exec(
+        &self,
+        cmd: &str,
+        args: &[&str],
+        options: ExecOptions<'_>,
+    ) -> Result<ExecOutput, VaultError> {
+        let mut command = Command::new(cmd);
+        command.args(args);
+        command.stdin(if options.stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        });
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        let mut child = command
+            .spawn()
+            .map_err(|e| VaultError::Other(format!("Failed to spawn {cmd}: {e}")))?;
+
+        if let Some(data) = options.stdin {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin
+                    .write_all(data)
+                    .map_err(|e| VaultError::Other(format!("Failed to write stdin: {e}")))?;
+            }
+        }
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| VaultError::Other(format!("Failed to wait for {cmd}: {e}")))?;
+
+        Ok(ExecOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            exit_code: output.status.code().unwrap_or(-1),
+        })
+    }
+
+    async fn read_file(&self, _path: &Path) -> Result<Vec<u8>, VaultError> {
+        unreachable!("SecretToolBackend never touches the filesystem")
+    }
+
+    async fn write_file(
+        &self,
+        _path: &Path,
+        _content: &[u8],
+        _mode: u32,
+    ) -> Result<(), VaultError> {
+        unreachable!("SecretToolBackend never touches the filesystem")
+    }
+
+    async fn file_exists(&self, _path: &Path) -> Result<bool, VaultError> {
+        unreachable!("SecretToolBackend never touches the filesystem")
+    }
+
+    async fn delete_file(&self, _path: &Path) -> Result<(), VaultError> {
+        unreachable!("SecretToolBackend never touches the filesystem")
+    }
+
+    async fn list_dir(&self, _path: &Path) -> Result<Vec<String>, VaultError> {
+        unreachable!("SecretToolBackend never touches the filesystem")
+    }
+
+    fn platform(&self) -> Platform {
+        Platform::Linux
+    }
+
+    fn config_dir(&self) -> &Path {
+        &self.config_dir
+    }
+}
+
+/// Extract the `--name`/stdin fixture the CLI-level conformance suite
+/// already asserts on, so this test's id/secret aren't a second,
+/// hand-duplicated copy of that data.
+fn shared_store_fixture() -> (String, String) {
+    let case = vaultkeeper_conformance::all_cases()
+        .into_iter()
+        .find(|c| c.name == "store succeeds with valid secret")
+        .expect("vaultkeeper-conformance must define 'store succeeds with valid secret'");
+
+    let name_flag_pos = case
+        .command
+        .iter()
+        .position(|arg| arg == "--name")
+        .expect("case must pass --name");
+    let name = case.command[name_flag_pos + 1].clone();
+    let secret = case.stdin.expect("case must supply stdin secret");
+    (name, secret)
+}
+
+/// True only when this test can plausibly reach a real Secret Service:
+/// Linux, `secret-tool` on PATH, and a session bus address exported (as
+/// `dbus-run-session` does for the whole invocation).
+fn secret_tool_environment_available() -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
+    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_err() {
+        return false;
+    }
+    Command::new("secret-tool")
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[tokio::test]
+async fn secret_tool_backend_conformance_against_real_secret_tool() {
+    if !secret_tool_environment_available() {
+        eprintln!(
+            "skipping secret_tool_backend_conformance_against_real_secret_tool: \
+             requires target_os=linux, `secret-tool` on PATH, and \
+             DBUS_SESSION_BUS_ADDRESS set (run under `dbus-run-session`). \
+             This is expected on non-Linux development machines and CI \
+             runners without a session bus (issue #291 AC5)."
+        );
+        return;
+    }
+
+    let host = std::sync::Arc::new(RealLinuxHost {
+        config_dir: std::env::temp_dir(),
+    });
+    let backend = SecretToolBackend::new(host);
+    let (name, secret) = shared_store_fixture();
+    // Namespace the id so repeated CI runs against a shared session bus
+    // don't collide with a leftover entry from a previous run.
+    let name = format!("{name}-{}", std::process::id());
+
+    assert!(
+        backend.is_available().await,
+        "secret-tool must be available"
+    );
+
+    backend
+        .store(&name, &secret)
+        .await
+        .expect("store must succeed against a real Secret Service");
+
+    assert!(
+        backend.exists(&name).await.unwrap(),
+        "exists must be true immediately after store"
+    );
+
+    let retrieved = backend
+        .retrieve(&name)
+        .await
+        .expect("retrieve must succeed for a just-stored entry");
+    assert_eq!(
+        retrieved, secret,
+        "retrieved secret must match the stored value byte-for-byte"
+    );
+
+    let listed = backend.list().await.expect("list must succeed");
+    assert!(
+        listed.contains(&name),
+        "list must include the just-stored id: {listed:?}"
+    );
+
+    backend
+        .delete(&name)
+        .await
+        .expect("delete must succeed for an existing entry");
+
+    assert!(
+        !backend.exists(&name).await.unwrap(),
+        "exists must be false immediately after delete"
+    );
+
+    let err = backend
+        .retrieve(&name)
+        .await
+        .expect_err("retrieve of a deleted entry must fail");
+    assert!(
+        matches!(err, VaultError::SecretNotFound { .. }),
+        "expected SecretNotFound after delete, got {err:?}"
+    );
+
+    let delete_err = backend
+        .delete(&name)
+        .await
+        .expect_err("deleting an already-deleted entry must fail");
+    assert!(
+        matches!(delete_err, VaultError::SecretNotFound { .. }),
+        "expected SecretNotFound deleting a missing entry, got {delete_err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Ports the Linux Secret Service backend (`SecretToolBackend`) from the TypeScript
`vaultkeeper` package into `vaultkeeper-core`, driving `secret-tool(1)` over
`HostPlatform::exec`. This is the first backend port in the epic (#288) and
establishes the shared subprocess-port pattern: four verbs (`store`, `lookup`,
`clear`, `search`), no filesystem state, no crypto, secret handed to `store`
only on stdin (never argv).

The attribute schema (`vaultkeeper-id` attribute key, `vaultkeeper: ` label
prefix) is byte-for-byte identical to the TS backend, so entries written by
either implementation are mutually readable.

## Acceptance criteria coverage

1. **`store` is argv-safe (unit).** `store_passes_secret_on_stdin_not_argv` and
   `store_argv_sentinel_survives_full_round_trip`
   (`crates/vaultkeeper-core/src/backend/secret_tool.rs`) assert the secret
   never appears in any recorded child-process argv across `store` →
   `retrieve` → `delete`, and that it's delivered via `ExecOptions::stdin`.
2. **Byte-for-byte round trip (unit).**
   `round_trips_secret_with_spaces_quotes_and_embedded_newlines` and
   `round_trips_non_ascii_secret_byte_for_byte` cover spaces, single/double
   quotes, embedded newlines, and non-ASCII (accents, CJK, emoji).
3. **Not-found semantics never panic (unit).**
   `retrieve_missing_returns_secret_not_found`,
   `delete_missing_returns_secret_not_found`, and
   `store_failure_surfaces_typed_error_not_panic` assert typed
   `VaultError::SecretNotFound` / `VaultError::Other` — matching the TS
   backend's `SecretNotFoundError` semantics — never an unwrap/panic.
4. **Attribute schema parity with the TS backend (unit).**
   `attribute_key_matches_ts_backend`, `label_prefix_matches_ts_backend`, and
   `parse_search_ids_matches_ts_backend_output_shape` (the last replays the
   exact `secret-tool search` output fixture from
   `packages/vaultkeeper/test/unit/backend/secret-tool-backend.test.ts`)
   pin the wire schema to the TS implementation's `ATTRIBUTE_KEY`/`LABEL_PREFIX`
   constants.
5. **Conformance on a Linux runner under `dbus-run-session`.** The native CLI
   has no per-backend selection yet (blocked on the registry item, #273), so
   there is no CLI invocation the existing `vaultkeeper-conformance`
   CLI-level suite could shell out to that would exercise this backend
   specifically. Per the issue's fallback guidance, I added
   `crates/vaultkeeper-core/tests/secret_tool_conformance.rs`: a real
   `secret-tool` + real (non-mocked) `HostPlatform` integration test that
   drives `store`/`retrieve`/`exists`/`list`/`delete` end-to-end against a
   real Secret Service daemon. It shares its id/secret fixture with the
   CLI-level conformance data by reading it straight out of
   `vaultkeeper_conformance::all_cases()`'s `"store succeeds with valid
   secret"` case rather than duplicating it by hand. It gates itself on
   `target_os = "linux"` + `secret-tool` on `PATH` +
   `DBUS_SESSION_BUS_ADDRESS` being set (as `dbus-run-session` exports for
   the whole invocation) and skips with a clear message everywhere else —
   this sandboxed macOS dev environment included, where it is confirmed to
   compile and skip cleanly. It is **not yet wired into a Linux CI job** —
   that requires a `dbus-run-session` step in `.github/workflows/ci.yml`,
   which I did not add since it's CI-topology scope beyond this backend port;
   flagging this as a natural follow-up for the registry-wiring issue (#273)
   or its own small item.

## WASM artifact

`SecretToolBackend` is not referenced from `crates/vaultkeeper-wasm`, so no
wasm-bindgen export/import surface changed. Verified with a full
`wasm-pack build --target nodejs crates/vaultkeeper-wasm` + the repo's
`scripts/wasm-export-fingerprint.mjs` diffed against the committed
`packages/vaultkeeper-wasm/wasm/vaultkeeper_wasm_bg.wasm` — **no drift** — so
no artifact regeneration/commit was needed.

## Gate results (this branch, rebased on latest `origin/main`)

- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, 0 warnings.
- `cargo test --workspace` — **321 passed, 0 failed, 0 ignored** across all
  crates (includes 19 new `secret_tool` unit tests + the new gated
  conformance test, which self-reports skipped on this non-Linux runner).
- `pnpm check` — clean (typecheck + lint + api-report, all projects).
- `pnpm test` — **244 passed, 19 skipped (pre-existing), 0 failed** across 25
  TypeScript test files.

Refs #291
