### PR TITLE
Port KeychainBackend to vaultkeeper-core over security -i stdin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,25 @@ jobs:
           path: target/release/vaultkeeper
           retention-days: 1
 
+  keychain-conformance:
+    name: macOS Keychain Backend Conformance
+    # Runs `KeychainBackend` against the real `security(1)` binary and a real
+    # Keychain, via an ephemeral `create-keychain` (issue #290 AC5). The
+    # `rust` job above only runs on ubuntu-latest, where this test detects
+    # the missing macOS prerequisite and skips itself (see
+    # crates/vaultkeeper-core/tests/keychain_conformance.rs), so it needs its
+    # own macOS runner to actually execute.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run keychain conformance test
+        run: cargo test -p vaultkeeper-core --test keychain_conformance -- --nocapture
+
   wasm-guards:
     name: WASM Build Guards (drift + size)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
     # crates/vaultkeeper-core/tests/keychain_conformance.rs), so it needs its
     # own macOS runner to actually execute.
     runs-on: macos-latest
+    # macOS runner minutes bill at ~10x Linux minutes — cap this well below
+    # the 6h default so a hung interactive `security` process (e.g. an
+    # unexpected TTY prompt) can't run away with cost instead of failing
+    # fast.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/vaultkeeper-core/src/backend/keychain.rs
+++ b/crates/vaultkeeper-core/src/backend/keychain.rs
@@ -291,9 +291,18 @@ impl SecretBackend for KeychainBackend {
         // in the stream, so a failing pre-delete (no prior entry) followed
         // by a successful add still yields exit code 0 — verified
         // empirically (see module docs).
+        // `encoded` is quoted so an empty secret still yields a value token
+        // (`-w ""`): a bare trailing `-w` would flip `security` into its
+        // interactive getpass prompt and hang a non-interactive caller.
+        // Base64 output never contains `"`/`\`/newline, so plain quoting is
+        // exact (no escaping needed) — enforced by the debug_assert below.
+        debug_assert!(
+            !encoded.contains(['"', '\\', '\n', '\r']),
+            "base64 output must be quote-safe"
+        );
         let script = format!(
             "delete-generic-password -a {account_token} -s {service_token}\n\
-             add-generic-password -a {account_token} -s {service_token} -w {encoded}\n"
+             add-generic-password -a {account_token} -s {service_token} -w \"{encoded}\"\n"
         );
 
         let output = self
@@ -322,6 +331,17 @@ impl SecretBackend for KeychainBackend {
             // entirely removes any path for a future `security` version (or
             // an unanticipated error mode) to leak the secret or its base64
             // encoding into a `VaultError` message that might be logged.
+            // Locked-keychain detection mirrors retrieve/delete/exists —
+            // still without embedding stderr (the signature check reads it,
+            // the error message never includes it).
+            if Self::is_locked_keychain_error(&output.stderr) {
+                return Err(VaultError::BackendLocked {
+                    message: format!(
+                        "macOS Keychain is locked and cannot be written non-interactively for {id}"
+                    ),
+                    interactive: true,
+                });
+            }
             return Err(VaultError::Exec {
                 message: format!(
                     "security add-generic-password failed with exit code {}",
@@ -859,6 +879,54 @@ mod tests {
         assert_eq!(backend.retrieve(id).await.unwrap(), "value");
     }
 
+    #[tokio::test]
+    async fn store_quotes_the_secret_token_so_an_empty_secret_cannot_hang() {
+        // A bare trailing `-w` flips `security` into its interactive getpass
+        // prompt; quoting guarantees a value token even for "".
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        backend.store("empty-id", "").await.unwrap();
+
+        {
+            // Scoped: exists() below records into the same calls mutex, so
+            // the guard must drop before that call.
+            let calls = host.calls.lock().expect("calls lock");
+            let stdin = calls
+                .iter()
+                .find_map(|c| c.stdin.as_ref())
+                .expect("store must pass a stdin script");
+            let script = String::from_utf8(stdin.clone()).expect("script is UTF-8");
+            assert!(
+                script.contains("-w \"\""),
+                "empty secret must still produce a quoted value token, got: {script}"
+            );
+        }
+        assert!(backend.exists("empty-id").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn store_locked_keychain_reports_backend_locked() {
+        // Same locked-signature mapping retrieve/delete/exists already have;
+        // stderr is read for detection but never embedded in the message.
+        let host = Arc::new(LockedKeychainHost {
+            inner: TestHost::new(),
+        });
+        let err = KeychainBackend::new(host)
+            .store("id", "secret")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                VaultError::BackendLocked {
+                    interactive: true,
+                    ..
+                }
+            ),
+            "expected BackendLocked, got {err:?}"
+        );
+    }
+
     // ── Security regression: an id containing a newline must never reach
     // `security -i`'s stdin command stream — it has no escape for `\n`/`\r`,
     // so an unescaped newline in `id` would terminate the current command
@@ -1200,7 +1268,7 @@ mod tests {
             options: ExecOptions<'_>,
         ) -> Result<ExecOutput, VaultError> {
             match args.first().copied() {
-                Some("find-generic-password") | Some("delete-generic-password") => Ok(ExecOutput {
+                Some("find-generic-password") | Some("delete-generic-password") | Some("-i") => Ok(ExecOutput {
                     stdout: Vec::new(),
                     stderr: b"security: SecKeychainFindGenericPassword: User interaction is not allowed."
                         .to_vec(),

--- a/crates/vaultkeeper-core/src/backend/keychain.rs
+++ b/crates/vaultkeeper-core/src/backend/keychain.rs
@@ -228,11 +228,24 @@ impl SecretBackend for KeychainBackend {
             )
             .await?;
         if output.exit_code != 0 {
+            // Deliberately does NOT embed `output.stderr` here, unlike every
+            // other error path in this file. Every other `security`
+            // subprocess in this backend is invoked with an argv-only
+            // command (no stdin secret involved), so its stderr is safe to
+            // surface verbatim for diagnostics. This is the one process
+            // whose stdin carries the secret (in `encoded`, base64-encoded)
+            // — verified empirically that real `security -i`'s stderr never
+            // echoes the command line or `-w` value back (only a status
+            // line like `add-generic-password: returned -25299`), but that
+            // is an unenforced behavioral property of a third-party binary,
+            // not a contract this backend can rely on. Omitting stderr here
+            // entirely removes any path for a future `security` version (or
+            // an unanticipated error mode) to leak the secret or its base64
+            // encoding into a `VaultError` message that might be logged.
             return Err(VaultError::Exec {
                 message: format!(
-                    "security add-generic-password failed with exit code {}: {}",
-                    output.exit_code,
-                    String::from_utf8_lossy(&output.stderr)
+                    "security add-generic-password failed with exit code {}",
+                    output.exit_code
                 ),
                 command: "security".to_string(),
             });
@@ -616,6 +629,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn store_overwrites_an_existing_entry_via_the_pre_delete_line() {
+        // Regression coverage for the load-bearing `delete-generic-password`
+        // line that precedes `add-generic-password` in store()'s -i script:
+        // without it, a second store() for the same id would fail with the
+        // real `security`'s "item already exists" error (verified
+        // empirically — see module docs), since add-generic-password alone
+        // never overwrites. TestHost's `run_interactive_script` mirrors
+        // that duplicate-add failure, so this test genuinely fails if the
+        // pre-delete line is removed.
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+
+        backend.store("upsert-id", "first-value").await.unwrap();
+        assert_eq!(backend.retrieve("upsert-id").await.unwrap(), "first-value");
+
+        backend
+            .store("upsert-id", "second-value")
+            .await
+            .expect("storing the same id again must succeed by overwriting, not erroring");
+        assert_eq!(
+            backend.retrieve("upsert-id").await.unwrap(),
+            "second-value",
+            "the second store must have replaced the first value"
+        );
+    }
+
+    #[tokio::test]
     async fn store_passes_secret_and_its_base64_encoding_on_stdin_not_argv() {
         let host = TestHost::new();
         let backend = KeychainBackend::new(host.clone());
@@ -925,6 +965,81 @@ mod tests {
         assert!(
             matches!(err, VaultError::Exec { ref command, .. } if command == "security"),
             "expected VaultError::Exec carrying the failing command, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_failure_never_embeds_raw_stderr_in_the_error_message() {
+        // Unlike every other error path in this file, store()'s error
+        // message must never echo `security`'s stderr verbatim: it's the
+        // one subprocess whose stdin carries the secret, so an
+        // unanticipated future `security` error mode that echoes its input
+        // back on stderr must not have a path into a `VaultError` message
+        // that could get logged. Fake a stderr that would fail this test if
+        // it leaked through — including the base64 form of a sentinel
+        // secret, mirroring how the real secret is encoded before it's
+        // embedded in the -i script.
+        struct EchoingStderrHost {
+            inner: Arc<TestHost>,
+        }
+
+        const SENTINEL: &str = "store-error-sentinel-should-never-leak-into-message";
+
+        #[async_trait::async_trait]
+        impl HostPlatform for EchoingStderrHost {
+            async fn exec(
+                &self,
+                _cmd: &str,
+                _args: &[&str],
+                _options: ExecOptions<'_>,
+            ) -> Result<ExecOutput, VaultError> {
+                let encoded = Base64::encode_string(SENTINEL.as_bytes());
+                Ok(ExecOutput {
+                    stdout: Vec::new(),
+                    stderr: format!(
+                        "security: unexpected error near `add-generic-password -a vaultkeeper \
+                         -s \"vaultkeeper:id\" -w {encoded}`"
+                    )
+                    .into_bytes(),
+                    exit_code: 1,
+                })
+            }
+            async fn read_file(&self, p: &Path) -> Result<Vec<u8>, VaultError> {
+                self.inner.read_file(p).await
+            }
+            async fn write_file(&self, p: &Path, c: &[u8], m: u32) -> Result<(), VaultError> {
+                self.inner.write_file(p, c, m).await
+            }
+            async fn file_exists(&self, p: &Path) -> Result<bool, VaultError> {
+                self.inner.file_exists(p).await
+            }
+            async fn delete_file(&self, p: &Path) -> Result<(), VaultError> {
+                self.inner.delete_file(p).await
+            }
+            async fn list_dir(&self, p: &Path) -> Result<Vec<String>, VaultError> {
+                self.inner.list_dir(p).await
+            }
+            fn platform(&self) -> Platform {
+                self.inner.platform()
+            }
+            fn config_dir(&self) -> &Path {
+                self.inner.config_dir()
+            }
+        }
+
+        let host = Arc::new(EchoingStderrHost {
+            inner: TestHost::new(),
+        });
+        let err = KeychainBackend::new(host)
+            .store("id", SENTINEL)
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+        let encoded = Base64::encode_string(SENTINEL.as_bytes());
+        assert!(
+            !message.contains(SENTINEL) && !message.contains(&encoded),
+            "store()'s error message must never embed raw stderr (which could carry the \
+             secret or its base64 encoding): {message:?}"
         );
     }
 

--- a/crates/vaultkeeper-core/src/backend/keychain.rs
+++ b/crates/vaultkeeper-core/src/backend/keychain.rs
@@ -1,0 +1,1029 @@
+//! macOS Keychain backend, driven via the `security(1)` CLI.
+//!
+//! Ports the TypeScript `KeychainBackend`
+//! (`packages/vaultkeeper/src/backend/keychain-backend.ts`) into
+//! `vaultkeeper-core`, unchanged in wire behavior: same account/service
+//! naming (`vaultkeeper` account, `vaultkeeper:<id>` service), same
+//! base64-encoded generic-password storage. Entries written by either
+//! implementation are mutually readable because the naming scheme below is
+//! byte-for-byte identical to the TS backend's.
+//!
+//! # The `store` argv-leak problem, and its resolution (issue #290)
+//!
+//! The TS backend's `store()` passes the base64-encoded secret as
+//! `security add-generic-password ... -w <encoded>` — a plain argv command.
+//! That puts the secret in this process's argv, visible to `ps`/Activity
+//! Monitor for the (brief) lifetime of the child process. `security`'s
+//! direct `-w` flag has no stdin channel: `-w <value>` always puts `<value>`
+//! in argv, and `-w` with no value falls back to an interactive `getpass()`
+//! TTY prompt that ignores piped stdin (verified empirically: piping a
+//! command stream at a bare trailing `-w` produces `password data for new
+//! item: retype password for new item:` prompt text and does not read the
+//! intended value).
+//!
+//! **Resolution:** `security -i` ("interactive mode") reads *multiple*
+//! commands from stdin, one per line, until EOF — see `man security`. Run as
+//! `security -i` with no other argv, the OS-visible argv is just `security
+//! -i`; the entire `add-generic-password ... -w <value>` command instead
+//! rides the stdin command stream, never touching argv. This was verified
+//! directly before implementation:
+//!
+//! ```text
+//! $ printf 'add-generic-password -a t -s vk-spike -w dGVzdA==\n' | security -i
+//! $ security find-generic-password -a t -s vk-spike -w
+//! dGVzdA==
+//! ```
+//!
+//! The value came back byte-for-byte, confirming `-w <value>` is parsed off
+//! the `-i` stdin stream rather than diverted to the TTY prompt. `store()`
+//! stays a plain [`HostPlatform::exec`] call (which already carries stdin) —
+//! no Security.framework FFI, no host split, no wasm-portability loss.
+//!
+//! base64-encoding the secret before it enters the stdin script is *load
+//! -bearing* and is kept unchanged from the TS backend: the base64 alphabet
+//! (`A-Za-z0-9+/=`) contains no character `security -i`'s command tokenizer
+//! treats specially, so `-w <base64>` is always exactly one clean token
+//! regardless of what bytes the underlying secret contains.
+//!
+//! ## Scope: only `store` uses the command stream
+//!
+//! `retrieve` (`find-generic-password -w`, secret on stdout only),
+//! `delete`/`exists` (no secret in argv at all), and `list`
+//! (`dump-keychain` + parse) are all argv-safe as plain `security <args...>`
+//! exec calls — porting them 1:1 from the TS backend needs no `-i` handling.
+//!
+//! ## Quoting the account/service tokens in the `-i` stdin script
+//!
+//! Unlike a plain argv call, the `-i` stdin stream is *tokenized by
+//! `security` itself* (its own quoting rules, not the shell's). The account
+//! (`vaultkeeper`, a fixed constant) and service (`vaultkeeper:<id>`, where
+//! `<id>` is caller-supplied) are embedded as double-quoted tokens with `\`
+//! and `"` backslash-escaped, verified empirically to round-trip service
+//! names containing spaces, embedded double quotes, and embedded backslashes
+//! correctly through `security -i`. An embedded newline in `<id>` is not
+//! escaped by this scheme (it would prematurely terminate the `-i` command
+//! line) — `id` values are expected to be single-line identifiers, as they
+//! are everywhere else in vaultkeeper.
+//!
+//! ## Coordination with #270
+//!
+//! The TS `KeychainBackend`'s argv leak is also tracked as standalone defect
+//! #270. This Rust-core port supersedes it with the `security -i` design
+//! described above; #270 is left open to apply the equivalent fix to the TS
+//! implementation, which this PR does not touch.
+
+use crate::backend::types::{ExecOptions, HostPlatform, ListableBackend, Platform, SecretBackend};
+use crate::errors::VaultError;
+use base64ct::{Base64, Encoding};
+use std::sync::Arc;
+
+/// Keychain account used for every vaultkeeper-managed entry. Must match the
+/// TS backend's `ACCOUNT` exactly.
+const ACCOUNT: &str = "vaultkeeper";
+
+/// Service name prefix applied to every vaultkeeper-managed entry. Must
+/// match the TS backend's `SERVICE_PREFIX` exactly.
+const SERVICE_PREFIX: &str = "vaultkeeper:";
+
+/// macOS Keychain secret backend, driven entirely through `security(1)`
+/// subprocess calls via [`HostPlatform::exec`].
+///
+/// Only meaningfully available on Darwin (macOS) with the `security` CLI on
+/// PATH.
+pub struct KeychainBackend {
+    host: Arc<dyn HostPlatform>,
+}
+
+impl KeychainBackend {
+    /// Create a new `KeychainBackend` using the given host for subprocess
+    /// orchestration.
+    pub fn new(host: Arc<dyn HostPlatform>) -> Self {
+        Self { host }
+    }
+
+    fn service_name(id: &str) -> String {
+        format!("{SERVICE_PREFIX}{id}")
+    }
+
+    /// Quote `value` as a single token for `security -i`'s stdin command
+    /// tokenizer: wrap in double quotes, backslash-escaping any embedded `\`
+    /// or `"` — verified empirically (see module docs) to round-trip
+    /// spaces, embedded double quotes, and embedded backslashes.
+    fn quote_for_interactive_stream(value: &str) -> String {
+        let mut quoted = String::with_capacity(value.len() + 2);
+        quoted.push('"');
+        for c in value.chars() {
+            if c == '\\' || c == '"' {
+                quoted.push('\\');
+            }
+            quoted.push(c);
+        }
+        quoted.push('"');
+        quoted
+    }
+
+    /// Parse a `security dump-keychain` attribute line for the
+    /// `0x00000007 <blob>=...` (service name) attribute, returning the raw
+    /// UTF-8 string value regardless of which of `security`'s two display
+    /// forms was used:
+    ///
+    /// - Plain quoted form (fully printable ASCII): `="<value>"`.
+    /// - Hex + octal-escaped display form (any byte outside printable ASCII,
+    ///   including `\`): `=0x<HEX>  "<octal-escaped display>"` — the hex
+    ///   digits are the authoritative raw bytes; the quoted text afterwards
+    ///   is only a lossy human-readable rendering, so this parses the hex
+    ///   form when present rather than the ambiguous quoted display.
+    fn parse_service_attribute_line(line: &str) -> Option<String> {
+        let rest = line.trim_start().strip_prefix("0x00000007 <blob>=")?;
+        if let Some(hex) = rest.strip_prefix("0x") {
+            let hex_digits: String = hex.chars().take_while(|c| c.is_ascii_hexdigit()).collect();
+            if hex_digits.is_empty() || !hex_digits.len().is_multiple_of(2) {
+                return None;
+            }
+            let mut bytes = Vec::with_capacity(hex_digits.len() / 2);
+            let hex_bytes = hex_digits.as_bytes();
+            for chunk in hex_bytes.chunks(2) {
+                let byte_str = std::str::from_utf8(chunk).ok()?;
+                bytes.push(u8::from_str_radix(byte_str, 16).ok()?);
+            }
+            String::from_utf8(bytes).ok()
+        } else {
+            let quoted = rest.strip_prefix('"')?;
+            let end = quoted.find('"')?;
+            Some(quoted[..end].to_string())
+        }
+    }
+
+    /// Parse every `vaultkeeper:<id>` service name out of `security
+    /// dump-keychain` output, returning the bare `<id>` portion — mirrors
+    /// the TS backend's `/0x00000007 <blob>="vaultkeeper:([^"]+)"/g` regex,
+    /// generalized to also cover `security`'s hex-escaped display form for
+    /// non-printable-ASCII names (see [`Self::parse_service_attribute_line`]).
+    fn parse_dump_ids(stdout: &str) -> Vec<String> {
+        stdout
+            .lines()
+            .filter_map(Self::parse_service_attribute_line)
+            .filter_map(|service| service.strip_prefix(SERVICE_PREFIX).map(str::to_string))
+            .collect()
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl SecretBackend for KeychainBackend {
+    fn backend_type(&self) -> &str {
+        "keychain"
+    }
+
+    fn display_name(&self) -> &str {
+        "macOS Keychain"
+    }
+
+    async fn is_available(&self) -> bool {
+        if self.host.platform() != Platform::Darwin {
+            return false;
+        }
+        // `security version` is not a real subcommand (verified empirically
+        // to always fail with "unknown command"), unlike the TS backend's
+        // probe which relies on it. `list-keychains` is a real, read-only,
+        // side-effect-free command that both confirms `security` is on PATH
+        // and that it can actually talk to the keychain subsystem.
+        match self
+            .host
+            .exec("security", &["list-keychains"], ExecOptions::default())
+            .await
+        {
+            Ok(output) => output.exit_code == 0,
+            Err(_) => false,
+        }
+    }
+
+    async fn store(&self, id: &str, secret: &str) -> Result<(), VaultError> {
+        let service = Self::service_name(id);
+        let account_token = Self::quote_for_interactive_stream(ACCOUNT);
+        let service_token = Self::quote_for_interactive_stream(&service);
+        let encoded = Base64::encode_string(secret.as_bytes());
+
+        // Single `security -i` process for the whole store operation (both
+        // the pre-delete of any existing entry and the fresh add), so the
+        // secret's only appearance anywhere is on this one process's stdin.
+        // `security -i`'s overall exit code reflects the *last* command run
+        // in the stream, so a failing pre-delete (no prior entry) followed
+        // by a successful add still yields exit code 0 — verified
+        // empirically (see module docs).
+        let script = format!(
+            "delete-generic-password -a {account_token} -s {service_token}\n\
+             add-generic-password -a {account_token} -s {service_token} -w {encoded}\n"
+        );
+
+        let output = self
+            .host
+            .exec(
+                "security",
+                &["-i"],
+                ExecOptions {
+                    stdin: Some(script.as_bytes()),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        if output.exit_code != 0 {
+            return Err(VaultError::Exec {
+                message: format!(
+                    "security add-generic-password failed with exit code {}: {}",
+                    output.exit_code,
+                    String::from_utf8_lossy(&output.stderr)
+                ),
+                command: "security".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn retrieve(&self, id: &str) -> Result<String, VaultError> {
+        let service = Self::service_name(id);
+        let output = self
+            .host
+            .exec(
+                "security",
+                &[
+                    "find-generic-password",
+                    "-a",
+                    ACCOUNT,
+                    "-s",
+                    service.as_str(),
+                    "-w",
+                ],
+                ExecOptions::default(),
+            )
+            .await?;
+        if output.exit_code != 0 {
+            return Err(VaultError::SecretNotFound {
+                message: format!("Secret not found in macOS Keychain: {id}"),
+            });
+        }
+        let encoded = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let decoded = Base64::decode_vec(&encoded).map_err(|e| {
+            VaultError::Other(format!(
+                "macOS Keychain returned malformed base64 for {id}: {e}"
+            ))
+        })?;
+        String::from_utf8(decoded).map_err(|e| {
+            VaultError::Other(format!(
+                "macOS Keychain entry for {id} decoded to invalid UTF-8: {e}"
+            ))
+        })
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), VaultError> {
+        let service = Self::service_name(id);
+        let output = self
+            .host
+            .exec(
+                "security",
+                &[
+                    "delete-generic-password",
+                    "-a",
+                    ACCOUNT,
+                    "-s",
+                    service.as_str(),
+                ],
+                ExecOptions::default(),
+            )
+            .await?;
+        if output.exit_code != 0 {
+            return Err(VaultError::SecretNotFound {
+                message: format!("Secret not found in macOS Keychain: {id}"),
+            });
+        }
+        Ok(())
+    }
+
+    async fn exists(&self, id: &str) -> Result<bool, VaultError> {
+        let service = Self::service_name(id);
+        let output = self
+            .host
+            .exec(
+                "security",
+                &[
+                    "find-generic-password",
+                    "-a",
+                    ACCOUNT,
+                    "-s",
+                    service.as_str(),
+                ],
+                ExecOptions::default(),
+            )
+            .await?;
+        Ok(output.exit_code == 0)
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ListableBackend for KeychainBackend {
+    async fn list(&self) -> Result<Vec<String>, VaultError> {
+        let output = self
+            .host
+            .exec("security", &["dump-keychain"], ExecOptions::default())
+            .await?;
+        if output.exit_code != 0 {
+            return Ok(Vec::new());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Ok(Self::parse_dump_ids(&stdout))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::ExecOutput;
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+
+    /// Records every `exec` invocation (command, args, stdin) so tests can
+    /// assert on exactly what was shelled out — in particular, the
+    /// argv-sentinel assertion for AC1.
+    #[derive(Debug, Clone)]
+    struct RecordedExec {
+        cmd: String,
+        args: Vec<String>,
+        stdin: Option<Vec<u8>>,
+    }
+
+    /// Test double for `HostPlatform` that fakes a macOS Keychain in memory,
+    /// keyed by service name, and records every subprocess invocation for
+    /// argv inspection. Understands the `security -i` stdin command stream
+    /// well enough to execute `delete-generic-password`/`add-generic-password`
+    /// lines against its in-memory store, mirroring the real tool's
+    /// behavior verified empirically before implementation.
+    struct TestHost {
+        config_dir: PathBuf,
+        /// service -> secret (raw bytes as returned by `-w`, i.e. base64 text)
+        entries: Mutex<std::collections::HashMap<String, String>>,
+        calls: Mutex<Vec<RecordedExec>>,
+        list_keychains_unavailable: bool,
+        platform: Platform,
+    }
+
+    impl TestHost {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                config_dir: PathBuf::from("/test/config"),
+                entries: Mutex::new(std::collections::HashMap::new()),
+                calls: Mutex::new(Vec::new()),
+                list_keychains_unavailable: false,
+                platform: Platform::Darwin,
+            })
+        }
+
+        /// Minimal re-implementation of `security -i`'s per-line tokenizer,
+        /// just enough to parse the two command shapes this backend ever
+        /// sends: `delete-generic-password -a <tok> -s <tok>` and
+        /// `add-generic-password -a <tok> -s <tok> -w <value>`, where `<tok>`
+        /// may be a double-quoted, backslash-escaped token.
+        fn tokenize(line: &str) -> Vec<String> {
+            let mut tokens = Vec::new();
+            let mut chars = line.chars().peekable();
+            while let Some(&c) = chars.peek() {
+                if c.is_whitespace() {
+                    chars.next();
+                    continue;
+                }
+                if c == '"' {
+                    chars.next();
+                    let mut token = String::new();
+                    while let Some(c) = chars.next() {
+                        if c == '\\' {
+                            if let Some(escaped) = chars.next() {
+                                token.push(escaped);
+                            }
+                        } else if c == '"' {
+                            break;
+                        } else {
+                            token.push(c);
+                        }
+                    }
+                    tokens.push(token);
+                } else {
+                    let mut token = String::new();
+                    while let Some(&c) = chars.peek() {
+                        if c.is_whitespace() {
+                            break;
+                        }
+                        token.push(c);
+                        chars.next();
+                    }
+                    tokens.push(token);
+                }
+            }
+            tokens
+        }
+
+        fn run_interactive_script(&self, script: &str) -> ExecOutput {
+            let mut last_exit_code = 0;
+            let mut stderr = Vec::new();
+            for line in script.lines() {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let tokens = Self::tokenize(line);
+                match tokens.first().map(String::as_str) {
+                    Some("delete-generic-password") => {
+                        let service = tokens.get(4).expect("service token").clone();
+                        let removed = self.entries.lock().unwrap().remove(&service).is_some();
+                        last_exit_code = if removed { 0 } else { 45 };
+                        if !removed {
+                            stderr.extend_from_slice(b"item not found\n");
+                        }
+                    }
+                    Some("add-generic-password") => {
+                        let service = tokens.get(4).expect("service token").clone();
+                        let value = tokens.get(6).expect("-w value token").clone();
+                        let mut entries = self.entries.lock().unwrap();
+                        if let std::collections::hash_map::Entry::Vacant(e) = entries.entry(service)
+                        {
+                            e.insert(value);
+                            last_exit_code = 0;
+                        } else {
+                            last_exit_code = 45;
+                            stderr.extend_from_slice(b"item already exists\n");
+                        }
+                    }
+                    other => panic!("unexpected -i command in test: {other:?}"),
+                }
+            }
+            ExecOutput {
+                stdout: Vec::new(),
+                stderr,
+                exit_code: last_exit_code,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl HostPlatform for TestHost {
+        async fn exec(
+            &self,
+            cmd: &str,
+            args: &[&str],
+            options: ExecOptions<'_>,
+        ) -> Result<ExecOutput, VaultError> {
+            self.calls.lock().unwrap().push(RecordedExec {
+                cmd: cmd.to_string(),
+                args: args.iter().map(|s| s.to_string()).collect(),
+                stdin: options.stdin.map(|s| s.to_vec()),
+            });
+
+            match args.first().copied() {
+                Some("list-keychains") => {
+                    if self.list_keychains_unavailable {
+                        return Ok(ExecOutput {
+                            stdout: Vec::new(),
+                            stderr: b"command not found".to_vec(),
+                            exit_code: 127,
+                        });
+                    }
+                    Ok(ExecOutput {
+                        stdout: b"\"/test/login.keychain-db\"\n".to_vec(),
+                        stderr: Vec::new(),
+                        exit_code: 0,
+                    })
+                }
+                Some("-i") => {
+                    let script = options
+                        .stdin
+                        .map(|b| String::from_utf8_lossy(b).to_string())
+                        .unwrap_or_default();
+                    Ok(self.run_interactive_script(&script))
+                }
+                Some("find-generic-password") => {
+                    let service = args.get(4).expect("service arg").to_string();
+                    let wants_value = args.contains(&"-w");
+                    match self.entries.lock().unwrap().get(&service) {
+                        Some(value) => Ok(ExecOutput {
+                            stdout: if wants_value {
+                                format!("{value}\n").into_bytes()
+                            } else {
+                                Vec::new()
+                            },
+                            stderr: Vec::new(),
+                            exit_code: 0,
+                        }),
+                        None => Ok(ExecOutput {
+                            stdout: Vec::new(),
+                            stderr: b"The specified item could not be found in the keychain."
+                                .to_vec(),
+                            exit_code: 44,
+                        }),
+                    }
+                }
+                Some("delete-generic-password") => {
+                    let service = args.get(4).expect("service arg").to_string();
+                    let removed = self.entries.lock().unwrap().remove(&service).is_some();
+                    Ok(ExecOutput {
+                        stdout: Vec::new(),
+                        stderr: if removed {
+                            Vec::new()
+                        } else {
+                            b"The specified item could not be found in the keychain.".to_vec()
+                        },
+                        exit_code: if removed { 0 } else { 44 },
+                    })
+                }
+                Some("dump-keychain") => {
+                    let entries = self.entries.lock().unwrap();
+                    let mut stdout = String::new();
+                    for service in entries.keys() {
+                        let is_plain_ascii = service
+                            .bytes()
+                            .all(|b| (0x20..0x7f).contains(&b) && b != b'\\');
+                        stdout.push_str("attributes:\n");
+                        if is_plain_ascii {
+                            stdout.push_str(&format!("    0x00000007 <blob>=\"{service}\"\n"));
+                        } else {
+                            let hex: String = service.bytes().map(|b| format!("{b:02X}")).collect();
+                            stdout.push_str(&format!(
+                                "    0x00000007 <blob>=0x{hex}  \"{service}\"\n"
+                            ));
+                        }
+                    }
+                    Ok(ExecOutput {
+                        stdout: stdout.into_bytes(),
+                        stderr: Vec::new(),
+                        exit_code: 0,
+                    })
+                }
+                other => panic!("unexpected security invocation: {other:?}"),
+            }
+        }
+        async fn read_file(&self, _path: &Path) -> Result<Vec<u8>, VaultError> {
+            panic!("KeychainBackend must not touch the filesystem")
+        }
+        async fn write_file(
+            &self,
+            _path: &Path,
+            _content: &[u8],
+            _mode: u32,
+        ) -> Result<(), VaultError> {
+            panic!("KeychainBackend must not touch the filesystem")
+        }
+        async fn file_exists(&self, _path: &Path) -> Result<bool, VaultError> {
+            panic!("KeychainBackend must not touch the filesystem")
+        }
+        async fn delete_file(&self, _path: &Path) -> Result<(), VaultError> {
+            panic!("KeychainBackend must not touch the filesystem")
+        }
+        async fn list_dir(&self, _path: &Path) -> Result<Vec<String>, VaultError> {
+            panic!("KeychainBackend must not touch the filesystem")
+        }
+        fn platform(&self) -> Platform {
+            self.platform
+        }
+        fn config_dir(&self) -> &Path {
+            &self.config_dir
+        }
+    }
+
+    // ── AC4 (naming parity): account/service scheme matches the TS backend ─
+
+    #[test]
+    fn account_matches_ts_backend() {
+        // packages/vaultkeeper/src/backend/keychain-backend.ts: ACCOUNT
+        assert_eq!(ACCOUNT, "vaultkeeper");
+    }
+
+    #[test]
+    fn service_prefix_matches_ts_backend() {
+        // packages/vaultkeeper/src/backend/keychain-backend.ts: SERVICE_PREFIX
+        assert_eq!(SERVICE_PREFIX, "vaultkeeper:");
+    }
+
+    // ── AC1: store is argv-safe — the secret only ever travels on stdin,
+    // as a single `security -i` process ─────────────────────────────────
+
+    #[tokio::test]
+    async fn store_issues_a_single_security_interactive_process() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        backend.store("my-secret", "secret-value").await.unwrap();
+
+        let calls = host.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "store should issue exactly one exec call");
+        assert_eq!(calls[0].cmd, "security");
+        assert_eq!(calls[0].args, vec!["-i"]);
+    }
+
+    #[tokio::test]
+    async fn store_passes_secret_and_its_base64_encoding_on_stdin_not_argv() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        const SENTINEL: &str = "argv-sentinel-should-never-appear-in-args";
+        backend.store("sentinel-id", SENTINEL).await.unwrap();
+
+        let encoded = Base64::encode_string(SENTINEL.as_bytes());
+        let calls = host.calls.lock().unwrap();
+        for call in calls.iter() {
+            assert!(
+                call.args.iter().all(|a| !a.contains(SENTINEL)),
+                "the secret must never appear in child process argv: {:?}",
+                call.args
+            );
+            assert!(
+                call.args.iter().all(|a| !a.contains(&encoded)),
+                "the base64-encoded secret must never appear in child process argv: {:?}",
+                call.args
+            );
+        }
+        let stdin = calls[0]
+            .stdin
+            .as_ref()
+            .expect("store's exec call must carry stdin");
+        let script = String::from_utf8_lossy(stdin);
+        assert!(
+            script.contains(&encoded),
+            "the base64-encoded secret must be delivered on stdin: {script:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_argv_sentinel_survives_full_round_trip() {
+        // Broader regression: run store -> retrieve -> exists -> delete and
+        // assert the sentinel never leaked into argv at any step, not just
+        // store.
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        const SENTINEL: &str = "super-secret-value-42";
+
+        backend.store("rt-id", SENTINEL).await.unwrap();
+        let retrieved = backend.retrieve("rt-id").await.unwrap();
+        assert_eq!(retrieved, SENTINEL);
+        assert!(backend.exists("rt-id").await.unwrap());
+        backend.delete("rt-id").await.unwrap();
+
+        let encoded = Base64::encode_string(SENTINEL.as_bytes());
+        let calls = host.calls.lock().unwrap();
+        for call in calls.iter() {
+            assert!(
+                call.args.iter().all(|a| !a.contains(SENTINEL)),
+                "the secret must never appear in child process argv at any step: {:?}",
+                call.args
+            );
+            assert!(
+                call.args.iter().all(|a| !a.contains(&encoded)),
+                "the base64-encoded secret must never appear in child process argv at any step: {:?}",
+                call.args
+            );
+        }
+    }
+
+    // ── AC2: byte-for-byte round trip of spaces/quotes/newlines/non-ASCII ──
+
+    #[tokio::test]
+    async fn round_trips_secret_with_spaces_quotes_and_embedded_newlines() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let secret = "hello \"world\" 'quoted'\nmiddle line\nend";
+        backend.store("spaces-quotes-id", secret).await.unwrap();
+        let retrieved = backend.retrieve("spaces-quotes-id").await.unwrap();
+        assert_eq!(retrieved, secret);
+    }
+
+    #[tokio::test]
+    async fn round_trips_non_ascii_secret_byte_for_byte() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let secret = "pässwörd-日本語-emoji-🔐-Ñoño";
+        backend.store("non-ascii-id", secret).await.unwrap();
+        let retrieved = backend.retrieve("non-ascii-id").await.unwrap();
+        assert_eq!(retrieved, secret);
+    }
+
+    #[tokio::test]
+    async fn round_trips_id_containing_spaces_and_quotes() {
+        // The id (not just the secret) must survive `security -i`'s own
+        // tokenizer once embedded in the service-name token.
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let id = "my id with \"quotes\" and \\backslash";
+        backend.store(id, "value").await.unwrap();
+        assert!(backend.exists(id).await.unwrap());
+        assert_eq!(backend.retrieve(id).await.unwrap(), "value");
+    }
+
+    // ── AC3: retrieve/delete/exists/list are plain exec calls ──────────────
+
+    #[tokio::test]
+    async fn retrieve_delete_exists_are_plain_argv_exec_calls() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        backend.store("plain-id", "value").await.unwrap();
+
+        host.calls.lock().unwrap().clear();
+        assert_eq!(backend.retrieve("plain-id").await.unwrap(), "value");
+        assert!(backend.exists("plain-id").await.unwrap());
+        backend.delete("plain-id").await.unwrap();
+
+        let calls = host.calls.lock().unwrap();
+        assert_eq!(calls.len(), 3);
+        for call in calls.iter() {
+            assert_ne!(
+                call.args.first().map(String::as_str),
+                Some("-i"),
+                "retrieve/exists/delete must never use interactive mode: {:?}",
+                call.args
+            );
+            assert!(
+                call.stdin.is_none(),
+                "retrieve/exists/delete must not carry stdin: {:?}",
+                call.args
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn list_parses_plain_and_hex_escaped_dump_keychain_entries() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        backend.store("alpha", "val-a").await.unwrap();
+        backend
+            .store("awkward name: with spaces", "val-b")
+            .await
+            .unwrap();
+        backend.store("日本語-emoji-🔐", "val-c").await.unwrap();
+
+        let mut ids = backend.list().await.unwrap();
+        ids.sort();
+        let mut expected = vec!["alpha", "awkward name: with spaces", "日本語-emoji-🔐"];
+        expected.sort_unstable();
+        assert_eq!(ids, expected);
+    }
+
+    #[test]
+    fn parse_dump_ids_matches_ts_backend_output_shape() {
+        // Mirrors the fixture in
+        // packages/vaultkeeper/test/unit/backend/keychain-backend.test.ts
+        let stdout = [
+            "keychain: \"/test/login.keychain-db\"",
+            "attributes:",
+            "    0x00000007 <blob>=\"vaultkeeper:my-secret\"",
+            "    0x00000008 <blob>=<NULL>",
+            "attributes:",
+            "    0x00000007 <blob>=\"vaultkeeper:another-secret\"",
+        ]
+        .join("\n");
+
+        let ids = KeychainBackend::parse_dump_ids(&stdout);
+        assert_eq!(ids, vec!["my-secret", "another-secret"]);
+    }
+
+    #[test]
+    fn parse_dump_ids_ignores_entries_without_the_vaultkeeper_prefix() {
+        let stdout = "    0x00000007 <blob>=\"some-other-app:unrelated\"\n";
+        let ids = KeychainBackend::parse_dump_ids(stdout);
+        assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_returns_empty_when_dump_keychain_fails() {
+        struct FailingDumpHost {
+            inner: Arc<TestHost>,
+        }
+
+        #[async_trait::async_trait]
+        impl HostPlatform for FailingDumpHost {
+            async fn exec(
+                &self,
+                cmd: &str,
+                args: &[&str],
+                options: ExecOptions<'_>,
+            ) -> Result<ExecOutput, VaultError> {
+                if args.first().copied() == Some("dump-keychain") {
+                    return Ok(ExecOutput {
+                        stdout: Vec::new(),
+                        stderr: b"keychain locked".to_vec(),
+                        exit_code: 1,
+                    });
+                }
+                self.inner.exec(cmd, args, options).await
+            }
+            async fn read_file(&self, p: &Path) -> Result<Vec<u8>, VaultError> {
+                self.inner.read_file(p).await
+            }
+            async fn write_file(&self, p: &Path, c: &[u8], m: u32) -> Result<(), VaultError> {
+                self.inner.write_file(p, c, m).await
+            }
+            async fn file_exists(&self, p: &Path) -> Result<bool, VaultError> {
+                self.inner.file_exists(p).await
+            }
+            async fn delete_file(&self, p: &Path) -> Result<(), VaultError> {
+                self.inner.delete_file(p).await
+            }
+            async fn list_dir(&self, p: &Path) -> Result<Vec<String>, VaultError> {
+                self.inner.list_dir(p).await
+            }
+            fn platform(&self) -> Platform {
+                self.inner.platform()
+            }
+            fn config_dir(&self) -> &Path {
+                self.inner.config_dir()
+            }
+        }
+
+        let host = Arc::new(FailingDumpHost {
+            inner: TestHost::new(),
+        });
+        let backend = KeychainBackend::new(host);
+        assert_eq!(backend.list().await.unwrap(), Vec::<String>::new());
+    }
+
+    // ── AC4 (negative): missing entries and exec failures surface typed
+    // errors, never a partial/garbage secret ───────────────────────────────
+
+    #[tokio::test]
+    async fn retrieve_missing_returns_secret_not_found() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host);
+        let err = backend.retrieve("nonexistent").await.unwrap_err();
+        assert!(
+            matches!(err, VaultError::SecretNotFound { .. }),
+            "expected SecretNotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_missing_returns_secret_not_found() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host);
+        let err = backend.delete("nonexistent").await.unwrap_err();
+        assert!(
+            matches!(err, VaultError::SecretNotFound { .. }),
+            "expected SecretNotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exists_returns_false_for_missing_and_true_for_present() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host);
+        assert!(!backend.exists("nonexistent").await.unwrap());
+        backend.store("present-id", "value").await.unwrap();
+        assert!(backend.exists("present-id").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn store_failure_surfaces_typed_error_not_panic() {
+        struct FailingHost {
+            inner: Arc<TestHost>,
+        }
+
+        #[async_trait::async_trait]
+        impl HostPlatform for FailingHost {
+            async fn exec(
+                &self,
+                _cmd: &str,
+                _args: &[&str],
+                _options: ExecOptions<'_>,
+            ) -> Result<ExecOutput, VaultError> {
+                Ok(ExecOutput {
+                    stdout: Vec::new(),
+                    stderr: b"security: SecKeychainItemCreateFromContent: keychain locked".to_vec(),
+                    exit_code: 45,
+                })
+            }
+            async fn read_file(&self, p: &Path) -> Result<Vec<u8>, VaultError> {
+                self.inner.read_file(p).await
+            }
+            async fn write_file(&self, p: &Path, c: &[u8], m: u32) -> Result<(), VaultError> {
+                self.inner.write_file(p, c, m).await
+            }
+            async fn file_exists(&self, p: &Path) -> Result<bool, VaultError> {
+                self.inner.file_exists(p).await
+            }
+            async fn delete_file(&self, p: &Path) -> Result<(), VaultError> {
+                self.inner.delete_file(p).await
+            }
+            async fn list_dir(&self, p: &Path) -> Result<Vec<String>, VaultError> {
+                self.inner.list_dir(p).await
+            }
+            fn platform(&self) -> Platform {
+                self.inner.platform()
+            }
+            fn config_dir(&self) -> &Path {
+                self.inner.config_dir()
+            }
+        }
+
+        let host = Arc::new(FailingHost {
+            inner: TestHost::new(),
+        });
+        let err = KeychainBackend::new(host)
+            .store("id", "secret")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, VaultError::Exec { ref command, .. } if command == "security"),
+            "expected VaultError::Exec carrying the failing command, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn retrieve_surfaces_typed_error_on_malformed_base64_not_garbage_secret() {
+        struct GarbageHost {
+            inner: Arc<TestHost>,
+        }
+
+        #[async_trait::async_trait]
+        impl HostPlatform for GarbageHost {
+            async fn exec(
+                &self,
+                cmd: &str,
+                args: &[&str],
+                options: ExecOptions<'_>,
+            ) -> Result<ExecOutput, VaultError> {
+                if args.first().copied() == Some("find-generic-password") {
+                    return Ok(ExecOutput {
+                        stdout: b"not-valid-base64!!!\n".to_vec(),
+                        stderr: Vec::new(),
+                        exit_code: 0,
+                    });
+                }
+                self.inner.exec(cmd, args, options).await
+            }
+            async fn read_file(&self, p: &Path) -> Result<Vec<u8>, VaultError> {
+                self.inner.read_file(p).await
+            }
+            async fn write_file(&self, p: &Path, c: &[u8], m: u32) -> Result<(), VaultError> {
+                self.inner.write_file(p, c, m).await
+            }
+            async fn file_exists(&self, p: &Path) -> Result<bool, VaultError> {
+                self.inner.file_exists(p).await
+            }
+            async fn delete_file(&self, p: &Path) -> Result<(), VaultError> {
+                self.inner.delete_file(p).await
+            }
+            async fn list_dir(&self, p: &Path) -> Result<Vec<String>, VaultError> {
+                self.inner.list_dir(p).await
+            }
+            fn platform(&self) -> Platform {
+                self.inner.platform()
+            }
+            fn config_dir(&self) -> &Path {
+                self.inner.config_dir()
+            }
+        }
+
+        let host = Arc::new(GarbageHost {
+            inner: TestHost::new(),
+        });
+        let err = KeychainBackend::new(host).retrieve("id").await.unwrap_err();
+        assert!(
+            matches!(err, VaultError::Other(_)),
+            "expected a typed error (never a garbage secret), got {err:?}"
+        );
+    }
+
+    // ── Additional coverage: is_available/backend_type/display_name ────────
+
+    #[tokio::test]
+    async fn is_available_false_on_non_darwin_platform() {
+        let host = Arc::new(TestHost {
+            config_dir: PathBuf::from("/test/config"),
+            entries: Mutex::new(std::collections::HashMap::new()),
+            calls: Mutex::new(Vec::new()),
+            list_keychains_unavailable: false,
+            platform: Platform::Linux,
+        });
+        let backend = KeychainBackend::new(host);
+        assert!(!backend.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn is_available_true_on_darwin_when_security_responds() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host);
+        assert!(backend.is_available().await);
+    }
+
+    #[tokio::test]
+    async fn is_available_false_when_security_not_installed() {
+        let host = Arc::new(TestHost {
+            config_dir: PathBuf::from("/test/config"),
+            entries: Mutex::new(std::collections::HashMap::new()),
+            calls: Mutex::new(Vec::new()),
+            list_keychains_unavailable: true,
+            platform: Platform::Darwin,
+        });
+        let backend = KeychainBackend::new(host);
+        assert!(!backend.is_available().await);
+    }
+
+    #[test]
+    fn backend_type_and_display_name() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host);
+        assert_eq!(backend.backend_type(), "keychain");
+        assert_eq!(backend.display_name(), "macOS Keychain");
+    }
+}

--- a/crates/vaultkeeper-core/src/backend/keychain.rs
+++ b/crates/vaultkeeper-core/src/backend/keychain.rs
@@ -39,8 +39,8 @@
 //! stays a plain [`HostPlatform::exec`] call (which already carries stdin) —
 //! no Security.framework FFI, no host split, no wasm-portability loss.
 //!
-//! base64-encoding the secret before it enters the stdin script is *load
-//! -bearing* and is kept unchanged from the TS backend: the base64 alphabet
+//! base64-encoding the secret before it enters the stdin script is
+//! *load-bearing* and is kept unchanged from the TS backend: the base64 alphabet
 //! (`A-Za-z0-9+/=`) contains no character `security -i`'s command tokenizer
 //! treats specially, so `-w <base64>` is always exactly one clean token
 //! regardless of what bytes the underlying secret contains.

--- a/crates/vaultkeeper-core/src/backend/keychain.rs
+++ b/crates/vaultkeeper-core/src/backend/keychain.rs
@@ -60,10 +60,14 @@
 //! `<id>` is caller-supplied) are embedded as double-quoted tokens with `\`
 //! and `"` backslash-escaped, verified empirically to round-trip service
 //! names containing spaces, embedded double quotes, and embedded backslashes
-//! correctly through `security -i`. An embedded newline in `<id>` is not
-//! escaped by this scheme (it would prematurely terminate the `-i` command
-//! line) — `id` values are expected to be single-line identifiers, as they
-//! are everywhere else in vaultkeeper.
+//! correctly through `security -i`. An embedded newline (`\n` or `\r`) in
+//! `<id>` cannot be escaped by this scheme — it would prematurely terminate
+//! the current `-i` command line and let an attacker-controlled `id` inject
+//! arbitrary follow-on `security -i` subcommands. `id` values (and a NUL
+//! byte, which no `security` command can represent at all) are therefore
+//! **enforced** to be single-line: every public method on this backend
+//! rejects such an `id` with a typed [`VaultError`] before issuing any
+//! subprocess call at all.
 //!
 //! ## Coordination with #270
 //!
@@ -71,6 +75,23 @@
 //! #270. This Rust-core port supersedes it with the `security -i` design
 //! described above; #270 is left open to apply the equivalent fix to the TS
 //! implementation, which this PR does not touch.
+//!
+//! ## Known edge cases
+//!
+//! - **Non-atomic overwrite window.** `store()`'s `-i` script is
+//!   `delete-generic-password` immediately followed by `add-generic-password`
+//!   *within the same `security -i` process*, but `security` still executes
+//!   them as two separate Keychain operations, not one transaction. If the
+//!   delete succeeds but the add then fails (e.g. the keychain is locked or
+//!   disk-full partway through), the old secret is already gone and the new
+//!   one was never written — the entry is left missing, not merely stale.
+//! - **Cross-process store/store race.** Two processes calling `store()` for
+//!   the same `id` at the same time can both pass their own delete before
+//!   either add runs, then both add succeed (each against an
+//!   already-cleared slot) or one add fails with "item already exists" if it
+//!   loses the race to the other's add — `security` provides no
+//!   compare-and-swap primitive this backend could use to serialize the two
+//!   Keychain writes.
 
 use crate::backend::types::{ExecOptions, HostPlatform, ListableBackend, Platform, SecretBackend};
 use crate::errors::VaultError;
@@ -105,6 +126,52 @@ impl KeychainBackend {
         format!("{SERVICE_PREFIX}{id}")
     }
 
+    /// The `SecCopyErrorMessageString` text Apple's Security framework emits
+    /// for `errSecInteractionNotAllowed` (-25308) — the standard OSStatus a
+    /// locked keychain returns when a command needs to decrypt/read item
+    /// data (or otherwise requires a keychain-unlock prompt) and no
+    /// interactive session is available to show one, e.g. a headless CI
+    /// runner with no login session. `security(1)` surfaces this verbatim on
+    /// stderr. Matched case-insensitively as a substring, not tied to a
+    /// specific exit code: on a real macOS login session *with* GUI access
+    /// (verified empirically on this development machine), a locked-
+    /// keychain `find-generic-password -w` instead blocks indefinitely on an
+    /// interactive Security Agent unlock prompt rather than failing fast, so
+    /// no single fast-failing exit code could be captured live here — the
+    /// documented Apple error text is the one part of this signature that's
+    /// stable regardless of which of those two behaviors a given runner
+    /// exhibits.
+    const LOCKED_KEYCHAIN_STDERR_SIGNATURE: &str = "user interaction is not allowed";
+
+    /// True if `stderr` carries the [`Self::LOCKED_KEYCHAIN_STDERR_SIGNATURE`]
+    /// for a locked keychain that can't be read non-interactively.
+    fn is_locked_keychain_error(stderr: &[u8]) -> bool {
+        String::from_utf8_lossy(stderr)
+            .to_lowercase()
+            .contains(Self::LOCKED_KEYCHAIN_STDERR_SIGNATURE)
+    }
+
+    /// Reject an `id` containing a newline (`\n`/`\r`) or NUL byte before
+    /// any `security` subprocess is issued.
+    ///
+    /// `store()` embeds `id` inside a `security -i` stdin command stream
+    /// that `security` itself tokenizes line-by-line; a newline in `id`
+    /// cannot be escaped there and would terminate the current command
+    /// line, letting the rest of `id` be interpreted as one or more
+    /// additional `security -i` subcommands (see module docs). `retrieve`,
+    /// `delete`, and `exists` don't use the `-i` stream, but reject the same
+    /// ids for consistency: an id with an embedded newline could never have
+    /// been produced by a successful `store()` on this backend, so refusing
+    /// it uniformly avoids surprising per-method behavior.
+    fn reject_multiline_id(id: &str) -> Result<(), VaultError> {
+        if id.contains('\n') || id.contains('\r') || id.contains('\0') {
+            return Err(VaultError::Other(format!(
+                "macOS Keychain secret id must not contain a newline, carriage return, or NUL byte: {id:?}"
+            )));
+        }
+        Ok(())
+    }
+
     /// Quote `value` as a single token for `security -i`'s stdin command
     /// tokenizer: wrap in double quotes, backslash-escaping any embedded `\`
     /// or `"` — verified empirically (see module docs) to round-trip
@@ -127,12 +194,24 @@ impl KeychainBackend {
     /// UTF-8 string value regardless of which of `security`'s two display
     /// forms was used:
     ///
-    /// - Plain quoted form (fully printable ASCII): `="<value>"`.
+    /// - Plain quoted form (fully printable ASCII, no backslash): `="<value>"`.
     /// - Hex + octal-escaped display form (any byte outside printable ASCII,
-    ///   including `\`): `=0x<HEX>  "<octal-escaped display>"` — the hex
-    ///   digits are the authoritative raw bytes; the quoted text afterwards
-    ///   is only a lossy human-readable rendering, so this parses the hex
-    ///   form when present rather than the ambiguous quoted display.
+    ///   or containing a backslash): `=0x<HEX>  "<octal-escaped display>"` —
+    ///   the hex digits are the authoritative raw bytes; the quoted text
+    ///   afterwards is only a lossy human-readable rendering, so this parses
+    ///   the hex form when present rather than the ambiguous quoted display.
+    ///
+    /// The plain quoted form does **not** escape a `"` embedded in the
+    /// value — verified empirically against the real `security` binary: an
+    /// id of `ends with quote"` dumps as `="vaultkeeper:ends with quote""`,
+    /// i.e. the line simply ends with two consecutive `"` (the embedded one,
+    /// then the true closing delimiter), with no distinguishing escape
+    /// between them. Locating the *first* embedded `"` (as if it always
+    /// closed the value) truncates the id at that point and silently drops
+    /// everything after it — this parses the *last* `"` on the line as the
+    /// closing delimiter instead, which is unambiguous because `security`
+    /// never emits anything after the closing quote on a `<blob>` line
+    /// (verified empirically: no trailing whitespace or content follows).
     fn parse_service_attribute_line(line: &str) -> Option<String> {
         let rest = line.trim_start().strip_prefix("0x00000007 <blob>=")?;
         if let Some(hex) = rest.strip_prefix("0x") {
@@ -149,7 +228,7 @@ impl KeychainBackend {
             String::from_utf8(bytes).ok()
         } else {
             let quoted = rest.strip_prefix('"')?;
-            let end = quoted.find('"')?;
+            let end = quoted.rfind('"')?;
             Some(quoted[..end].to_string())
         }
     }
@@ -199,6 +278,7 @@ impl SecretBackend for KeychainBackend {
     }
 
     async fn store(&self, id: &str, secret: &str) -> Result<(), VaultError> {
+        Self::reject_multiline_id(id)?;
         let service = Self::service_name(id);
         let account_token = Self::quote_for_interactive_stream(ACCOUNT);
         let service_token = Self::quote_for_interactive_stream(&service);
@@ -254,6 +334,7 @@ impl SecretBackend for KeychainBackend {
     }
 
     async fn retrieve(&self, id: &str) -> Result<String, VaultError> {
+        Self::reject_multiline_id(id)?;
         let service = Self::service_name(id);
         let output = self
             .host
@@ -271,6 +352,14 @@ impl SecretBackend for KeychainBackend {
             )
             .await?;
         if output.exit_code != 0 {
+            if Self::is_locked_keychain_error(&output.stderr) {
+                return Err(VaultError::BackendLocked {
+                    message: format!(
+                        "macOS Keychain is locked and cannot be read non-interactively for {id}"
+                    ),
+                    interactive: true,
+                });
+            }
             return Err(VaultError::SecretNotFound {
                 message: format!("Secret not found in macOS Keychain: {id}"),
             });
@@ -289,6 +378,7 @@ impl SecretBackend for KeychainBackend {
     }
 
     async fn delete(&self, id: &str) -> Result<(), VaultError> {
+        Self::reject_multiline_id(id)?;
         let service = Self::service_name(id);
         let output = self
             .host
@@ -305,6 +395,14 @@ impl SecretBackend for KeychainBackend {
             )
             .await?;
         if output.exit_code != 0 {
+            if Self::is_locked_keychain_error(&output.stderr) {
+                return Err(VaultError::BackendLocked {
+                    message: format!(
+                        "macOS Keychain is locked and cannot be modified non-interactively for {id}"
+                    ),
+                    interactive: true,
+                });
+            }
             return Err(VaultError::SecretNotFound {
                 message: format!("Secret not found in macOS Keychain: {id}"),
             });
@@ -313,6 +411,7 @@ impl SecretBackend for KeychainBackend {
     }
 
     async fn exists(&self, id: &str) -> Result<bool, VaultError> {
+        Self::reject_multiline_id(id)?;
         let service = Self::service_name(id);
         let output = self
             .host
@@ -328,6 +427,14 @@ impl SecretBackend for KeychainBackend {
                 ExecOptions::default(),
             )
             .await?;
+        if output.exit_code != 0 && Self::is_locked_keychain_error(&output.stderr) {
+            return Err(VaultError::BackendLocked {
+                message: format!(
+                    "macOS Keychain is locked and cannot be queried non-interactively for {id}"
+                ),
+                interactive: true,
+            });
+        }
         Ok(output.exit_code == 0)
     }
 }
@@ -752,6 +859,96 @@ mod tests {
         assert_eq!(backend.retrieve(id).await.unwrap(), "value");
     }
 
+    // ── Security regression: an id containing a newline must never reach
+    // `security -i`'s stdin command stream — it has no escape for `\n`/`\r`,
+    // so an unescaped newline in `id` would terminate the current command
+    // and let the remainder of `id` be interpreted as one or more injected
+    // `security -i` subcommands ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn store_rejects_id_with_embedded_newline_before_any_exec() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let err = backend
+            .store("evil\nid", "value")
+            .await
+            .expect_err("an id with an embedded newline must be rejected");
+        assert!(matches!(err, VaultError::Other(_)), "got {err:?}");
+        assert!(
+            host.calls.lock().unwrap().is_empty(),
+            "no subprocess should be spawned when the id is rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn retrieve_rejects_id_with_embedded_carriage_return_before_any_exec() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let err = backend
+            .retrieve("evil\rid")
+            .await
+            .expect_err("an id with an embedded carriage return must be rejected");
+        assert!(matches!(err, VaultError::Other(_)), "got {err:?}");
+        assert!(host.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_rejects_id_with_embedded_newline_before_any_exec() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let err = backend
+            .delete("evil\nid")
+            .await
+            .expect_err("an id with an embedded newline must be rejected");
+        assert!(matches!(err, VaultError::Other(_)), "got {err:?}");
+        assert!(host.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn exists_rejects_id_with_embedded_newline_before_any_exec() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let err = backend
+            .exists("evil\nid")
+            .await
+            .expect_err("an id with an embedded newline must be rejected");
+        assert!(matches!(err, VaultError::Other(_)), "got {err:?}");
+        assert!(host.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_rejects_id_with_embedded_nul_before_any_exec() {
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let err = backend
+            .store("evil\0id", "value")
+            .await
+            .expect_err("an id with an embedded NUL byte must be rejected");
+        assert!(matches!(err, VaultError::Other(_)), "got {err:?}");
+        assert!(host.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_rejects_an_injection_shaped_id_with_zero_exec_calls() {
+        // Shaped like a real attack: the newline-delimited "second command"
+        // would, if it ever reached `security -i`, delete an unrelated
+        // entry and then add an attacker-controlled one. Proves not just
+        // that the call is rejected, but that *no* exec of any kind runs —
+        // so the injected subcommand text never has a chance to execute.
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let injection_id = "a\"\ndelete-generic-password -s other -a x\nadd-generic-password -a x -s other -w evil";
+        let err = backend
+            .store(injection_id, "value")
+            .await
+            .expect_err("an injection-shaped id must be rejected");
+        assert!(matches!(err, VaultError::Other(_)), "got {err:?}");
+        assert!(
+            host.calls.lock().unwrap().is_empty(),
+            "zero exec calls must occur for a rejected injection-shaped id"
+        );
+    }
+
     // ── AC3: retrieve/delete/exists/list are plain exec calls ──────────────
 
     #[tokio::test]
@@ -798,6 +995,71 @@ mod tests {
         let mut expected = vec!["alpha", "awkward name: with spaces", "日本語-emoji-🔐"];
         expected.sort_unstable();
         assert_eq!(ids, expected);
+    }
+
+    #[tokio::test]
+    async fn list_round_trips_an_id_with_an_embedded_double_quote() {
+        // Regression for the store/list asymmetry: store() supports ids with
+        // embedded double quotes (escaped for `security -i`'s tokenizer),
+        // but real `security dump-keychain`'s plain-quoted display form
+        // embeds a `"` in the id raw and unescaped (verified empirically —
+        // see `parse_service_attribute_line` doc comment), so list()'s
+        // parser must not stop at the *first* embedded quote.
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let id = r#"has "quotes" inside"#;
+        backend.store(id, "value").await.unwrap();
+
+        let ids = backend.list().await.unwrap();
+        assert_eq!(
+            ids,
+            vec![id.to_string()],
+            "list() must recover the full id, not truncate at the first embedded quote"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_round_trips_an_id_ending_in_a_double_quote() {
+        // Edge case of the same asymmetry: when the id itself ends in `"`,
+        // the dumped line ends with two consecutive `"` characters (the
+        // embedded one, then the true closing delimiter) — verified
+        // empirically against the real `security` binary. Parsing from the
+        // *last* quote correctly recovers the trailing embedded quote.
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host.clone());
+        let id = r#"ends with quote""#;
+        backend.store(id, "value").await.unwrap();
+
+        let ids = backend.list().await.unwrap();
+        assert_eq!(ids, vec![id.to_string()]);
+    }
+
+    #[test]
+    fn parse_service_attribute_line_recovers_id_with_embedded_quote_not_truncated() {
+        // Captured line shape verified empirically against the real
+        // `security` binary: storing an id of `has "quotes" inside` dumps
+        // as exactly this line, with the embedded quotes unescaped.
+        let line = r#"    0x00000007 <blob>="vaultkeeper:has "quotes" inside""#;
+        let parsed = KeychainBackend::parse_service_attribute_line(line);
+        assert_eq!(
+            parsed,
+            Some("vaultkeeper:has \"quotes\" inside".to_string()),
+            "must not truncate at the first embedded quote"
+        );
+    }
+
+    #[test]
+    fn parse_service_attribute_line_recovers_id_ending_in_a_quote() {
+        // Captured line shape verified empirically: storing an id of
+        // `ends with quote"` dumps with the line ending in two consecutive
+        // `"` characters.
+        let line = r#"    0x00000007 <blob>="vaultkeeper:ends with quote"""#;
+        let parsed = KeychainBackend::parse_service_attribute_line(line);
+        assert_eq!(
+            parsed,
+            Some("vaultkeeper:ends with quote\"".to_string()),
+            "must recover the trailing embedded quote, not treat it as the closing delimiter"
+        );
     }
 
     #[test]
@@ -910,6 +1172,142 @@ mod tests {
         assert!(!backend.exists("nonexistent").await.unwrap());
         backend.store("present-id", "value").await.unwrap();
         assert!(backend.exists("present-id").await.unwrap());
+    }
+
+    // ── Locked keychain: retrieve/delete/exists must report BackendLocked,
+    // not misreport a locked keychain as a missing secret. Signature is the
+    // documented Apple `SecCopyErrorMessageString` text for
+    // `errSecInteractionNotAllowed` (-25308); see
+    // `KeychainBackend::LOCKED_KEYCHAIN_STDERR_SIGNATURE`'s doc comment for
+    // why this couldn't be captured against a genuinely locked real keychain
+    // in this environment (it blocks on an interactive unlock prompt
+    // instead of failing fast) ───────────────────────────────────────────
+
+    /// Wraps [`TestHost`] and, for `find-generic-password` /
+    /// `delete-generic-password`, always answers with the documented
+    /// `errSecInteractionNotAllowed` stderr signature instead of delegating,
+    /// simulating a locked keychain that can't be read non-interactively.
+    struct LockedKeychainHost {
+        inner: Arc<TestHost>,
+    }
+
+    #[async_trait::async_trait]
+    impl HostPlatform for LockedKeychainHost {
+        async fn exec(
+            &self,
+            cmd: &str,
+            args: &[&str],
+            options: ExecOptions<'_>,
+        ) -> Result<ExecOutput, VaultError> {
+            match args.first().copied() {
+                Some("find-generic-password") | Some("delete-generic-password") => Ok(ExecOutput {
+                    stdout: Vec::new(),
+                    stderr: b"security: SecKeychainFindGenericPassword: User interaction is not allowed."
+                        .to_vec(),
+                    exit_code: 36,
+                }),
+                _ => self.inner.exec(cmd, args, options).await,
+            }
+        }
+        async fn read_file(&self, p: &Path) -> Result<Vec<u8>, VaultError> {
+            self.inner.read_file(p).await
+        }
+        async fn write_file(&self, p: &Path, c: &[u8], m: u32) -> Result<(), VaultError> {
+            self.inner.write_file(p, c, m).await
+        }
+        async fn file_exists(&self, p: &Path) -> Result<bool, VaultError> {
+            self.inner.file_exists(p).await
+        }
+        async fn delete_file(&self, p: &Path) -> Result<(), VaultError> {
+            self.inner.delete_file(p).await
+        }
+        async fn list_dir(&self, p: &Path) -> Result<Vec<String>, VaultError> {
+            self.inner.list_dir(p).await
+        }
+        fn platform(&self) -> Platform {
+            self.inner.platform()
+        }
+        fn config_dir(&self) -> &Path {
+            self.inner.config_dir()
+        }
+    }
+
+    #[tokio::test]
+    async fn retrieve_on_locked_keychain_returns_backend_locked_not_secret_not_found() {
+        let host = Arc::new(LockedKeychainHost {
+            inner: TestHost::new(),
+        });
+        let err = KeychainBackend::new(host)
+            .retrieve("some-id")
+            .await
+            .expect_err("a locked keychain must not report success");
+        assert!(
+            matches!(
+                err,
+                VaultError::BackendLocked {
+                    interactive: true,
+                    ..
+                }
+            ),
+            "expected BackendLocked, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_on_locked_keychain_returns_backend_locked_not_secret_not_found() {
+        let host = Arc::new(LockedKeychainHost {
+            inner: TestHost::new(),
+        });
+        let err = KeychainBackend::new(host)
+            .delete("some-id")
+            .await
+            .expect_err("a locked keychain must not report success");
+        assert!(
+            matches!(
+                err,
+                VaultError::BackendLocked {
+                    interactive: true,
+                    ..
+                }
+            ),
+            "expected BackendLocked, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn exists_on_locked_keychain_returns_backend_locked_not_false() {
+        let host = Arc::new(LockedKeychainHost {
+            inner: TestHost::new(),
+        });
+        let err = KeychainBackend::new(host)
+            .exists("some-id")
+            .await
+            .expect_err("a locked keychain must not silently report 'does not exist'");
+        assert!(
+            matches!(
+                err,
+                VaultError::BackendLocked {
+                    interactive: true,
+                    ..
+                }
+            ),
+            "expected BackendLocked, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unrecognized_non_zero_exit_still_reports_secret_not_found() {
+        // Parity guard: only the specific locked-keychain stderr signature
+        // is special-cased. Every other non-zero exit (e.g. a genuinely
+        // missing entry) must still map to SecretNotFound, matching the TS
+        // backend and this backend's pre-existing behavior.
+        let host = TestHost::new();
+        let backend = KeychainBackend::new(host);
+        let err = backend.retrieve("truly-missing").await.unwrap_err();
+        assert!(
+            matches!(err, VaultError::SecretNotFound { .. }),
+            "expected SecretNotFound for an ordinary missing entry, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/vaultkeeper-core/src/backend/mod.rs
+++ b/crates/vaultkeeper-core/src/backend/mod.rs
@@ -6,6 +6,7 @@
 pub mod dpapi;
 pub mod file;
 pub mod in_memory;
+pub mod keychain;
 mod registry;
 pub mod secret_tool;
 mod signing_store;
@@ -15,6 +16,7 @@ pub mod yubikey;
 pub use dpapi::DpapiBackend;
 pub use file::FileBackend;
 pub use in_memory::InMemoryBackend;
+pub use keychain::KeychainBackend;
 pub use registry::BackendRegistry;
 pub use secret_tool::SecretToolBackend;
 pub use types::{

--- a/crates/vaultkeeper-core/tests/keychain_conformance.rs
+++ b/crates/vaultkeeper-core/tests/keychain_conformance.rs
@@ -1,0 +1,354 @@
+//! macOS conformance test for [`vaultkeeper_core::backend::KeychainBackend`]
+//! against the *real* `security(1)` binary and a real Keychain, using an
+//! ephemeral `create-keychain` so this test never touches the developer's or
+//! CI runner's real login keychain (issue #290, AC5).
+//!
+//! # Why this lives here, not in `vaultkeeper-conformance`
+//!
+//! Mirrors `secret_tool_conformance.rs`'s rationale exactly: the
+//! `vaultkeeper-conformance` crate's cases are CLI-level (fixed argv against
+//! the `vaultkeeper` binary), and the native CLI does not yet support
+//! selecting a backend at the command line — that wiring is a separate,
+//! not-yet-landed epic item (`vaultkeeper-core` issue #273). Until that
+//! lands there is no CLI invocation this test could shell out to that would
+//! exercise `KeychainBackend` specifically, so this test instead drives the
+//! backend directly, while still sharing assertion *data* with the CLI-level
+//! conformance suite: the id/secret pair below is read straight out of
+//! `vaultkeeper_conformance::all_cases()`'s `"store succeeds with valid
+//! secret"` case rather than being duplicated by hand.
+//!
+//! # Ephemeral keychain isolation
+//!
+//! `KeychainBackend` (like the TS backend it ports) never passes `-k
+//! <keychain>` to `security` — every command implicitly targets the current
+//! *default* keychain. To exercise the real backend without touching
+//! whatever keychain a developer or CI runner already has as their default,
+//! this test:
+//!
+//! 1. Creates a throwaway keychain file in a temp directory with a random
+//!    password (`security create-keychain`).
+//! 2. Adds it to the keychain search list and unlocks it, then makes it the
+//!    default keychain (`security list-keychains -s`, `unlock-keychain`,
+//!    `default-keychain -s`) so unqualified `security` commands resolve to
+//!    it.
+//! 3. Disables auto-lock for the duration of the test
+//!    (`set-keychain-settings`) so a slow CI run doesn't hit a relock.
+//! 4. Runs the full store/retrieve/exists/list/delete conformance flow.
+//! 5. Restores the previous default keychain and search list, then deletes
+//!    the ephemeral keychain file (`security delete-keychain`) — via an RAII
+//!    guard so this cleanup runs even if an assertion above panics.
+//!
+//! # Gating
+//!
+//! Only meaningful on `target_os = "macos"` with `security` on PATH (true of
+//! every macOS runner image). Everywhere else the test detects the missing
+//! prerequisite and skips itself with a clear message, mirroring
+//! `secret_tool_conformance.rs`'s Linux/D-Bus gate.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use vaultkeeper_core::backend::{
+    ExecOptions, ExecOutput, HostPlatform, KeychainBackend, ListableBackend, Platform,
+    SecretBackend,
+};
+use vaultkeeper_core::errors::VaultError;
+
+/// Minimal real `HostPlatform` sufficient for `KeychainBackend`, which never
+/// touches the filesystem. File methods are unreachable in practice — they
+/// panic instead of silently doing the wrong thing if that assumption ever
+/// changes.
+struct RealMacHost {
+    config_dir: PathBuf,
+}
+
+#[async_trait::async_trait]
+impl HostPlatform for RealMacHost {
+    async fn exec(
+        &self,
+        cmd: &str,
+        args: &[&str],
+        options: ExecOptions<'_>,
+    ) -> Result<ExecOutput, VaultError> {
+        let mut command = Command::new(cmd);
+        command.args(args);
+        command.stdin(if options.stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        });
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        let mut child = command
+            .spawn()
+            .map_err(|e| VaultError::Other(format!("Failed to spawn {cmd}: {e}")))?;
+
+        if let Some(data) = options.stdin {
+            use std::io::Write;
+            if let Some(ref mut stdin) = child.stdin {
+                stdin
+                    .write_all(data)
+                    .map_err(|e| VaultError::Other(format!("Failed to write stdin: {e}")))?;
+            }
+        }
+
+        let output = child
+            .wait_with_output()
+            .map_err(|e| VaultError::Other(format!("Failed to wait for {cmd}: {e}")))?;
+
+        Ok(ExecOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            exit_code: output.status.code().unwrap_or(-1),
+        })
+    }
+
+    async fn read_file(&self, _path: &Path) -> Result<Vec<u8>, VaultError> {
+        unreachable!("KeychainBackend never touches the filesystem")
+    }
+
+    async fn write_file(
+        &self,
+        _path: &Path,
+        _content: &[u8],
+        _mode: u32,
+    ) -> Result<(), VaultError> {
+        unreachable!("KeychainBackend never touches the filesystem")
+    }
+
+    async fn file_exists(&self, _path: &Path) -> Result<bool, VaultError> {
+        unreachable!("KeychainBackend never touches the filesystem")
+    }
+
+    async fn delete_file(&self, _path: &Path) -> Result<(), VaultError> {
+        unreachable!("KeychainBackend never touches the filesystem")
+    }
+
+    async fn list_dir(&self, _path: &Path) -> Result<Vec<String>, VaultError> {
+        unreachable!("KeychainBackend never touches the filesystem")
+    }
+
+    fn platform(&self) -> Platform {
+        Platform::Darwin
+    }
+
+    fn config_dir(&self) -> &Path {
+        &self.config_dir
+    }
+}
+
+/// True only on macOS with `security` on PATH.
+fn keychain_environment_available() -> bool {
+    if !cfg!(target_os = "macos") {
+        return false;
+    }
+    Command::new("security")
+        .arg("list-keychains")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// Extract the `--name`/stdin fixture the CLI-level conformance suite
+/// already asserts on, so this test's id/secret aren't a second,
+/// hand-duplicated copy of that data.
+fn shared_store_fixture() -> (String, String) {
+    let case = vaultkeeper_conformance::all_cases()
+        .into_iter()
+        .find(|c| c.name == "store succeeds with valid secret")
+        .expect("vaultkeeper-conformance must define 'store succeeds with valid secret'");
+
+    let name_flag_pos = case
+        .command
+        .iter()
+        .position(|arg| arg == "--name")
+        .expect("case must pass --name");
+    let name = case.command[name_flag_pos + 1].clone();
+    let secret = case.stdin.expect("case must supply stdin secret");
+    (name, secret)
+}
+
+/// Runs a `security` command with a fixed argv (no stdin), panicking with
+/// stderr on failure. Used only for ephemeral-keychain setup/teardown, never
+/// for anything touching the secret under test.
+fn run_security(args: &[&str]) -> std::process::Output {
+    Command::new("security")
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn `security {args:?}`: {e}"))
+}
+
+/// RAII guard that creates an ephemeral keychain for the duration of the
+/// test and restores the prior default keychain + search list on drop, so
+/// cleanup runs even if an assertion panics mid-test.
+struct EphemeralKeychain {
+    path: PathBuf,
+    previous_default: Option<String>,
+}
+
+impl EphemeralKeychain {
+    fn create() -> Self {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("vk-conformance-{}.keychain-db", std::process::id()));
+        // Best-effort: clear out a stale keychain from a previous crashed run.
+        let _ = std::fs::remove_file(&path);
+
+        let previous_default = {
+            let output = run_security(&["default-keychain"]);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            stdout
+                .trim()
+                .trim_matches('"')
+                .to_string()
+                .split_whitespace()
+                .next()
+                .map(str::to_string)
+                .or_else(|| Some(stdout.trim().trim_matches('"').to_string()))
+                .filter(|s| !s.is_empty())
+        };
+
+        let password = format!(
+            "vk-conformance-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default()
+        );
+        let path_str = path.to_str().expect("temp path must be valid UTF-8");
+
+        let create = run_security(&["create-keychain", "-p", &password, path_str]);
+        assert!(
+            create.status.success(),
+            "security create-keychain failed: {}",
+            String::from_utf8_lossy(&create.stderr)
+        );
+
+        let unlock = run_security(&["unlock-keychain", "-p", &password, path_str]);
+        assert!(
+            unlock.status.success(),
+            "security unlock-keychain failed: {}",
+            String::from_utf8_lossy(&unlock.stderr)
+        );
+
+        // Disable auto-lock so a slow CI run can't relock the keychain
+        // mid-test: "no-timeout" args set no idle timeout and don't lock on
+        // sleep.
+        let settings = run_security(&["set-keychain-settings", path_str]);
+        assert!(
+            settings.status.success(),
+            "security set-keychain-settings failed: {}",
+            String::from_utf8_lossy(&settings.stderr)
+        );
+
+        let set_default = run_security(&["default-keychain", "-s", path_str]);
+        assert!(
+            set_default.status.success(),
+            "security default-keychain -s failed: {}",
+            String::from_utf8_lossy(&set_default.stderr)
+        );
+
+        Self {
+            path,
+            previous_default,
+        }
+    }
+}
+
+impl Drop for EphemeralKeychain {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous_default {
+            let _ = run_security(&["default-keychain", "-s", previous]);
+        }
+        let path_str = self.path.to_string_lossy().to_string();
+        let _ = run_security(&["delete-keychain", &path_str]);
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+#[tokio::test]
+async fn keychain_backend_conformance_against_real_security_binary() {
+    if !keychain_environment_available() {
+        eprintln!(
+            "skipping keychain_backend_conformance_against_real_security_binary: \
+             requires target_os=macos and `security` on PATH. This is \
+             expected on non-macOS development machines and CI runners \
+             (issue #290 AC5)."
+        );
+        return;
+    }
+
+    let ephemeral = EphemeralKeychain::create();
+
+    let host = std::sync::Arc::new(RealMacHost {
+        config_dir: std::env::temp_dir(),
+    });
+    let backend = KeychainBackend::new(host);
+    let (name, secret) = shared_store_fixture();
+    // Namespace the id so repeated runs against a reused keychain path don't
+    // collide with a leftover entry from a previous run.
+    let name = format!("{name}-{}", std::process::id());
+
+    assert!(
+        backend.is_available().await,
+        "security must be available and the ephemeral keychain reachable"
+    );
+
+    backend
+        .store(&name, &secret)
+        .await
+        .expect("store must succeed against a real Keychain");
+
+    assert!(
+        backend.exists(&name).await.unwrap(),
+        "exists must be true immediately after store"
+    );
+
+    let retrieved = backend
+        .retrieve(&name)
+        .await
+        .expect("retrieve must succeed for a just-stored entry");
+    assert_eq!(
+        retrieved, secret,
+        "retrieved secret must match the stored value byte-for-byte"
+    );
+
+    let listed = backend.list().await.expect("list must succeed");
+    assert!(
+        listed.contains(&name),
+        "list must include the just-stored id: {listed:?}"
+    );
+
+    backend
+        .delete(&name)
+        .await
+        .expect("delete must succeed for an existing entry");
+
+    assert!(
+        !backend.exists(&name).await.unwrap(),
+        "exists must be false immediately after delete"
+    );
+
+    let err = backend
+        .retrieve(&name)
+        .await
+        .expect_err("retrieve of a deleted entry must fail");
+    assert!(
+        matches!(err, VaultError::SecretNotFound { .. }),
+        "expected SecretNotFound after delete, got {err:?}"
+    );
+
+    let delete_err = backend
+        .delete(&name)
+        .await
+        .expect_err("deleting an already-deleted entry must fail");
+    assert!(
+        matches!(delete_err, VaultError::SecretNotFound { .. }),
+        "expected SecretNotFound deleting a missing entry, got {delete_err:?}"
+    );
+
+    drop(ephemeral);
+}

--- a/crates/vaultkeeper-core/tests/keychain_conformance.rs
+++ b/crates/vaultkeeper-core/tests/keychain_conformance.rs
@@ -182,14 +182,31 @@ fn shared_store_fixture() -> (String, String) {
     (name, secret)
 }
 
-/// Runs a `security` command with a fixed argv (no stdin), panicking with
-/// stderr on failure. Used only for ephemeral-keychain setup/teardown, never
-/// for anything touching the secret under test.
+/// Runs a `security` command with a fixed argv (no stdin). Panics only if
+/// the process cannot be spawned; a non-zero exit is returned to the caller,
+/// who decides whether it is fatal (setup asserts success; teardown is
+/// best-effort). Used only for ephemeral-keychain setup/teardown, never for
+/// anything touching the secret under test.
 fn run_security(args: &[&str]) -> std::process::Output {
     Command::new("security")
         .args(args)
         .output()
         .unwrap_or_else(|e| panic!("failed to spawn `security {args:?}`: {e}"))
+}
+
+/// Like [`run_security`], but panics (with stderr) unless the command exits
+/// zero — for setup reads whose output the harness depends on: proceeding
+/// with an empty capture would silently skip session-state restoration in
+/// `Drop`, leaving the runner's keychain configuration mutated.
+fn run_security_ok(args: &[&str]) -> std::process::Output {
+    let out = run_security(args);
+    assert!(
+        out.status.success(),
+        "security {args:?} failed with exit {:?}: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
 }
 
 /// Parse `security list-keychains`/`security default-keychain` output —
@@ -232,9 +249,14 @@ impl EphemeralKeychain {
         let _ = std::fs::remove_file(&path);
 
         let previous_search_list =
-            parse_quoted_keychain_paths(&run_security(&["list-keychains"]).stdout);
+            parse_quoted_keychain_paths(&run_security_ok(&["list-keychains"]).stdout);
+        assert!(
+            !previous_search_list.is_empty(),
+            "list-keychains returned no paths — refusing to proceed, since Drop \
+             could not restore the session's search list afterwards"
+        );
         let previous_default =
-            parse_quoted_keychain_paths(&run_security(&["default-keychain"]).stdout)
+            parse_quoted_keychain_paths(&run_security_ok(&["default-keychain"]).stdout)
                 .into_iter()
                 .next();
 

--- a/crates/vaultkeeper-core/tests/keychain_conformance.rs
+++ b/crates/vaultkeeper-core/tests/keychain_conformance.rs
@@ -21,20 +21,31 @@
 //!
 //! `KeychainBackend` (like the TS backend it ports) never passes `-k
 //! <keychain>` to `security` — every command implicitly targets the current
-//! *default* keychain. To exercise the real backend without touching
-//! whatever keychain a developer or CI runner already has as their default,
-//! this test:
+//! *default* keychain for writes, and the current *search list* for reads
+//! (`find-generic-password`, `delete-generic-password`, and critically
+//! `dump-keychain`, which `list()` uses, walk every keychain on the search
+//! list, not just the default one). To exercise the real backend without
+//! observing — or polluting — whatever keychains a developer or CI runner
+//! already has configured, this test:
 //!
 //! 1. Creates a throwaway keychain file in a temp directory with a random
 //!    password (`security create-keychain`).
-//! 2. Adds it to the keychain search list and unlocks it, then makes it the
-//!    default keychain (`security list-keychains -s`, `unlock-keychain`,
-//!    `default-keychain -s`) so unqualified `security` commands resolve to
-//!    it.
-//! 3. Disables auto-lock for the duration of the test
+//! 2. Captures the current search list, then **replaces** it with just the
+//!    ephemeral keychain (`security list-keychains -s <ephemeral>`) — not
+//!    merely prepends it — so `dump-keychain`'s `list()` scan can only ever
+//!    observe entries this test itself wrote, never a developer's or
+//!    runner's real login-keychain entries. (Relying on `default-keychain
+//!    -s` alone to also fix up the search list was tried and rejected: it
+//!    was observed, empirically, to sometimes silently mutate the search
+//!    list as a side effect and sometimes not, which is exactly the kind of
+//!    OS/version-dependent behavior this isolation must not depend on.)
+//! 3. Unlocks the ephemeral keychain and makes it the default
+//!    (`unlock-keychain`, `default-keychain -s`) so unqualified `security`
+//!    write commands (`add-generic-password`) resolve to it.
+//! 4. Disables auto-lock for the duration of the test
 //!    (`set-keychain-settings`) so a slow CI run doesn't hit a relock.
-//! 4. Runs the full store/retrieve/exists/list/delete conformance flow.
-//! 5. Restores the previous default keychain and search list, then deletes
+//! 5. Runs the full store/retrieve/exists/list/delete conformance flow.
+//! 6. Restores the previous search list and default keychain, then deletes
 //!    the ephemeral keychain file (`security delete-keychain`) — via an RAII
 //!    guard so this cleanup runs even if an assertion above panics.
 //!
@@ -181,11 +192,24 @@ fn run_security(args: &[&str]) -> std::process::Output {
         .unwrap_or_else(|e| panic!("failed to spawn `security {args:?}`: {e}"))
 }
 
+/// Parse `security list-keychains`/`security default-keychain` output —
+/// one double-quoted path per line — into bare path strings.
+fn parse_quoted_keychain_paths(stdout: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .map(|line| line.trim().trim_matches('"').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 /// RAII guard that creates an ephemeral keychain for the duration of the
-/// test and restores the prior default keychain + search list on drop, so
-/// cleanup runs even if an assertion panics mid-test.
+/// test, replaces the search list with just that keychain (so `list()`'s
+/// `dump-keychain` scan can never observe a pre-existing login-keychain
+/// entry), and restores the prior search list + default keychain on drop —
+/// so cleanup runs even if an assertion panics mid-test.
 struct EphemeralKeychain {
     path: PathBuf,
+    previous_search_list: Vec<String>,
     previous_default: Option<String>,
 }
 
@@ -196,19 +220,12 @@ impl EphemeralKeychain {
         // Best-effort: clear out a stale keychain from a previous crashed run.
         let _ = std::fs::remove_file(&path);
 
-        let previous_default = {
-            let output = run_security(&["default-keychain"]);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            stdout
-                .trim()
-                .trim_matches('"')
-                .to_string()
-                .split_whitespace()
-                .next()
-                .map(str::to_string)
-                .or_else(|| Some(stdout.trim().trim_matches('"').to_string()))
-                .filter(|s| !s.is_empty())
-        };
+        let previous_search_list =
+            parse_quoted_keychain_paths(&run_security(&["list-keychains"]).stdout);
+        let previous_default =
+            parse_quoted_keychain_paths(&run_security(&["default-keychain"]).stdout)
+                .into_iter()
+                .next();
 
         let password = format!(
             "vk-conformance-{}-{}",
@@ -244,6 +261,18 @@ impl EphemeralKeychain {
             String::from_utf8_lossy(&settings.stderr)
         );
 
+        // Replace (not prepend) the search list with just the ephemeral
+        // keychain. This is what actually isolates `list()`'s
+        // `dump-keychain` scan from a developer's or runner's real
+        // login-keychain entries — `dump-keychain` (no `-k`) walks every
+        // keychain on the search list, not just the default one.
+        let set_search_list = run_security(&["list-keychains", "-s", path_str]);
+        assert!(
+            set_search_list.status.success(),
+            "security list-keychains -s failed: {}",
+            String::from_utf8_lossy(&set_search_list.stderr)
+        );
+
         let set_default = run_security(&["default-keychain", "-s", path_str]);
         assert!(
             set_default.status.success(),
@@ -253,6 +282,7 @@ impl EphemeralKeychain {
 
         Self {
             path,
+            previous_search_list,
             previous_default,
         }
     }
@@ -260,6 +290,11 @@ impl EphemeralKeychain {
 
 impl Drop for EphemeralKeychain {
     fn drop(&mut self) {
+        if !self.previous_search_list.is_empty() {
+            let mut args = vec!["list-keychains", "-s"];
+            args.extend(self.previous_search_list.iter().map(String::as_str));
+            let _ = run_security(&args);
+        }
         if let Some(previous) = &self.previous_default {
             let _ = run_security(&["default-keychain", "-s", previous]);
         }
@@ -317,9 +352,15 @@ async fn keychain_backend_conformance_against_real_security_binary() {
     );
 
     let listed = backend.list().await.expect("list must succeed");
-    assert!(
-        listed.contains(&name),
-        "list must include the just-stored id: {listed:?}"
+    // Not just `contains` — the search-list replacement in
+    // `EphemeralKeychain::create` is what actually isolates this scan from
+    // a developer's or runner's real login-keychain entries, so assert the
+    // *only* thing visible is what this test itself stored.
+    assert_eq!(
+        listed,
+        vec![name.clone()],
+        "list must observe exactly this test's own entry, nothing from a \
+         pre-existing login keychain: {listed:?}"
     );
 
     backend

--- a/crates/vaultkeeper-core/tests/keychain_conformance.rs
+++ b/crates/vaultkeeper-core/tests/keychain_conformance.rs
@@ -296,6 +296,19 @@ impl EphemeralKeychain {
             String::from_utf8_lossy(&settings.stderr)
         );
 
+        // Construct the RAII guard BEFORE the first global mutation below:
+        // if `default-keychain -s` panics after `list-keychains -s` already
+        // ran, the guard's Drop must still restore the captured session
+        // state. Everything above this point only touched the ephemeral
+        // keychain file, never global state, so a panic earlier leaves
+        // nothing to restore.
+        let guard = Self {
+            path,
+            previous_search_list,
+            previous_default,
+        };
+        let path_str = guard.path.to_str().expect("temp path must be valid UTF-8");
+
         // Replace (not prepend) the search list with just the ephemeral
         // keychain. This is what actually isolates `list()`'s
         // `dump-keychain` scan from a developer's or runner's real
@@ -315,11 +328,7 @@ impl EphemeralKeychain {
             String::from_utf8_lossy(&set_default.stderr)
         );
 
-        Self {
-            path,
-            previous_search_list,
-            previous_default,
-        }
+        guard
     }
 }
 

--- a/crates/vaultkeeper-core/tests/keychain_conformance.rs
+++ b/crates/vaultkeeper-core/tests/keychain_conformance.rs
@@ -213,10 +213,21 @@ struct EphemeralKeychain {
     previous_default: Option<String>,
 }
 
+/// Distinguishes concurrently-running tests within the same test binary
+/// process: `cargo test` runs each `#[tokio::test]` in this file on its own
+/// thread of the same process by default, so `std::process::id()` alone is
+/// not unique enough to keep two tests' ephemeral keychain files from
+/// colliding on the same path.
+static EPHEMERAL_KEYCHAIN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 impl EphemeralKeychain {
     fn create() -> Self {
+        let seq = EPHEMERAL_KEYCHAIN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let dir = std::env::temp_dir();
-        let path = dir.join(format!("vk-conformance-{}.keychain-db", std::process::id()));
+        let path = dir.join(format!(
+            "vk-conformance-{}-{seq}.keychain-db",
+            std::process::id()
+        ));
         // Best-effort: clear out a stale keychain from a previous crashed run.
         let _ = std::fs::remove_file(&path);
 
@@ -252,8 +263,10 @@ impl EphemeralKeychain {
         );
 
         // Disable auto-lock so a slow CI run can't relock the keychain
-        // mid-test: "no-timeout" args set no idle timeout and don't lock on
-        // sleep.
+        // mid-test: `set-keychain-settings` with no `-t`/`-l` flags at all
+        // sets no idle timeout and does not lock on sleep, which is exactly
+        // the "never auto-lock" behavior wanted here — no args are actually
+        // passed beyond the keychain path itself.
         let settings = run_security(&["set-keychain-settings", path_str]);
         assert!(
             settings.status.success(),
@@ -304,7 +317,15 @@ impl Drop for EphemeralKeychain {
     }
 }
 
+// `EphemeralKeychain::create`/`Drop` mutate *global*, session-wide state
+// (`security list-keychains -s` / `security default-keychain -s`), not
+// anything scoped to the ephemeral keychain file itself. Two tests in this
+// file running concurrently (the default for `#[tokio::test]`s in the same
+// binary) would race on that shared state and could restore the wrong
+// "previous" search list/default keychain on drop — serialize them onto one
+// real OS thread instead.
 #[tokio::test]
+#[serial_test::serial(keychain_session_state)]
 async fn keychain_backend_conformance_against_real_security_binary() {
     if !keychain_environment_available() {
         eprintln!(
@@ -390,6 +411,58 @@ async fn keychain_backend_conformance_against_real_security_binary() {
         matches!(delete_err, VaultError::SecretNotFound { .. }),
         "expected SecretNotFound deleting a missing entry, got {delete_err:?}"
     );
+
+    drop(ephemeral);
+}
+
+/// Conformance-level regression for the store/list asymmetry (issue #304
+/// review): `store()` supports an id with an embedded double quote (escaped
+/// for `security -i`'s tokenizer), but real `security dump-keychain`'s
+/// plain-quoted display form embeds the quote raw and unescaped, so `list()`
+/// must not truncate the id at the first embedded quote. Runs against the
+/// real `security` binary and a real (ephemeral) keychain, not just the
+/// in-memory `TestHost` in `keychain.rs`'s unit tests.
+#[tokio::test]
+#[serial_test::serial(keychain_session_state)]
+async fn keychain_backend_list_round_trips_a_quoted_id_against_real_security_binary() {
+    if !keychain_environment_available() {
+        eprintln!(
+            "skipping keychain_backend_list_round_trips_a_quoted_id_against_real_security_binary: \
+             requires target_os=macos and `security` on PATH."
+        );
+        return;
+    }
+
+    let ephemeral = EphemeralKeychain::create();
+
+    let host = std::sync::Arc::new(RealMacHost {
+        config_dir: std::env::temp_dir(),
+    });
+    let backend = KeychainBackend::new(host);
+    let id = format!("has \"quotes\" inside-{}", std::process::id());
+
+    backend
+        .store(&id, "quoted-id-secret")
+        .await
+        .expect("store must succeed for an id with an embedded double quote");
+
+    let listed = backend.list().await.expect("list must succeed");
+    assert_eq!(
+        listed,
+        vec![id.clone()],
+        "list() must recover the full id, not truncate at the first embedded quote: {listed:?}"
+    );
+
+    assert_eq!(
+        backend.retrieve(&id).await.unwrap(),
+        "quoted-id-secret",
+        "retrieve must still work for the same quoted id"
+    );
+
+    backend
+        .delete(&id)
+        .await
+        .expect("delete must succeed for the quoted-id entry");
 
     drop(ephemeral);
 }


### PR DESCRIPTION
Refs #290

## Pre-implementation verification (run FIRST, per issue instructions)

```
$ printf 'add-generic-password -a t -s vk-spike -w dGVzdA==\n' | security -i
$ security find-generic-password -a t -s vk-spike -w
dGVzdA==
```

Exit code 0, no getpass prompt, no TTY hang. The value round-tripped byte-for-byte through
`find-generic-password -w`, confirming `add-generic-password ... -w <value>` is parsed off the
`-i` stdin command stream rather than diverted to the interactive `getpass()` prompt. Verified the
inverse too: a bare trailing `-w` (no inline value) *does* trigger `password data for new item:
retype password for new item:` prompt text even inside `-i` mode — confirming `-w <value>` must
always be inline, never bare.

Design proceeded on this confirmation.

## What this does

Ports the macOS `KeychainBackend` (`packages/vaultkeeper/src/backend/keychain-backend.ts`) into
`vaultkeeper-core` as `crates/vaultkeeper-core/src/backend/keychain.rs` — a pure
`HostPlatform::exec` subprocess orchestrator over `security(1)`, no Security.framework FFI, no
host split. Same account (`vaultkeeper`)/service (`vaultkeeper:<id>`) naming as the TS backend, so
entries are mutually readable.

**`store`'s argv-leak fix:** the whole `delete-generic-password` (pre-clean) +
`add-generic-password ... -w <base64>` command pair is sent as a two-line script over a single
`security -i` process's stdin. The OS-visible argv for that process is just `security -i` — the
secret and its base64 encoding never appear in any child process's argv. `security -i`'s overall
exit code reflects the *last* command in the stream, so a failing pre-delete (nothing to delete)
followed by a successful add still yields exit 0 (verified empirically before relying on it).
base64-encoding is kept unchanged from the TS backend — it's what keeps `-w <value>` a single
clean token for `security -i`'s own stdin tokenizer regardless of the secret's byte content.

**Scope, per the issue:** only `store` uses the `-i` stream. `retrieve`
(`find-generic-password -w`, secret on stdout only), `delete`/`exists` (no secret in argv at all),
and `list` (`dump-keychain` + parse) are plain argv `security <args>` calls, ported 1:1.

**Account/service quoting in the `-i` stream:** unlike a plain argv call, the `-i` stdin stream is
tokenized by `security` itself. The account and `vaultkeeper:<id>` service are embedded as
double-quoted, backslash-escaped tokens — verified empirically to round-trip service names with
spaces, embedded double quotes, and embedded backslashes. (An embedded newline in `id` would break
the single-line `-i` command and is out of scope, consistent with `id` being a single-line
identifier everywhere else in vaultkeeper.)

**`list` parsing:** generalizes the TS backend's `/0x00000007 <blob>="vaultkeeper:([^"]+)"/g`
regex to also handle `security dump-keychain`'s hex+octal-escaped display form, which it switches
to for any service name containing a backslash or a non-printable-ASCII byte (verified
empirically) — the hex digits are parsed as the authoritative raw bytes rather than relying on the
lossy octal-escaped text.

**`is_available` deviation from the TS backend:** the TS backend probes with `security version`,
which is not a real `security` subcommand — verified it always fails with `unknown command
"version"`, so the TS backend's availability check is unconditionally broken on real `security`.
The Rust port instead probes with `security list-keychains`, a real, read-only, side-effect-free
command, so `is_available()` actually reflects reality. This is an internal probe-command choice,
not a change to any wire-visible behavior (storage format, argv shape, or secret handling) — filed
as a known deviation rather than silently perpetuating a broken check.

## Acceptance criteria mapping

1. **(unit) `store` argv-safety** — `store_issues_a_single_security_interactive_process`,
   `store_passes_secret_and_its_base64_encoding_on_stdin_not_argv`,
   `store_argv_sentinel_survives_full_round_trip` (`crates/vaultkeeper-core/src/backend/keychain.rs`).
   A sentinel secret is injected and asserted absent from every recorded child argv across the
   whole store→retrieve→exists→delete flow, with the base64-encoded form checked too.
2. **(unit) byte-for-byte round trip** —
   `round_trips_secret_with_spaces_quotes_and_embedded_newlines`,
   `round_trips_non_ascii_secret_byte_for_byte`.
3. **(unit) retrieve/delete/exists/list are plain exec, list parses awkward names** —
   `retrieve_delete_exists_are_plain_argv_exec_calls` (asserts no `-i` and no stdin on those
   calls), `list_parses_plain_and_hex_escaped_dump_keychain_entries`,
   `parse_dump_ids_matches_ts_backend_output_shape`,
   `parse_dump_ids_ignores_entries_without_the_vaultkeeper_prefix`,
   `round_trips_id_containing_spaces_and_quotes` (id, not just secret, survives the `-i`
   tokenizer).
4. **(unit, negative) typed errors, never garbage** — `retrieve_missing_returns_secret_not_found`,
   `delete_missing_returns_secret_not_found`, `store_failure_surfaces_typed_error_not_panic`,
   `retrieve_surfaces_typed_error_on_malformed_base64_not_garbage_secret`.
5. **Conformance on macOS via ephemeral create-keychain** —
   `crates/vaultkeeper-core/tests/keychain_conformance.rs`
   (`keychain_backend_conformance_against_real_security_binary`), sharing its id/secret fixture
   with `vaultkeeper-conformance`'s `"store succeeds with valid secret"` case. Creates a
   throwaway keychain via `security create-keychain`, makes it the default keychain for the
   test's duration (an RAII guard restores the previous default and deletes the ephemeral
   keychain even on panic), runs the full store→exists→retrieve→list→delete→re-retrieve flow
   against the real binary, then tears down. Gated to skip cleanly off-macOS. New
   `keychain-conformance` CI job on `macos-latest` runs it — **there was previously no macOS CI
   runner in this repo at all**, so this PR adds the first one, alongside the existing Linux-only
   `secret_tool_conformance.rs`'s equivalent gate (which stays ungated in CI per its own header
   comment, since it also needs a D-Bus session this repo's CI doesn't set up yet).

## Coordination with #270

#270 tracks the TS `KeychainBackend`'s equivalent argv leak. This PR does **not** touch the TS
implementation — it only lands the Rust-core port with the `security -i` design the issue
prescribes. #270 stays open for the TS-side fix.

## Test plan

- `cargo test --workspace`: 434 tests passed, 0 failed (261 in `vaultkeeper-core`'s lib including
  22 new keychain unit tests; 1 in the new `keychain_conformance` integration test, run for real
  against this macOS dev machine's `security` binary via an ephemeral keychain — verified cleanup
  restored the prior default keychain and left no leftover keychain files).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo clippy -p vaultkeeper-wasm --target wasm32-unknown-unknown -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Rebuilt the wasm artifact with the pinned toolchain (`crates/vaultkeeper-wasm/wasm-toolchain.env`:
  rustc 1.95.0, wasm-pack 0.15.0, binaryen 131 — all already installed locally, matching pinned
  versions) since `vaultkeeper-core` (which the wasm crate links) changed. Export/import
  fingerprint against the previously-committed artifact matched (47 exports / 54 imports, both
  sides) — expected, since `KeychainBackend` isn't wired into any wasm-exported binding — but the
  compiled `.wasm` binary itself differs, so the regenerated artifact is committed per the
  package's regeneration policy. `.js`/`.d.ts` outputs were byte-identical (no interface change).
  Both budgets pass (uncompressed 514,629 / 1,048,576 bytes; gzip 199,485 / 409,600 bytes).
- `pnpm check`: clean (pre-existing `security/detect-object-injection` warnings in
  `packages/cli/src/{config-dir,suggest}.ts` are unrelated to this change).
- `pnpm check:api-docs`: up to date (no public TS API surface changed by this PR).
- `pnpm test`: 263 passed, 19 skipped (expected platform-conditional skips), 0 failed.
