### PR TITLE
Document that releases are human-gated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,15 @@ Workflow:
 
 ## Conventions
 
+### Releases are human-gated
+
+Merging the changesets bot PR (branch `changeset-release/main`, title "Version
+Packages") **is** the release trigger: it runs the release workflow, publishing
+to npm (OIDC trusted publishing) and crates.io. No agent may merge that PR,
+enable auto-merge on it, or otherwise cause it to merge — regardless of CI or
+review-thread state. Only a human merges it. If its state blocks other work,
+report that to the user and stop.
+
 ### Errors
 
 All errors extend `VaultError` (defined in `packages/vaultkeeper/src/errors.ts`). When adding a new error class:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,8 +276,8 @@ Workflow:
 
 ### Releases are human-gated
 
-Merging the changesets bot PR (branch `changeset-release/main`, title "Version
-Packages") **is** the release trigger: it runs the release workflow, publishing
+Merging the changesets bot PR — branch `changeset-release/main`, titled
+"Version Packages" — **is** the release trigger: it runs the release workflow, publishing
 to npm (OIDC trusted publishing) and crates.io. No agent may merge that PR,
 enable auto-merge on it, or otherwise cause it to merge — regardless of CI or
 review-thread state. Only a human merges it. If its state blocks other work,


### PR DESCRIPTION
## Summary

Adds a Conventions entry to `CLAUDE.md` stating that merging the changesets bot PR (`changeset-release/main`, "Version Packages") is itself the release trigger — publishing to npm via OIDC trusted publishing and to crates.io — and is therefore reserved for a human. Agents must not merge it, arm auto-merge on it, or otherwise cause it to merge, regardless of CI or review-thread state.

Documentation-only; no code or workflow changes.