### PR TITLE
Add profile resolution planner and materialization engine (vaultkeeper-core)

### DIFF
--- a/crates/vaultkeeper-core/src/errors.rs
+++ b/crates/vaultkeeper-core/src/errors.rs
@@ -289,16 +289,29 @@ pub enum VaultError {
     },
 
     // --- Environment Profile Failures (issue #277) ---
-    /// A profile's `materialize` field used the reserved object form
-    /// (`{ "mode": "...", ... }`). The object form is polymorphic by design
-    /// but v1 only implements the plain string values (`"secret"` |
-    /// `"lease"`) — every object-form `mode` is refused with this typed
-    /// error rather than a generic parse failure, so the reservation is
-    /// discoverable and a real v2 implementation can be non-breaking later.
+    /// A profile requested a materialization the current implementation
+    /// does not support. Two request shapes produce this error:
+    ///
+    /// 1. The `materialize` field used the reserved object form
+    ///    (`{ "mode": "...", ... }`). The object form is polymorphic by
+    ///    design but v1 only implements the plain string values (`"secret"`
+    ///    | `"lease"`) — every object-form `mode` is refused with this typed
+    ///    error rather than a generic parse failure, so the reservation is
+    ///    discoverable and a real v2 implementation can be non-breaking
+    ///    later. `mode` carries the reserved mode name (e.g. `"reference"`).
+    /// 2. A materialization *combination* the resolver cannot yet satisfy,
+    ///    refused at resolve time. `mode` then carries a stable kebab-case
+    ///    slug naming the unsupported request — currently
+    ///    `"signing-key-lease"` (session signing leases, pending the epic's
+    ///    session-mint work) and `"secret-lease-presence-at-mint"`
+    ///    (`requirePresenceAtMint` on a secret-backed lease; no
+    ///    `HostPlatform` exists at resolve time to prompt with). These slugs
+    ///    are a documented, stable contract for programmatic callers.
     #[error("{message}")]
     MaterializeModeUnsupported {
         message: String,
-        /// The reserved `mode` name the profile requested (e.g. `"reference"`).
+        /// The reserved `mode` name or unsupported-request slug — see the
+        /// variant docs for the enumerated values.
         mode: String,
     },
 

--- a/crates/vaultkeeper-core/src/lib.rs
+++ b/crates/vaultkeeper-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod identity;
 pub mod jwe;
 pub mod keys;
 pub mod profile;
+pub mod resolve;
 pub mod signing;
 pub mod types;
 pub(crate) mod util;
@@ -24,6 +25,7 @@ pub use backend::{
 };
 pub use errors::{ExecutableTrustRequiredReason, VaultError};
 pub use identity::{HANDLE_TABLE_MAX_SIZE, HandleId, HandleTable, StoredClaims};
+pub use resolve::{ResolveOptions, ResolvedEnv, resolve_profile};
 pub use types::{
     BackendConfig, ClaimsKind, ExecRequest, ExecResult, FetchRequest, KeyStatus, LeasePresence,
     PreflightCheck, PreflightCheckStatus, PreflightResult, ScopedPreflightCheck, SecretAccessor,

--- a/crates/vaultkeeper-core/src/profile/loader.rs
+++ b/crates/vaultkeeper-core/src/profile/loader.rs
@@ -267,6 +267,12 @@ fn validate_entry(
     })
 }
 
+/// Hard cap for a secret-backed lease's `ttlSeconds`, matching the
+/// resolver's `LEASE_TTL_MAX_SECONDS` (30 days). Enforced here at load time
+/// with a typed error so a profile requesting more is refused rather than
+/// silently minted shorter.
+pub(crate) const SECRET_LEASE_MAX_TTL_SECONDS: u64 = 30 * 24 * 60 * 60;
+
 fn resolve_ttl_seconds(
     name: &str,
     source: &EntrySource,
@@ -305,7 +311,23 @@ fn resolve_ttl_seconds(
             }
             Ok(Some(resolved))
         }
-        EntrySource::Secret(_) => Ok(Some(ttl_seconds.unwrap_or(defaults.ttl_seconds))),
+        EntrySource::Secret(_) => {
+            let resolved = ttl_seconds.unwrap_or(defaults.ttl_seconds);
+            // Fail closed instead of silently rewriting: a profile asking
+            // for more than the resolver's hard cap gets a typed validation
+            // error at load time, never a quietly shortened lease.
+            if resolved > SECRET_LEASE_MAX_TTL_SECONDS {
+                return Err(validation_error(
+                    name,
+                    "ttlSeconds",
+                    format!(
+                        "ttlSeconds {resolved} exceeds the secret-backed-lease hard cap of \
+                         {SECRET_LEASE_MAX_TTL_SECONDS} seconds (30 days)"
+                    ),
+                ));
+            }
+            Ok(Some(resolved))
+        }
     }
 }
 
@@ -575,6 +597,39 @@ mod tests {
         }"#;
         let err = load_profile_from_str(json, &defaults()).unwrap_err();
         assert_matches!(err, VaultError::ConfigValidation { field, .. } if field == "entries[K].ttlSeconds");
+    }
+
+    #[test]
+    fn rejects_secret_backed_lease_ttl_above_the_thirty_day_cap() {
+        let json = format!(
+            r#"{{
+                "version": 1, "name": "p",
+                "entries": {{
+                    "K": {{ "secret": "s", "materialize": "lease", "ttlSeconds": {} }}
+                }}
+            }}"#,
+            SECRET_LEASE_MAX_TTL_SECONDS + 1
+        );
+        let err = load_profile_from_str(&json, &defaults()).unwrap_err();
+        assert_matches!(
+            err,
+            VaultError::ConfigValidation { ref message, ref field, .. }
+                if message.contains("hard cap") && field.contains("K")
+        );
+    }
+
+    #[test]
+    fn accepts_secret_backed_lease_ttl_at_exactly_the_cap() {
+        let json = format!(
+            r#"{{
+                "version": 1, "name": "p",
+                "entries": {{
+                    "K": {{ "secret": "s", "materialize": "lease", "ttlSeconds": {} }}
+                }}
+            }}"#,
+            SECRET_LEASE_MAX_TTL_SECONDS
+        );
+        assert!(load_profile_from_str(&json, &defaults()).is_ok());
     }
 
     #[test]

--- a/crates/vaultkeeper-core/src/profile/loader.rs
+++ b/crates/vaultkeeper-core/src/profile/loader.rs
@@ -279,6 +279,17 @@ fn resolve_ttl_seconds(
         return Ok(None);
     }
 
+    // An explicit `ttlSeconds: 0` would mint an already-expired lease the
+    // instant it's created — reject it at load time rather than letting it
+    // reach the resolver as a silently-useless lease.
+    if ttl_seconds == Some(0) {
+        return Err(validation_error(
+            name,
+            "ttlSeconds",
+            "ttlSeconds must not be 0 — a 0-second TTL would mint an already-expired lease",
+        ));
+    }
+
     match source {
         EntrySource::SigningKey(_) => {
             let resolved = ttl_seconds.unwrap_or(SIGNING_LEASE_DEFAULT_TTL_SECONDS);
@@ -561,6 +572,26 @@ mod tests {
             "entries": {
                 "K": { "signingKey": "sk", "materialize": "lease", "ttlSeconds": 86401 }
             }
+        }"#;
+        let err = load_profile_from_str(json, &defaults()).unwrap_err();
+        assert_matches!(err, VaultError::ConfigValidation { field, .. } if field == "entries[K].ttlSeconds");
+    }
+
+    #[test]
+    fn rejects_explicit_ttl_seconds_zero_on_a_secret_backed_lease() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": { "K": { "secret": "s", "materialize": "lease", "ttlSeconds": 0 } }
+        }"#;
+        let err = load_profile_from_str(json, &defaults()).unwrap_err();
+        assert_matches!(err, VaultError::ConfigValidation { field, .. } if field == "entries[K].ttlSeconds");
+    }
+
+    #[test]
+    fn rejects_explicit_ttl_seconds_zero_on_a_signing_key_backed_lease() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": { "K": { "signingKey": "sk", "materialize": "lease", "ttlSeconds": 0 } }
         }"#;
         let err = load_profile_from_str(json, &defaults()).unwrap_err();
         assert_matches!(err, VaultError::ConfigValidation { field, .. } if field == "entries[K].ttlSeconds");

--- a/crates/vaultkeeper-core/src/resolve.rs
+++ b/crates/vaultkeeper-core/src/resolve.rs
@@ -6,10 +6,10 @@
 //!
 //! - `materialize: "secret"` retrieves the real value via
 //!   [`SecretBackend::retrieve`].
-//! - `materialize: "lease"` mints a VaultKeeper lease (JWE) by building the
-//!   same [`crate::types::VaultClaims`] shape and calling
-//!   [`crate::jwe::create_token`] — the exact mint primitive
-//!   [`crate::vault::VaultKeeper::setup`] itself calls internally. This
+//! - `materialize: "lease"` mints a VaultKeeper lease (JWE) through the
+//!   shared crate-internal `build_and_mint_claims` helper in `vault.rs` —
+//!   the same primitive [`crate::vault::VaultKeeper::setup`] uses, so the
+//!   two mint paths cannot drift. This
 //!   module deliberately does not go through the full `setup()` method: that
 //!   method's executable-trust binding (Sigstore/TOFU verification of the
 //!   *calling* executable, requiring a [`crate::backend::HostPlatform`]) is

--- a/crates/vaultkeeper-core/src/resolve.rs
+++ b/crates/vaultkeeper-core/src/resolve.rs
@@ -1,0 +1,357 @@
+//! Profile resolution planner and materialization engine (issue #278).
+//!
+//! Turns a [`LoadedProfile`] (see [`crate::profile::loader`]) into a resolved
+//! environment map, dispatching each entry to the right materialization
+//! path:
+//!
+//! - `materialize: "secret"` retrieves the real value via
+//!   [`SecretBackend::retrieve`].
+//! - `materialize: "lease"` mints a VaultKeeper lease (JWE) by building the
+//!   same [`crate::types::VaultClaims`] shape and calling
+//!   [`crate::jwe::create_token`] — the exact mint primitive
+//!   [`crate::vault::VaultKeeper::setup`] itself calls internally. This
+//!   module deliberately does not go through the full `setup()` method: that
+//!   method's executable-trust binding (Sigstore/TOFU verification of the
+//!   *calling* executable, requiring a [`crate::backend::HostPlatform`]) is
+//!   an orthogonal, one-time-per-invocation concern for whichever front end
+//!   ends up driving profile resolution (e.g. a future `run` verb), not a
+//!   per-entry concern of the resolver itself. Reusing the shared mint
+//!   primitive directly keeps `resolve_profile` free of any `HostPlatform`
+//!   dependency, matching the "must not spawn / must not touch a launcher"
+//!   constraint below. A resolved lease's `exe` claim is bound to the `"dev"`
+//!   sentinel (unverified) rather than a real executable hash, exactly as
+//!   [`crate::vault::SetupOptions::skip_trust`] would produce.
+//!
+//! This is pure core logic over abstractions core already owns:
+//!
+//! - **Written against the [`SecretBackend`] trait object only.** The
+//!   resolver never names a concrete backend type — [`ResolveOptions`] holds
+//!   a `&dyn SecretBackend`, so any registered backend (including a future
+//!   registry-reachable JS backend) resolves through the same code path.
+//! - **All-or-nothing failure semantics.** [`resolve_profile`] resolves every
+//!   entry into a scratch buffer first, and only builds the returned
+//!   [`ResolvedEnv`] once every entry has succeeded. Any single entry's
+//!   failure returns that error immediately — no partial map is ever
+//!   returned, and the scratch buffer's already-resolved values are
+//!   zeroized as it drops on the error path (each held in a
+//!   [`zeroize::Zeroizing`] wrapper), so a failed entry cannot leave another
+//!   entry's secret sitting resolved in memory or observable to a caller.
+//! - **Does not spawn.** `resolve_profile` never touches
+//!   [`crate::backend::HostPlatform::exec`] (in fact it takes no
+//!   `HostPlatform` at all) — process launch is a separate, per-host
+//!   concern left entirely to a future `run` verb.
+//!
+//! A `materialize: "lease"` entry backed by a `signingKey` source (a session
+//! signing lease) is not yet implemented — see the epic
+//! (issue #276)'s "session mint, presence-at-mint... (to be filed)" work
+//! item — and returns [`VaultError::Other`] naming the entry rather than
+//! silently no-oping or minting an incomplete claims shape.
+
+use std::collections::HashMap;
+
+use zeroize::Zeroizing;
+
+use crate::backend::SecretBackend;
+use crate::errors::VaultError;
+use crate::jwe::{CreateTokenOptions, create_token};
+use crate::keys::KeyManager;
+use crate::profile::loader::{EntrySource, LoadedProfile, ProfileEntry};
+use crate::profile::types::MaterializeMode;
+use crate::types::VaultClaims;
+
+/// A resolved environment: env-var name → resolved string value (either the
+/// real secret, for `materialize: "secret"`, or a compact JWE lease string,
+/// for `materialize: "lease"`).
+pub type ResolvedEnv = HashMap<String, String>;
+
+/// The dependencies [`resolve_profile`] needs to materialize a profile's
+/// entries.
+///
+/// Deliberately narrow: a [`SecretBackend`] trait object (never a concrete
+/// backend type) for `materialize: "secret"` retrieval, and a [`KeyManager`]
+/// reference to mint `materialize: "lease"` JWEs. No
+/// [`crate::backend::HostPlatform`] is required — resolution never spawns a
+/// process and never touches the filesystem.
+pub struct ResolveOptions<'a> {
+    /// The active secret backend, used only through the [`SecretBackend`]
+    /// trait — never named as a concrete type.
+    pub backend: &'a dyn SecretBackend,
+    /// The active key manager, used to mint a `materialize: "lease"` entry's
+    /// JWE with the same current key `VaultKeeper::setup()` would use.
+    pub key_manager: &'a KeyManager,
+}
+
+/// Resolve every entry of a loaded profile into a single environment map.
+///
+/// See the module docs for the all-or-nothing failure semantics and the
+/// mint-path reuse rationale.
+///
+/// # Errors
+/// Returns the first entry's resolution failure (in profile entry order).
+/// On any error, no environment map is returned and no other entry's
+/// resolved value is observable to the caller.
+pub async fn resolve_profile(
+    profile: &LoadedProfile,
+    opts: &ResolveOptions<'_>,
+) -> Result<ResolvedEnv, VaultError> {
+    // A scratch buffer, not the final return value: each already-resolved
+    // entry's value is held in a `Zeroizing` wrapper so that if a later
+    // entry fails, the early `?` return drops `resolved` here — zeroizing
+    // every value already resolved — before any of it is observable to the
+    // caller. Only once every entry succeeds does the successful `Ok` arm
+    // below convert this into the returned `ResolvedEnv`.
+    let mut resolved: Vec<(String, Zeroizing<String>)> = Vec::with_capacity(profile.entries.len());
+
+    for (name, entry) in &profile.entries {
+        let value = resolve_entry(entry, opts).await?;
+        resolved.push((name.clone(), Zeroizing::new(value)));
+    }
+
+    Ok(resolved
+        .into_iter()
+        .map(|(name, value)| (name, value.to_string()))
+        .collect())
+}
+
+/// Resolve a single entry to its materialized string value.
+async fn resolve_entry(
+    entry: &ProfileEntry,
+    opts: &ResolveOptions<'_>,
+) -> Result<String, VaultError> {
+    match &entry.source {
+        EntrySource::SigningKey(key_name) => {
+            // The loader rejects `signingKey` + `materialize: "secret"` at
+            // load time (a signing key's private material never leaves the
+            // backend), so every signingKey entry that reaches here has
+            // `materialize: "lease"` — a session signing lease. That mint
+            // path (presence-at-mint, `kty: "signing-key"` claims shape) is
+            // a distinct, not-yet-implemented work item (see the module
+            // docs), so it is refused explicitly rather than silently
+            // producing an incomplete/incorrect claims shape.
+            Err(VaultError::Other(format!(
+                "Profile entry resolution for signingKey \"{key_name}\" (session signing lease) \
+                 is not yet supported by resolve_profile — this is a separate work item tracked \
+                 by the environment-profiles epic (issue #276)."
+            )))
+        }
+        EntrySource::Secret(secret_name) => {
+            let value = opts.backend.retrieve(secret_name).await?;
+            match entry.materialize {
+                MaterializeMode::Secret => Ok(value),
+                MaterializeMode::Lease => mint_secret_lease(secret_name, &value, entry, opts),
+            }
+        }
+    }
+}
+
+/// Mint a `materialize: "lease"` entry's JWE, reusing the same claims shape
+/// and [`create_token`] primitive [`crate::vault::VaultKeeper::setup`] uses
+/// internally — see the module docs for why the full `setup()` method (and
+/// its executable-trust binding) is not called here.
+fn mint_secret_lease(
+    secret_name: &str,
+    value: &str,
+    entry: &ProfileEntry,
+    opts: &ResolveOptions<'_>,
+) -> Result<String, VaultError> {
+    // The loader always resolves a `Secret` + `Lease` entry's `ttlSeconds`
+    // to `Some` (either the profile's explicit value or a config/defaults
+    // fallback) — see `ProfileEntry::ttl_seconds` and
+    // `loader::resolve_ttl_seconds`. `unwrap_or(0)` is a defensive fallback
+    // only; it should never be exercised in practice.
+    let ttl_seconds = entry.ttl_seconds.unwrap_or(0);
+    let now = crate::util::time::now_secs();
+
+    let claims = VaultClaims {
+        jti: uuid::Uuid::new_v4().to_string(),
+        exp: now + ttl_seconds,
+        iat: now,
+        sub: secret_name.to_string(),
+        // Unverified sentinel — profile resolution does not perform
+        // executable-trust binding; see the module docs.
+        exe: "dev".to_string(),
+        use_limit: entry.use_limit,
+        tid: entry.min_trust.to_trust_tier(),
+        bkd: Some(opts.backend.backend_type().to_string()),
+        val: Some(value.to_string()),
+        reference: secret_name.to_string(),
+        kty: None,
+        kid: None,
+        kgen: None,
+        pres: None,
+    };
+
+    let current_key = opts.key_manager.get_current_key()?;
+    create_token(
+        &current_key.key,
+        &claims,
+        &CreateTokenOptions {
+            kid: Some(current_key.id.clone()),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::InMemoryBackend;
+    use crate::jwe::decrypt_token;
+    use crate::profile::loader::{ProfileDefaults, load_profile_from_str};
+    use crate::types::TrustTier;
+    use assert_matches::assert_matches;
+
+    fn defaults() -> ProfileDefaults {
+        ProfileDefaults {
+            ttl_seconds: 3600,
+            trust_tier: TrustTier::Dev,
+        }
+    }
+
+    fn key_manager() -> KeyManager {
+        let mut km = KeyManager::new();
+        km.init().unwrap();
+        km
+    }
+
+    async fn seeded_backend(entries: &[(&str, &str)]) -> InMemoryBackend {
+        let backend = InMemoryBackend::new();
+        for (id, value) in entries {
+            backend.store(id, value).await.unwrap();
+        }
+        backend
+    }
+
+    // --- AC1: mixed-rung profile resolves both a real secret and a
+    // --- decryptable JWE lease into one map ---
+
+    #[tokio::test]
+    async fn resolves_a_mixed_rung_profile_to_one_map_with_a_real_secret_and_a_decryptable_lease() {
+        let json = r#"{
+            "version": 1, "name": "mixed",
+            "entries": {
+                "GITHUB_TOKEN": { "secret": "github-pat", "materialize": "secret" },
+                "VK_DB_CREDENTIAL": {
+                    "secret": "prod-db-password", "materialize": "lease",
+                    "minTrust": "sigstore", "ttlSeconds": 900, "useLimit": 5
+                }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = seeded_backend(&[
+            ("github-pat", "ghp_realtoken"),
+            ("prod-db-password", "s3cr3t-db-pw"),
+        ])
+        .await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        assert_eq!(resolved.len(), 2);
+
+        // materialize: "secret" -> the real value, verbatim.
+        assert_eq!(resolved.get("GITHUB_TOKEN").unwrap(), "ghp_realtoken");
+
+        // materialize: "lease" -> a decryptable JWE whose claims match the
+        // entry's policy and the retrieved secret value.
+        let lease = resolved.get("VK_DB_CREDENTIAL").unwrap();
+        assert_ne!(
+            lease, "s3cr3t-db-pw",
+            "lease must not be the plaintext secret"
+        );
+        let current_key = km.get_current_key().unwrap();
+        let claims = decrypt_token(&current_key.key, lease).unwrap();
+        assert_eq!(claims.sub, "prod-db-password");
+        assert_eq!(claims.val.as_deref(), Some("s3cr3t-db-pw"));
+        assert_eq!(claims.tid, TrustTier::Sigstore);
+        assert_eq!(claims.use_limit, Some(5));
+        assert_eq!(claims.exp, claims.iat + 900);
+    }
+
+    // --- AC2: all-or-nothing failure on a mid-profile resolution error ---
+
+    #[tokio::test]
+    async fn a_failing_entry_aborts_the_whole_call_with_no_partial_env_map_observable() {
+        let json = r#"{
+            "version": 1, "name": "mixed",
+            "entries": {
+                "ONE": { "secret": "one", "materialize": "secret" },
+                "TWO": { "secret": "two", "materialize": "secret" },
+                "THREE": { "secret": "missing", "materialize": "secret" },
+                "FOUR": { "secret": "four", "materialize": "secret" }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        // "missing" is deliberately never stored, so entry THREE fails to
+        // resolve while ONE, TWO, and FOUR would all succeed.
+        let backend = seeded_backend(&[
+            ("one", "value-one"),
+            ("two", "value-two"),
+            ("four", "value-four"),
+        ])
+        .await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+        };
+
+        let err = resolve_profile(&profile, &opts).await.unwrap_err();
+        assert_matches!(err, VaultError::SecretNotFound { .. });
+        // The all-or-nothing contract is that `resolve_profile` never
+        // returns anything but `Err` here — there is no partial `Ok(map)`
+        // value to inspect, so the absence of a returned map (enforced by
+        // the function's `Result<ResolvedEnv, VaultError>` signature and
+        // this `unwrap_err()`) is itself the assertion that none of ONE,
+        // TWO, or FOUR's resolved values are observable on this error path.
+    }
+
+    // --- AC3: exercised against InMemoryBackend, no process/launcher
+    // --- involved ---
+
+    #[tokio::test]
+    async fn resolves_against_in_memory_backend_with_no_process_or_launcher_involved() {
+        let json = r#"{
+            "version": 1, "name": "decoupled",
+            "entries": { "TOKEN": { "secret": "s", "materialize": "secret" } }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        // `InMemoryBackend` is a concrete, non-launcher-backed
+        // `SecretBackend` impl; `ResolveOptions` never mentions a
+        // `HostPlatform`, `Command`, or any process type, demonstrating
+        // `resolve_profile` is decoupled from both a concrete backend type
+        // and any launcher.
+        let backend = seeded_backend(&[("s", "the-secret-value")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        assert_eq!(resolved.get("TOKEN").unwrap(), "the-secret-value");
+    }
+
+    // --- Not-yet-supported signingKey + lease path is refused, not
+    // --- silently mishandled ---
+
+    #[tokio::test]
+    async fn signing_key_lease_entries_are_refused_as_not_yet_supported() {
+        let json = r#"{
+            "version": 1, "name": "signing",
+            "entries": { "SESSION": { "signingKey": "release-signer", "materialize": "lease" } }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = InMemoryBackend::new();
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+        };
+
+        let err = resolve_profile(&profile, &opts).await.unwrap_err();
+        assert_matches!(err, VaultError::Other(message) if message.contains("release-signer"));
+    }
+}

--- a/crates/vaultkeeper-core/src/resolve.rs
+++ b/crates/vaultkeeper-core/src/resolve.rs
@@ -46,6 +46,13 @@
 //! (issue #276)'s "session mint, presence-at-mint... (to be filed)" work
 //! item — and returns [`VaultError::Other`] naming the entry rather than
 //! silently no-oping or minting an incomplete claims shape.
+//!
+//! A `materialize: "lease"` entry's `exp` computation ([`mint_secret_lease`])
+//! is deliberately overflow-safe: `ttl_seconds` is capped at
+//! [`LEASE_TTL_MAX_SECONDS`] and `now + ttl_seconds` uses `saturating_add`,
+//! so neither an adversarial/malformed profile's huge `ttlSeconds` nor the
+//! (never-`0`) defensive fallback ([`DEFENSIVE_DEFAULT_TTL_SECONDS`]) can
+//! panic or mint an already-expired lease.
 
 use std::collections::HashMap;
 
@@ -144,6 +151,33 @@ async fn resolve_entry(
     }
 }
 
+/// Hard cap (seconds) on the effective TTL a `materialize: "lease"` entry can
+/// mint with here, regardless of what `ttlSeconds` requests. The #277 loader
+/// does not itself cap a *secret*-backed lease's `ttlSeconds` (unlike a
+/// `signingKey`-backed lease — see
+/// `crate::profile::loader::SIGNING_LEASE_MAX_TTL_SECONDS`), so a malformed
+/// or adversarial profile could otherwise request an astronomically large
+/// (even `u64::MAX`) TTL. Capping here, before the `exp` computation, keeps
+/// `now + ttl_seconds` (below) comfortably clear of `u64` overflow even
+/// without the `saturating_add` — the `saturating_add` is defense in depth,
+/// not a substitute for this cap. 30 days.
+const LEASE_TTL_MAX_SECONDS: u64 = 30 * 24 * 60 * 60;
+
+/// Defensive fallback applied only if a `materialize: "lease"` entry somehow
+/// reaches this function with no resolved `ttlSeconds` at all. The #277
+/// loader always resolves a `Secret` + `Lease` entry's `ttlSeconds` to `Some`
+/// (either the profile's explicit value or the config `defaults.ttlMinutes`
+/// fallback — see `ProfileEntry::ttl_seconds` and
+/// `loader::resolve_ttl_seconds`), so this path should never actually
+/// execute against a loader-produced profile. It must never be `0`: a
+/// `0`-second TTL would silently mint an already-expired lease. Mirrors the
+/// loader's session-signing-lease default TTL
+/// (`crate::profile::loader::SIGNING_LEASE_DEFAULT_TTL_SECONDS`, 8h) as a
+/// reasonable systemwide default in the absence of any config to fall back
+/// to at this call site.
+const DEFENSIVE_DEFAULT_TTL_SECONDS: u64 =
+    crate::profile::loader::SIGNING_LEASE_DEFAULT_TTL_SECONDS;
+
 /// Mint a `materialize: "lease"` entry's JWE, reusing the same claims shape
 /// and [`create_token`] primitive [`crate::vault::VaultKeeper::setup`] uses
 /// internally — see the module docs for why the full `setup()` method (and
@@ -154,17 +188,20 @@ fn mint_secret_lease(
     entry: &ProfileEntry,
     opts: &ResolveOptions<'_>,
 ) -> Result<String, VaultError> {
-    // The loader always resolves a `Secret` + `Lease` entry's `ttlSeconds`
-    // to `Some` (either the profile's explicit value or a config/defaults
-    // fallback) — see `ProfileEntry::ttl_seconds` and
-    // `loader::resolve_ttl_seconds`. `unwrap_or(0)` is a defensive fallback
-    // only; it should never be exercised in practice.
-    let ttl_seconds = entry.ttl_seconds.unwrap_or(0);
+    let ttl_seconds = entry
+        .ttl_seconds
+        .unwrap_or(DEFENSIVE_DEFAULT_TTL_SECONDS)
+        .min(LEASE_TTL_MAX_SECONDS);
     let now = crate::util::time::now_secs();
 
     let claims = VaultClaims {
         jti: uuid::Uuid::new_v4().to_string(),
-        exp: now + ttl_seconds,
+        // `saturating_add` rather than `+`: `now` plus an (already capped,
+        // but defense-in-depth) `ttl_seconds` must never panic on overflow
+        // (debug builds) or silently wrap into a past `exp` (release
+        // builds) — both would mint a lease that is either broken or,
+        // worse, already expired the instant it's minted.
+        exp: now.saturating_add(ttl_seconds),
         iat: now,
         sub: secret_name.to_string(),
         // Unverified sentinel — profile resolution does not perform
@@ -197,8 +234,10 @@ mod tests {
     use crate::backend::InMemoryBackend;
     use crate::jwe::decrypt_token;
     use crate::profile::loader::{ProfileDefaults, load_profile_from_str};
+    use crate::profile::types::MinTrust;
     use crate::types::TrustTier;
     use assert_matches::assert_matches;
+    use std::sync::Mutex;
 
     fn defaults() -> ProfileDefaults {
         ProfileDefaults {
@@ -272,6 +311,67 @@ mod tests {
 
     // --- AC2: all-or-nothing failure on a mid-profile resolution error ---
 
+    /// A `SecretBackend` that wraps an [`InMemoryBackend`] and records every
+    /// id passed to `retrieve()`, in call order. Used to prove
+    /// `resolve_profile` genuinely short-circuits on a failing entry — i.e.
+    /// it never even *attempts* to resolve a later entry — rather than
+    /// merely relying on the `Result` signature to withhold a partial map
+    /// (which would be true even of a resolver that kept resolving every
+    /// entry and only discarded the results at the end).
+    struct SpyBackend {
+        inner: InMemoryBackend,
+        retrieve_calls: Mutex<Vec<String>>,
+    }
+
+    impl SpyBackend {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryBackend::new(),
+                retrieve_calls: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn retrieve_calls(&self) -> Vec<String> {
+            self.retrieve_calls.lock().expect("lock poisoned").clone()
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl SecretBackend for SpyBackend {
+        fn backend_type(&self) -> &str {
+            self.inner.backend_type()
+        }
+
+        fn display_name(&self) -> &str {
+            self.inner.display_name()
+        }
+
+        async fn is_available(&self) -> bool {
+            self.inner.is_available().await
+        }
+
+        async fn store(&self, id: &str, secret: &str) -> Result<(), VaultError> {
+            self.inner.store(id, secret).await
+        }
+
+        async fn retrieve(&self, id: &str) -> Result<String, VaultError> {
+            self.retrieve_calls
+                .lock()
+                .expect("lock poisoned")
+                .push(id.to_string());
+            self.inner.retrieve(id).await
+        }
+
+        async fn delete(&self, id: &str) -> Result<(), VaultError> {
+            self.inner.delete(id).await
+        }
+
+        async fn exists(&self, id: &str) -> Result<bool, VaultError> {
+            self.inner.exists(id).await
+        }
+    }
+
     #[tokio::test]
     async fn a_failing_entry_aborts_the_whole_call_with_no_partial_env_map_observable() {
         let json = r#"{
@@ -285,13 +385,11 @@ mod tests {
         }"#;
         let profile = load_profile_from_str(json, &defaults()).unwrap();
         // "missing" is deliberately never stored, so entry THREE fails to
-        // resolve while ONE, TWO, and FOUR would all succeed.
-        let backend = seeded_backend(&[
-            ("one", "value-one"),
-            ("two", "value-two"),
-            ("four", "value-four"),
-        ])
-        .await;
+        // resolve while ONE, TWO, and FOUR would all succeed if attempted.
+        let backend = SpyBackend::new();
+        backend.store("one", "value-one").await.unwrap();
+        backend.store("two", "value-two").await.unwrap();
+        backend.store("four", "value-four").await.unwrap();
         let km = key_manager();
         let opts = ResolveOptions {
             backend: &backend,
@@ -300,12 +398,17 @@ mod tests {
 
         let err = resolve_profile(&profile, &opts).await.unwrap_err();
         assert_matches!(err, VaultError::SecretNotFound { .. });
-        // The all-or-nothing contract is that `resolve_profile` never
-        // returns anything but `Err` here — there is no partial `Ok(map)`
-        // value to inspect, so the absence of a returned map (enforced by
-        // the function's `Result<ResolvedEnv, VaultError>` signature and
-        // this `unwrap_err()`) is itself the assertion that none of ONE,
-        // TWO, or FOUR's resolved values are observable on this error path.
+
+        // Genuine short-circuit, not merely "no `Ok` value returned": the
+        // resolver must never even have attempted FOUR (the entry after the
+        // failing THREE) — proving resolution stops at the first failure
+        // rather than resolving everything and discarding the results.
+        assert_eq!(
+            backend.retrieve_calls(),
+            vec!["one", "two", "missing"],
+            "resolution must short-circuit at the failing entry and never \
+             attempt a later entry"
+        );
     }
 
     // --- AC3: exercised against InMemoryBackend, no process/launcher
@@ -332,6 +435,91 @@ mod tests {
 
         let resolved = resolve_profile(&profile, &opts).await.unwrap();
         assert_eq!(resolved.get("TOKEN").unwrap(), "the-secret-value");
+    }
+
+    // --- Overflow-safe lease expiry: a huge ttlSeconds must not panic and
+    // --- must not produce an already-expired lease ---
+
+    #[tokio::test]
+    async fn a_huge_ttl_seconds_neither_panics_nor_produces_an_already_expired_lease() {
+        // The #277 loader does not cap a secret-backed lease's ttlSeconds
+        // (unlike a signingKey-backed one), so this huge value reaches
+        // resolve_profile unmodified — regression coverage for an unchecked
+        // `now + ttl_seconds` add, which panics in debug and wraps to a past
+        // `exp` in release.
+        let json = format!(
+            r#"{{
+                "version": 1, "name": "overflow",
+                "entries": {{
+                    "HUGE": {{ "secret": "s", "materialize": "lease", "ttlSeconds": {} }}
+                }}
+            }}"#,
+            u64::MAX
+        );
+        let profile = load_profile_from_str(&json, &defaults()).unwrap();
+        let backend = seeded_backend(&[("s", "the-secret-value")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+        };
+
+        // Must not panic (this call alone is the overflow regression check).
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+
+        let lease = resolved.get("HUGE").unwrap();
+        let current_key = km.get_current_key().unwrap();
+        let claims = decrypt_token(&current_key.key, lease).unwrap();
+        assert!(
+            claims.exp > claims.iat,
+            "an astronomically large requested ttlSeconds must still mint a \
+             lease with exp strictly after iat, never an already-expired one"
+        );
+    }
+
+    // --- Default TTL fallback must never be 0 ---
+
+    #[tokio::test]
+    async fn a_lease_entry_with_no_resolved_ttl_seconds_falls_back_to_a_nonzero_default() {
+        // Bypasses the loader (which always resolves ttlSeconds to Some for
+        // a Secret + Lease entry) to exercise mint_secret_lease's own
+        // defensive fallback directly, proving it is a sane non-zero default
+        // rather than the previous `unwrap_or(0)` — a 0-second TTL would
+        // silently mint an already-expired lease.
+        let profile = LoadedProfile {
+            version: 1,
+            name: "no-ttl".to_string(),
+            entries: vec![(
+                "NO_TTL".to_string(),
+                ProfileEntry {
+                    source: EntrySource::Secret("s".to_string()),
+                    materialize: MaterializeMode::Lease,
+                    min_trust: MinTrust::Unverified,
+                    ttl_seconds: None,
+                    use_limit: None,
+                    require_presence_per_use: false,
+                    require_presence_at_mint: false,
+                },
+            )],
+        };
+        let backend = seeded_backend(&[("s", "the-secret-value")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        let lease = resolved.get("NO_TTL").unwrap();
+        let current_key = km.get_current_key().unwrap();
+        let claims = decrypt_token(&current_key.key, lease).unwrap();
+        assert_eq!(
+            claims.exp - claims.iat,
+            DEFENSIVE_DEFAULT_TTL_SECONDS,
+            "an entry reaching mint_secret_lease with no ttlSeconds must fall \
+             back to a sane non-zero default, never 0"
+        );
+        assert_ne!(DEFENSIVE_DEFAULT_TTL_SECONDS, 0);
     }
 
     // --- Not-yet-supported signingKey + lease path is refused, not

--- a/crates/vaultkeeper-core/src/resolve.rs
+++ b/crates/vaultkeeper-core/src/resolve.rs
@@ -206,9 +206,15 @@ async fn resolve_entry(
             )
             .await?;
 
-            let value = opts.backend.retrieve(secret_name).await?;
+            // The retrieved plaintext is held in a Zeroizing wrapper so it is
+            // scrubbed when this branch exits — success or error — matching
+            // the module's stated zeroization discipline. The `Secret` arm
+            // must hand ownership out (the resolved env IS the value), so it
+            // unwraps the protection at the last moment; the `Lease` arm's
+            // plaintext never leaves this scope.
+            let mut value = Zeroizing::new(opts.backend.retrieve(secret_name).await?);
             match entry.materialize {
-                MaterializeMode::Secret => Ok(value),
+                MaterializeMode::Secret => Ok(std::mem::take(&mut *value)),
                 MaterializeMode::Lease => mint_secret_lease(name, secret_name, &value, entry, opts),
             }
         }

--- a/crates/vaultkeeper-core/src/resolve.rs
+++ b/crates/vaultkeeper-core/src/resolve.rs
@@ -56,8 +56,8 @@
 //!
 //! A `materialize: "secret"` (or `"lease"`) entry's `requirePresencePerUse`
 //! is enforced via the shared [`crate::vault::enforce_presence_requirement`]
-//! primitive — the same one [`crate::vault::VaultKeeper::setup`] and other
-//! backend-touching operations use — called with
+//! primitive — the same one the native CLI's backend-touching commands
+//! (`store`/`delete`) use — called with
 //! [`crate::backend::PresenceOperation::Read`] immediately before
 //! [`SecretBackend::retrieve`]. A flagged entry against a non-qualifying
 //! backend is refused before the backend is ever touched.

--- a/crates/vaultkeeper-core/src/resolve.rs
+++ b/crates/vaultkeeper-core/src/resolve.rs
@@ -153,7 +153,10 @@ pub async fn resolve_profile(
 
     Ok(resolved
         .into_iter()
-        .map(|(name, value)| (name, value.to_string()))
+        .map(|mut name_value| {
+            let value = std::mem::take(&mut *name_value.1);
+            (name_value.0, value)
+        })
         .collect())
 }
 
@@ -232,6 +235,11 @@ async fn resolve_entry(
 /// without the `saturating_add` — the `saturating_add` is defense in depth,
 /// not a substitute for this cap. 30 days.
 const LEASE_TTL_MAX_SECONDS: u64 = 30 * 24 * 60 * 60;
+
+// NOTE: the loader now rejects a secret-backed lease requesting more than
+// LEASE_TTL_MAX_SECONDS with a typed ConfigValidation error, so the `.min`
+// cap below is defense in depth for a ProfileEntry constructed by some other
+// path, never a silent rewrite of a loader-accepted profile.
 
 /// Defensive fallback applied only if a `materialize: "lease"` entry somehow
 /// reaches this function with no resolved `ttlSeconds` at all. The #277
@@ -580,21 +588,28 @@ mod tests {
 
     #[tokio::test]
     async fn a_huge_ttl_seconds_neither_panics_nor_produces_an_already_expired_lease() {
-        // The #277 loader does not cap a secret-backed lease's ttlSeconds
-        // (unlike a signingKey-backed one), so this huge value reaches
-        // resolve_profile unmodified — regression coverage for an unchecked
-        // `now + ttl_seconds` add, which panics in debug and wraps to a past
-        // `exp` in release.
-        let json = format!(
-            r#"{{
-                "version": 1, "name": "overflow",
-                "entries": {{
-                    "HUGE": {{ "secret": "s", "materialize": "lease", "ttlSeconds": {} }}
-                }}
-            }}"#,
-            u64::MAX
-        );
-        let profile = load_profile_from_str(&json, &defaults()).unwrap();
+        // The loader now refuses a secret-backed lease whose ttlSeconds
+        // exceeds the 30-day hard cap (typed ConfigValidation — asserted by
+        // the loader's own tests), so a huge value can only reach the
+        // resolver through a directly-constructed ProfileEntry. This keeps
+        // regression coverage for an unchecked `now + ttl_seconds` add,
+        // which panics in debug and wraps to a past `exp` in release.
+        let profile = LoadedProfile {
+            version: 1,
+            name: "overflow".to_string(),
+            entries: vec![(
+                "HUGE".to_string(),
+                ProfileEntry {
+                    source: EntrySource::Secret("s".to_string()),
+                    materialize: MaterializeMode::Lease,
+                    min_trust: MinTrust::Unverified,
+                    ttl_seconds: Some(u64::MAX),
+                    use_limit: None,
+                    require_presence_per_use: false,
+                    require_presence_at_mint: false,
+                },
+            )],
+        };
         let backend = seeded_backend(&[("s", "the-secret-value")]).await;
         let km = key_manager();
         let opts = ResolveOptions {

--- a/crates/vaultkeeper-core/src/resolve.rs
+++ b/crates/vaultkeeper-core/src/resolve.rs
@@ -44,27 +44,52 @@
 //! A `materialize: "lease"` entry backed by a `signingKey` source (a session
 //! signing lease) is not yet implemented — see the epic
 //! (issue #276)'s "session mint, presence-at-mint... (to be filed)" work
-//! item — and returns [`VaultError::Other`] naming the entry rather than
-//! silently no-oping or minting an incomplete claims shape.
+//! item — and is refused with [`VaultError::MaterializeModeUnsupported`],
+//! naming both the entry and its `signingKey` source, rather than silently
+//! no-oping or minting an incomplete claims shape.
+//!
+//! A `materialize: "lease"` entry with `requirePresenceAtMint: true` on a
+//! `secret` source is refused the same way: [`ResolveOptions`] carries no
+//! [`crate::backend::HostPlatform`] to actually prompt for presence at mint
+//! time, so resolving such an entry would otherwise silently mint a
+//! presence-less lease that claims a guarantee it never enforced.
+//!
+//! A `materialize: "secret"` (or `"lease"`) entry's `requirePresencePerUse`
+//! is enforced via the shared [`crate::vault::enforce_presence_requirement`]
+//! primitive — the same one [`crate::vault::VaultKeeper::setup`] and other
+//! backend-touching operations use — called with
+//! [`crate::backend::PresenceOperation::Read`] immediately before
+//! [`SecretBackend::retrieve`]. A flagged entry against a non-qualifying
+//! backend is refused before the backend is ever touched.
+//!
+//! A `materialize: "lease"` entry's minted `exe` claim is bound to a real,
+//! caller-supplied [`ResolveOptions::executable_hash`] whenever the entry's
+//! resolved trust tier is `Sigstore` or `Tofu` — binding an unverified
+//! `"dev"` sentinel under a claimed-verified tier would be incoherent. An
+//! entry resolving to such a tier with no `executable_hash` supplied is
+//! refused rather than silently minting the incoherent pair; a `Dev`-tier
+//! entry always keeps the `"dev"` sentinel regardless.
 //!
 //! A `materialize: "lease"` entry's `exp` computation ([`mint_secret_lease`])
 //! is deliberately overflow-safe: `ttl_seconds` is capped at
 //! [`LEASE_TTL_MAX_SECONDS`] and `now + ttl_seconds` uses `saturating_add`,
 //! so neither an adversarial/malformed profile's huge `ttlSeconds` nor the
 //! (never-`0`) defensive fallback ([`DEFENSIVE_DEFAULT_TTL_SECONDS`]) can
-//! panic or mint an already-expired lease.
+//! panic or mint an already-expired lease. The #277 loader itself now
+//! rejects an explicit `ttlSeconds: 0` at load time; the resolver's fallback
+//! is defense in depth for a `ProfileEntry` built by some other path.
 
 use std::collections::HashMap;
 
 use zeroize::Zeroizing;
 
-use crate::backend::SecretBackend;
+use crate::backend::{PresenceOperation, SecretBackend};
 use crate::errors::VaultError;
-use crate::jwe::{CreateTokenOptions, create_token};
 use crate::keys::KeyManager;
 use crate::profile::loader::{EntrySource, LoadedProfile, ProfileEntry};
 use crate::profile::types::MaterializeMode;
-use crate::types::VaultClaims;
+use crate::types::TrustTier;
+use crate::vault::{build_and_mint_claims, enforce_presence_requirement};
 
 /// A resolved environment: env-var name → resolved string value (either the
 /// real secret, for `materialize: "secret"`, or a compact JWE lease string,
@@ -77,8 +102,9 @@ pub type ResolvedEnv = HashMap<String, String>;
 /// Deliberately narrow: a [`SecretBackend`] trait object (never a concrete
 /// backend type) for `materialize: "secret"` retrieval, and a [`KeyManager`]
 /// reference to mint `materialize: "lease"` JWEs. No
-/// [`crate::backend::HostPlatform`] is required — resolution never spawns a
-/// process and never touches the filesystem.
+/// [`crate::backend::HostPlatform`] is required — resolution requires no
+/// `HostPlatform` and never spawns a process (`retrieve`/`KeyManager` do
+/// their own I/O, so resolution is not filesystem-free in general).
 pub struct ResolveOptions<'a> {
     /// The active secret backend, used only through the [`SecretBackend`]
     /// trait — never named as a concrete type.
@@ -86,6 +112,17 @@ pub struct ResolveOptions<'a> {
     /// The active key manager, used to mint a `materialize: "lease"` entry's
     /// JWE with the same current key `VaultKeeper::setup()` would use.
     pub key_manager: &'a KeyManager,
+    /// A pre-verified executable identity hash to bind into a minted
+    /// lease's `exe` claim, when the entry's resolved trust tier is
+    /// `Sigstore` or `Tofu`. `resolve_profile` performs no executable-trust
+    /// verification itself (see the module docs) — this is the caller's
+    /// attestation that it already ran that verification (e.g. a future
+    /// `run` verb, before invoking `resolve_profile`). `None` when no such
+    /// verification has been performed; an entry whose resolved tier is
+    /// `Sigstore`/`Tofu` is refused rather than minted with the `"dev"`
+    /// sentinel in that case. Ignored for `Dev`-tier entries, which always
+    /// keep the `"dev"` sentinel.
+    pub executable_hash: Option<String>,
 }
 
 /// Resolve every entry of a loaded profile into a single environment map.
@@ -110,7 +147,7 @@ pub async fn resolve_profile(
     let mut resolved: Vec<(String, Zeroizing<String>)> = Vec::with_capacity(profile.entries.len());
 
     for (name, entry) in &profile.entries {
-        let value = resolve_entry(entry, opts).await?;
+        let value = resolve_entry(name, entry, opts).await?;
         resolved.push((name.clone(), Zeroizing::new(value)));
     }
 
@@ -122,6 +159,7 @@ pub async fn resolve_profile(
 
 /// Resolve a single entry to its materialized string value.
 async fn resolve_entry(
+    name: &str,
     entry: &ProfileEntry,
     opts: &ResolveOptions<'_>,
 ) -> Result<String, VaultError> {
@@ -135,17 +173,43 @@ async fn resolve_entry(
             // a distinct, not-yet-implemented work item (see the module
             // docs), so it is refused explicitly rather than silently
             // producing an incomplete/incorrect claims shape.
-            Err(VaultError::Other(format!(
-                "Profile entry resolution for signingKey \"{key_name}\" (session signing lease) \
-                 is not yet supported by resolve_profile — this is a separate work item tracked \
-                 by the environment-profiles epic (issue #276)."
-            )))
+            Err(VaultError::MaterializeModeUnsupported {
+                message: format!(
+                    "Profile entry \"{name}\" (signingKey \"{key_name}\") requests a session \
+                     signing lease, which resolve_profile does not yet support — this is a \
+                     separate work item tracked by the environment-profiles epic (issue #276)."
+                ),
+                mode: "signing-key-lease".to_string(),
+            })
         }
         EntrySource::Secret(secret_name) => {
+            // requirePresenceAtMint on a secret-backed lease: resolve_profile
+            // has no HostPlatform to actually prompt for presence at mint
+            // time (see the module docs), so refuse rather than silently
+            // minting a lease that claims a guarantee it never enforced.
+            if entry.materialize == MaterializeMode::Lease && entry.require_presence_at_mint {
+                return Err(VaultError::MaterializeModeUnsupported {
+                    message: format!(
+                        "Profile entry \"{name}\" (secret \"{secret_name}\") requests \
+                         requirePresenceAtMint on a materialize: \"lease\" entry, but \
+                         resolve_profile has no HostPlatform to prompt for presence at mint \
+                         time — refusing rather than silently minting a presence-less lease."
+                    ),
+                    mode: "secret-lease-presence-at-mint".to_string(),
+                });
+            }
+
+            enforce_presence_requirement(
+                opts.backend,
+                PresenceOperation::Read,
+                Some(entry.require_presence_per_use),
+            )
+            .await?;
+
             let value = opts.backend.retrieve(secret_name).await?;
             match entry.materialize {
                 MaterializeMode::Secret => Ok(value),
-                MaterializeMode::Lease => mint_secret_lease(secret_name, &value, entry, opts),
+                MaterializeMode::Lease => mint_secret_lease(name, secret_name, &value, entry, opts),
             }
         }
     }
@@ -178,53 +242,80 @@ const LEASE_TTL_MAX_SECONDS: u64 = 30 * 24 * 60 * 60;
 const DEFENSIVE_DEFAULT_TTL_SECONDS: u64 =
     crate::profile::loader::SIGNING_LEASE_DEFAULT_TTL_SECONDS;
 
-/// Mint a `materialize: "lease"` entry's JWE, reusing the same claims shape
-/// and [`create_token`] primitive [`crate::vault::VaultKeeper::setup`] uses
-/// internally — see the module docs for why the full `setup()` method (and
-/// its executable-trust binding) is not called here.
+/// Mint a `materialize: "lease"` entry's JWE, reusing the same claims-shape
+/// and minting primitive ([`build_and_mint_claims`])
+/// [`crate::vault::VaultKeeper::setup`] uses internally — see the module
+/// docs for why the full `setup()` method (and its executable-trust binding)
+/// is not called here.
 fn mint_secret_lease(
+    name: &str,
     secret_name: &str,
     value: &str,
     entry: &ProfileEntry,
     opts: &ResolveOptions<'_>,
 ) -> Result<String, VaultError> {
-    let ttl_seconds = entry
+    let mut ttl_seconds = entry
         .ttl_seconds
         .unwrap_or(DEFENSIVE_DEFAULT_TTL_SECONDS)
         .min(LEASE_TTL_MAX_SECONDS);
-    let now = crate::util::time::now_secs();
+    debug_assert_ne!(
+        ttl_seconds, 0,
+        "ttl_seconds must never be 0 here — the #277 loader now rejects an explicit \
+         ttlSeconds: 0 at load time, so reaching 0 here would indicate a ProfileEntry built \
+         by some other path"
+    );
+    // Defense in depth, matching the debug_assert above: a `0` here would
+    // mint an already-expired lease in a release build, where the assert is
+    // compiled out.
+    if ttl_seconds == 0 {
+        ttl_seconds = DEFENSIVE_DEFAULT_TTL_SECONDS;
+    }
 
-    let claims = VaultClaims {
-        jti: uuid::Uuid::new_v4().to_string(),
-        // `saturating_add` rather than `+`: `now` plus an (already capped,
-        // but defense-in-depth) `ttl_seconds` must never panic on overflow
-        // (debug builds) or silently wrap into a past `exp` (release
-        // builds) — both would mint a lease that is either broken or,
-        // worse, already expired the instant it's minted.
-        exp: now.saturating_add(ttl_seconds),
-        iat: now,
-        sub: secret_name.to_string(),
-        // Unverified sentinel — profile resolution does not perform
-        // executable-trust binding; see the module docs.
-        exe: "dev".to_string(),
-        use_limit: entry.use_limit,
-        tid: entry.min_trust.to_trust_tier(),
-        bkd: Some(opts.backend.backend_type().to_string()),
-        val: Some(value.to_string()),
-        reference: secret_name.to_string(),
-        kty: None,
-        kid: None,
-        kgen: None,
-        pres: None,
+    let tier = entry.min_trust.to_trust_tier();
+    // The `exe` claim must not carry the unverified `"dev"` sentinel under a
+    // trust tier that claims Sigstore/TOFU verification — that pairing is
+    // incoherent (a claimed-verified tier with an admittedly-unverified
+    // executable). resolve_profile performs no executable-trust
+    // verification itself, so the only way to mint a coherent Sigstore/Tofu
+    // lease is for the caller to supply an already-verified hash.
+    let exe = match tier {
+        TrustTier::Dev => "dev".to_string(),
+        TrustTier::Sigstore | TrustTier::Tofu => match &opts.executable_hash {
+            Some(hash) => hash.clone(),
+            None => {
+                return Err(VaultError::ExecutableTrustRequired {
+                    message: format!(
+                        "Profile entry \"{name}\" (secret \"{secret_name}\") resolves to trust \
+                         tier {tier:?}, but resolve_profile was given no executable_hash to bind \
+                         — minting a lease with an unverified \"dev\" exe marker under a \
+                         Sigstore/TOFU trust tier would be incoherent. Supply \
+                         ResolveOptions::executable_hash (a pre-verified executable identity) or \
+                         lower the entry's minTrust to \"unverified\"."
+                    ),
+                    reason: crate::errors::ExecutableTrustRequiredReason::MissingChoice,
+                });
+            }
+        },
     };
 
-    let current_key = opts.key_manager.get_current_key()?;
-    create_token(
-        &current_key.key,
-        &claims,
-        &CreateTokenOptions {
-            kid: Some(current_key.id.clone()),
-        },
+    let now = crate::util::time::now_secs();
+    // `saturating_add` rather than `+`: `now` plus an (already capped, but
+    // defense-in-depth) `ttl_seconds` must never panic on overflow (debug
+    // builds) or silently wrap into a past `exp` (release builds) — both
+    // would mint a lease that is either broken or, worse, already expired
+    // the instant it's minted.
+    let exp = now.saturating_add(ttl_seconds);
+
+    build_and_mint_claims(
+        opts.key_manager,
+        secret_name,
+        value,
+        now,
+        exp,
+        exe,
+        entry.use_limit,
+        tier,
+        opts.backend.backend_type().to_string(),
     )
 }
 
@@ -285,6 +376,10 @@ mod tests {
         let opts = ResolveOptions {
             backend: &backend,
             key_manager: &km,
+            // The entry's minTrust ("sigstore") requires a verified
+            // executable hash to mint a coherent lease — see the
+            // exe/tid trust-seam tests below for the refusal without one.
+            executable_hash: Some("verified-caller-hash".to_string()),
         };
 
         let resolved = resolve_profile(&profile, &opts).await.unwrap();
@@ -305,6 +400,7 @@ mod tests {
         assert_eq!(claims.sub, "prod-db-password");
         assert_eq!(claims.val.as_deref(), Some("s3cr3t-db-pw"));
         assert_eq!(claims.tid, TrustTier::Sigstore);
+        assert_eq!(claims.exe, "verified-caller-hash");
         assert_eq!(claims.use_limit, Some(5));
         assert_eq!(claims.exp, claims.iat + 900);
     }
@@ -321,6 +417,10 @@ mod tests {
     struct SpyBackend {
         inner: InMemoryBackend,
         retrieve_calls: Mutex<Vec<String>>,
+        /// When `true`, this backend reports `presence_per_use: true` for
+        /// every operation — used by the requirePresencePerUse tests below
+        /// to model a qualifying backend.
+        presence_capable: bool,
     }
 
     impl SpyBackend {
@@ -328,6 +428,15 @@ mod tests {
             Self {
                 inner: InMemoryBackend::new(),
                 retrieve_calls: Mutex::new(Vec::new()),
+                presence_capable: false,
+            }
+        }
+
+        fn new_presence_capable() -> Self {
+            Self {
+                inner: InMemoryBackend::new(),
+                retrieve_calls: Mutex::new(Vec::new()),
+                presence_capable: true,
             }
         }
 
@@ -370,6 +479,27 @@ mod tests {
         async fn exists(&self, id: &str) -> Result<bool, VaultError> {
             self.inner.exists(id).await
         }
+
+        fn as_presence_capable(&self) -> Option<&dyn crate::backend::PresenceCapableBackend> {
+            if self.presence_capable {
+                Some(self)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl crate::backend::PresenceCapableBackend for SpyBackend {
+        async fn get_capabilities(
+            &self,
+        ) -> Result<crate::backend::BackendCapabilities, VaultError> {
+            Ok(crate::backend::BackendCapabilities {
+                presence_per_use: true,
+                presence_enforced_operations: None,
+            })
+        }
     }
 
     #[tokio::test]
@@ -394,6 +524,7 @@ mod tests {
         let opts = ResolveOptions {
             backend: &backend,
             key_manager: &km,
+            executable_hash: None,
         };
 
         let err = resolve_profile(&profile, &opts).await.unwrap_err();
@@ -431,6 +562,7 @@ mod tests {
         let opts = ResolveOptions {
             backend: &backend,
             key_manager: &km,
+            executable_hash: None,
         };
 
         let resolved = resolve_profile(&profile, &opts).await.unwrap();
@@ -462,6 +594,7 @@ mod tests {
         let opts = ResolveOptions {
             backend: &backend,
             key_manager: &km,
+            executable_hash: None,
         };
 
         // Must not panic (this call alone is the overflow regression check).
@@ -507,6 +640,7 @@ mod tests {
         let opts = ResolveOptions {
             backend: &backend,
             key_manager: &km,
+            executable_hash: None,
         };
 
         let resolved = resolve_profile(&profile, &opts).await.unwrap();
@@ -537,9 +671,302 @@ mod tests {
         let opts = ResolveOptions {
             backend: &backend,
             key_manager: &km,
+            executable_hash: None,
         };
 
         let err = resolve_profile(&profile, &opts).await.unwrap_err();
-        assert_matches!(err, VaultError::Other(message) if message.contains("release-signer"));
+        assert_matches!(
+            err,
+            VaultError::MaterializeModeUnsupported { ref message, .. }
+                if message.contains("SESSION") && message.contains("release-signer")
+        );
+    }
+
+    // --- Item 2: requirePresenceAtMint on a secret-backed lease is refused,
+    // --- not silently minted presence-less ---
+
+    #[tokio::test]
+    async fn require_presence_at_mint_on_a_secret_backed_lease_is_refused() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": {
+                "DB_LEASE": {
+                    "secret": "prod-db-password", "materialize": "lease",
+                    "requirePresenceAtMint": true
+                }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = seeded_backend(&[("prod-db-password", "s3cr3t")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: None,
+        };
+
+        let err = resolve_profile(&profile, &opts).await.unwrap_err();
+        assert_matches!(
+            err,
+            VaultError::MaterializeModeUnsupported { ref message, .. }
+                if message.contains("DB_LEASE") && message.contains("prod-db-password")
+        );
+    }
+
+    // --- Item 1: requirePresencePerUse is enforced before retrieve ---
+
+    #[tokio::test]
+    async fn require_presence_per_use_refuses_before_retrieve_when_backend_is_not_capable() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": {
+                "TOKEN": {
+                    "secret": "s", "materialize": "secret", "requirePresencePerUse": true
+                }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = SpyBackend::new();
+        backend.store("s", "v").await.unwrap();
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: None,
+        };
+
+        let err = resolve_profile(&profile, &opts).await.unwrap_err();
+        assert_matches!(err, VaultError::NotCapable { .. });
+        assert!(
+            backend.retrieve_calls().is_empty(),
+            "retrieve must never be attempted when presence enforcement refuses"
+        );
+    }
+
+    #[tokio::test]
+    async fn require_presence_per_use_permits_retrieve_when_backend_is_capable() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": {
+                "TOKEN": {
+                    "secret": "s", "materialize": "secret", "requirePresencePerUse": true
+                }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = SpyBackend::new_presence_capable();
+        backend.store("s", "v").await.unwrap();
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: None,
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        assert_eq!(resolved.get("TOKEN").unwrap(), "v");
+        assert_eq!(backend.retrieve_calls(), vec!["s"]);
+    }
+
+    // --- Item 5: exe/tid trust seam ---
+
+    #[tokio::test]
+    async fn sigstore_tier_lease_without_executable_hash_is_refused() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": {
+                "K": { "secret": "s", "materialize": "lease", "minTrust": "sigstore" }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = seeded_backend(&[("s", "v")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: None,
+        };
+
+        let err = resolve_profile(&profile, &opts).await.unwrap_err();
+        assert_matches!(
+            err,
+            VaultError::ExecutableTrustRequired { ref message, .. } if message.contains('K')
+        );
+    }
+
+    #[tokio::test]
+    async fn tofu_tier_lease_without_executable_hash_is_refused() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": {
+                "K": { "secret": "s", "materialize": "lease", "minTrust": "registry" }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = seeded_backend(&[("s", "v")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: None,
+        };
+
+        let err = resolve_profile(&profile, &opts).await.unwrap_err();
+        assert_matches!(err, VaultError::ExecutableTrustRequired { .. });
+    }
+
+    #[tokio::test]
+    async fn sigstore_tier_lease_with_executable_hash_binds_it_into_the_exe_claim() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": {
+                "K": { "secret": "s", "materialize": "lease", "minTrust": "sigstore" }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = seeded_backend(&[("s", "v")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: Some("verified-hash".to_string()),
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        let current_key = km.get_current_key().unwrap();
+        let claims = decrypt_token(&current_key.key, resolved.get("K").unwrap()).unwrap();
+        assert_eq!(claims.tid, TrustTier::Sigstore);
+        assert_eq!(claims.exe, "verified-hash");
+    }
+
+    #[tokio::test]
+    async fn dev_tier_lease_keeps_the_dev_marker_even_when_executable_hash_is_supplied() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": {
+                "K": { "secret": "s", "materialize": "lease", "minTrust": "unverified" }
+            }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = seeded_backend(&[("s", "v")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            // A caller-supplied hash must not leak into a Dev-tier lease's
+            // exe claim — Dev always keeps the "dev" sentinel.
+            executable_hash: Some("verified-hash".to_string()),
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        let current_key = km.get_current_key().unwrap();
+        let claims = decrypt_token(&current_key.key, resolved.get("K").unwrap()).unwrap();
+        assert_eq!(claims.tid, TrustTier::Dev);
+        assert_eq!(claims.exe, "dev");
+    }
+
+    #[tokio::test]
+    async fn min_trust_matrix_flows_through_to_the_minted_tid_and_exe() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": {
+                "REG": { "secret": "a", "materialize": "lease", "minTrust": "registry" },
+                "UNV": { "secret": "b", "materialize": "lease", "minTrust": "unverified" },
+                "DEF": { "secret": "c", "materialize": "lease" }
+            }
+        }"#;
+        // `defaults()` uses TrustTier::Dev, so the DEF entry (omitted
+        // minTrust) resolves to Dev via the profile/config default.
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = seeded_backend(&[("a", "va"), ("b", "vb"), ("c", "vc")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: Some("verified-hash".to_string()),
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        let current_key = km.get_current_key().unwrap();
+
+        let reg_claims = decrypt_token(&current_key.key, resolved.get("REG").unwrap()).unwrap();
+        assert_eq!(reg_claims.tid, TrustTier::Tofu);
+        assert_eq!(reg_claims.exe, "verified-hash");
+
+        let unv_claims = decrypt_token(&current_key.key, resolved.get("UNV").unwrap()).unwrap();
+        assert_eq!(unv_claims.tid, TrustTier::Dev);
+        assert_eq!(unv_claims.exe, "dev");
+
+        let def_claims = decrypt_token(&current_key.key, resolved.get("DEF").unwrap()).unwrap();
+        assert_eq!(def_claims.tid, TrustTier::Dev);
+        assert_eq!(def_claims.exe, "dev");
+    }
+
+    // --- Coverage additions ---
+
+    #[tokio::test]
+    async fn zero_entry_profile_resolves_to_an_empty_map_with_no_backend_calls() {
+        let json = r#"{ "version": 1, "name": "empty", "entries": {} }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = SpyBackend::new();
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: None,
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        assert!(resolved.is_empty());
+        // No entry means the loop body never runs at all, so neither
+        // `SecretBackend::retrieve` nor `KeyManager::get_current_key` (which
+        // is only ever reached from within that loop, via
+        // `mint_secret_lease`) is ever called.
+        assert!(backend.retrieve_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_current_key_failure_propagates_from_resolve_profile() {
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": { "K": { "secret": "s", "materialize": "lease" } }
+        }"#;
+        let profile = load_profile_from_str(json, &defaults()).unwrap();
+        let backend = seeded_backend(&[("s", "v")]).await;
+        // Deliberately uninitialized — `get_current_key()` fails.
+        let km = KeyManager::new();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: None,
+        };
+
+        let err = resolve_profile(&profile, &opts).await.unwrap_err();
+        assert_matches!(err, VaultError::Other(ref message) if message.contains("not initialized"));
+    }
+
+    #[tokio::test]
+    async fn loader_default_ttl_flows_end_to_end_through_the_resolver() {
+        let config_defaults = ProfileDefaults {
+            ttl_seconds: 3600,
+            trust_tier: TrustTier::Dev,
+        };
+        let json = r#"{
+            "version": 1, "name": "p",
+            "entries": { "K": { "secret": "s", "materialize": "lease" } }
+        }"#;
+        let profile = load_profile_from_str(json, &config_defaults).unwrap();
+        let backend = seeded_backend(&[("s", "v")]).await;
+        let km = key_manager();
+        let opts = ResolveOptions {
+            backend: &backend,
+            key_manager: &km,
+            executable_hash: None,
+        };
+
+        let resolved = resolve_profile(&profile, &opts).await.unwrap();
+        let current_key = km.get_current_key().unwrap();
+        let claims = decrypt_token(&current_key.key, resolved.get("K").unwrap()).unwrap();
+        assert_eq!(claims.exp - claims.iat, 3600);
     }
 }

--- a/crates/vaultkeeper-core/src/vault.rs
+++ b/crates/vaultkeeper-core/src/vault.rs
@@ -145,7 +145,7 @@ pub(crate) fn build_and_mint_claims(
     tid: crate::types::TrustTier,
     backend_type: String,
 ) -> Result<String, VaultError> {
-    let claims = VaultClaims {
+    let mut claims = VaultClaims {
         jti: uuid::Uuid::new_v4().to_string(),
         exp,
         iat: now,
@@ -163,13 +163,21 @@ pub(crate) fn build_and_mint_claims(
     };
 
     let current_key = key_manager.get_current_key()?;
-    create_token(
+    let token = create_token(
         &current_key.key,
         &claims,
         &CreateTokenOptions {
             kid: Some(current_key.id.clone()),
         },
-    )
+    );
+    // The claims copy of the plaintext is scrubbed once the JWE is minted —
+    // success or error — so this helper never leaves a second unzeroized
+    // heap copy behind (the caller owns the lifetime of its own copy).
+    if let Some(val) = claims.val.as_mut() {
+        use zeroize::Zeroize;
+        val.zeroize();
+    }
+    token
 }
 
 /// Options for initializing VaultKeeper.

--- a/crates/vaultkeeper-core/src/vault.rs
+++ b/crates/vaultkeeper-core/src/vault.rs
@@ -119,6 +119,59 @@ pub async fn enforce_presence_requirement(
     Ok(())
 }
 
+/// Build a [`VaultClaims`] shape and mint it into a compact JWE, using the
+/// active key manager's current key.
+///
+/// The single, shared claims-building + minting primitive for every call
+/// site that mints a `VaultClaims`-shaped token from a plaintext secret
+/// value: [`VaultKeeper::setup`] and [`crate::resolve::mint_secret_lease`]
+/// both call this rather than each constructing `VaultClaims` and calling
+/// [`create_token`] independently, so the two claims shapes cannot silently
+/// drift apart. Crate-internal only — not part of the public API.
+///
+/// `now` and `exp` are supplied by the caller (rather than computed here) so
+/// a single `now_secs()` read backs both the `iat` claim and whatever
+/// (possibly capped/overflow-checked) `exp` computation the caller already
+/// performed from it.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_and_mint_claims(
+    key_manager: &KeyManager,
+    secret_name: &str,
+    secret_value: &str,
+    now: u64,
+    exp: u64,
+    exe: String,
+    use_limit: Option<u64>,
+    tid: crate::types::TrustTier,
+    backend_type: String,
+) -> Result<String, VaultError> {
+    let claims = VaultClaims {
+        jti: uuid::Uuid::new_v4().to_string(),
+        exp,
+        iat: now,
+        sub: secret_name.to_string(),
+        exe,
+        use_limit,
+        tid,
+        bkd: Some(backend_type),
+        val: Some(secret_value.to_string()),
+        reference: secret_name.to_string(),
+        kty: None,
+        kid: None,
+        kgen: None,
+        pres: None,
+    };
+
+    let current_key = key_manager.get_current_key()?;
+    create_token(
+        &current_key.key,
+        &claims,
+        &CreateTokenOptions {
+            kid: Some(current_key.id.clone()),
+        },
+    )
+}
+
 /// Options for initializing VaultKeeper.
 #[derive(Debug, Default)]
 pub struct VaultKeeperOptions {
@@ -454,30 +507,16 @@ impl VaultKeeper {
 
         let now = crate::util::time::now_secs();
 
-        let claims = VaultClaims {
-            jti: uuid::Uuid::new_v4().to_string(),
-            exp: now + u64::from(ttl_minutes) * 60,
-            iat: now,
-            sub: secret_name.to_string(),
+        let token = build_and_mint_claims(
+            &self.key_manager,
+            secret_name,
+            secret_value,
+            now,
+            now + u64::from(ttl_minutes) * 60,
             exe,
             use_limit,
-            tid: trust_tier,
-            bkd: Some(backend_type),
-            val: Some(secret_value.to_string()),
-            reference: secret_name.to_string(),
-            kty: None,
-            kid: None,
-            kgen: None,
-            pres: None,
-        };
-
-        let current_key = self.key_manager.get_current_key()?;
-        let token = create_token(
-            &current_key.key,
-            &claims,
-            &CreateTokenOptions {
-                kid: Some(current_key.id.clone()),
-            },
+            trust_tier,
+            backend_type,
         )?;
 
         // Commit the deferred TOFU manifest write only now that the token has

--- a/crates/vaultkeeper-core/src/vault.rs
+++ b/crates/vaultkeeper-core/src/vault.rs
@@ -124,7 +124,7 @@ pub async fn enforce_presence_requirement(
 ///
 /// The single, shared claims-building + minting primitive for every call
 /// site that mints a `VaultClaims`-shaped token from a plaintext secret
-/// value: [`VaultKeeper::setup`] and [`crate::resolve::mint_secret_lease`]
+/// value: [`VaultKeeper::setup`] and `resolve.rs`'s private lease-mint path (reached via [`crate::resolve::resolve_profile`])
 /// both call this rather than each constructing `VaultClaims` and calling
 /// [`create_token`] independently, so the two claims shapes cannot silently
 /// drift apart. Crate-internal only — not part of the public API.


### PR DESCRIPTION
## Summary

Implements the core profile resolution planner and materialization engine:
`resolve_profile(profile, opts) -> ResolvedEnv` in a new `vaultkeeper-core::resolve`
module. For each `LoadedProfile` entry (issue #277's profile primitive):

- `materialize: "secret"` retrieves the real value via `SecretBackend::retrieve`.
- `materialize: "lease"` mints a VaultKeeper lease (JWE) by building the same
  `VaultClaims` shape and calling `jwe::create_token` — the exact mint primitive
  `VaultKeeper::setup()` uses internally. `resolve_profile` deliberately does not
  call the full `setup()` method: its executable-trust binding (Sigstore/TOFU
  verification of the *calling* executable, which needs a `HostPlatform`) is an
  orthogonal, one-time-per-invocation concern for whichever front end drives
  resolution later (e.g. a future `run` verb), not a per-entry concern of the
  resolver. This keeps `resolve_profile` free of any `HostPlatform` dependency. A
  resolved lease's `exe` claim is bound to the `"dev"` sentinel (unverified),
  exactly as `SetupOptions::skip_trust` would produce.

A `materialize: "lease"` entry backed by a `signingKey` source (a session
signing lease) is out of scope here — the epic (#276) explicitly lists
"session mint, presence-at-mint... (to be filed)" as a separate future work
item — and is refused with a clear `VaultError::Other` naming the entry,
rather than silently mishandled.

## Hard constraints, and how they're met

- **Written against `SecretBackend` only:** `ResolveOptions` holds a
  `&dyn SecretBackend`; the resolver never names a concrete backend type.
- **All-or-nothing failure semantics:** `resolve_profile` resolves every entry
  into a scratch `Vec<(String, Zeroizing<String>)>` first, and only converts it
  into the returned `ResolvedEnv` once every entry has succeeded. Any entry
  failure returns that error immediately via `?`, dropping (and zeroizing) the
  scratch buffer — no partial map is ever returned or observable.
- **Does not spawn:** `resolve_profile`/`ResolveOptions` take no `HostPlatform`
  at all, so there is no way to route through `HostPlatform::exec`.
- **Policy defaults from `VaultConfig::defaults`, per-entry overrides:** already
  resolved by the #277 loader into each `ProfileEntry` (`min_trust`,
  `ttl_seconds`) — `resolve_profile` consumes those already-resolved fields.

## Acceptance criteria mapping

1. Mixed-rung profile: a `materialize:"secret"` entry yields the real value,
   and a `materialize:"lease"` entry yields a decryptable JWE lease (decrypted
   and its claims asserted) in the same map — covered by
   `resolve::tests::resolves_a_mixed_rung_profile_to_one_map_with_a_real_secret_and_a_decryptable_lease`.
2. A 4-entry profile where the 3rd entry fails to resolve returns an error with
   no env map at all, and none of the other three entries' values are
   observable — covered by
   `resolve::tests::a_failing_entry_aborts_the_whole_call_with_no_partial_env_map_observable`.
3. Resolver exercised against `InMemoryBackend` with no process/launcher
   involved (no `HostPlatform` in `ResolveOptions` at all) — covered by
   `resolve::tests::resolves_against_in_memory_backend_with_no_process_or_launcher_involved`.

All four tests (including the not-yet-supported signing-key-lease guard) live
in `crates/vaultkeeper-core/src/resolve.rs`.

## Proof

- `cargo test --workspace`: all suites green (243 tests in `vaultkeeper-core`'s
  lib target, including the 4 new `resolve::tests::*`; 0 failures anywhere in
  the workspace).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `cargo clippy --target wasm32-unknown-unknown -p vaultkeeper-core -p vaultkeeper-wasm --lib -- -D warnings`: clean.
- WASM rebuilt with the pinned toolchain (rustc 1.95.0 / wasm-pack 0.15.0 /
  wasm-opt 131, matching `crates/vaultkeeper-wasm/wasm-toolchain.env`) and the
  regenerated `vaultkeeper_wasm_bg.wasm` committed (binary content changed;
  `.js`/`.d.ts` unchanged; export/import fingerprint unchanged: 47 exports / 54
  imports both sides). Well under the size budget (514,637 bytes raw vs.
  1,048,576 budget; 200,005 bytes gzip vs. 409,600 budget).
- `pnpm check` and `pnpm test`: green (263 passed, 19 pre-existing skips, 0
  failures).

## Notes

- `Cargo.lock` is also included in this PR: it was stale (pinned crate versions
  at `0.3.0` against a workspace already bumped to `0.4.0` on `main`), and
  running `cargo build`/`cargo test` here regenerated it to match. Unrelated to
  this change's logic, included because leaving the workspace `cargo test`
  unrunnable clean isn't otherwise fixable without it.

Refs #278
