### PR TITLE
Add product brief and PRFAQ

### DIFF
--- a/docs/product/PRFAQ.md
+++ b/docs/product/PRFAQ.md
@@ -1,8 +1,11 @@
-# vaultkeeper PRFAQ
+# vaultkeeper 1.0 PRFAQ
 
-> Product reference document, written from the launch perspective: the press release and FAQ
-> describe vaultkeeper as it lands at launch. The "What exists today" question anchors current
-> implementation status against that. Kept current by the maintainers.
+> This is the PRFAQ for **vaultkeeper 1.0 — a release that has not shipped yet.** It is
+> written from 1.0's launch perspective, deliberately without hedging: everything described
+> here is in scope for 1.0 whether or not it has landed today. This document is the working
+> definition of what 1.0 means, and the artifact against which product feedback is given.
+> Current implementation status lives where it stays current — the repository's releases,
+> epics, and issue tracker — never here.
 
 ---
 
@@ -114,10 +117,11 @@ permissions. Every lease begins and ends with this key.
 
 A lease is an encrypted token, **minted** with the minting key, that occupies the env-var slot
 *instead of* a secret. It carries expiry, a usage limit, and revocation state, and it can only
-be **redeemed** — decrypted and honored — by the vaultkeeper that holds the minting key. That
-is why you should care: a lease captured into a log aggregator, a telemetry payload, or a bug
-report is dead on arrival anywhere else, because no other machine's vaultkeeper can redeem it.
-That is the leak class that actually happens, and it simply stops mattering.
+be **redeemed** — decrypted and honored — by the vaultkeeper that holds the minting key, *and
+only when presented by the process it was issued to*. That is why you should care: a lease
+captured into a log aggregator, a telemetry payload, or a bug report is dead on arrival —
+no other machine's vaultkeeper can decrypt it, and even another process on the same machine
+is refused at redemption. The leak classes that actually happen simply stop mattering.
 
 Signing leases are the same idea for signing keys: holding one lets a process *ask vaultkeeper
 to produce signatures* with a key it never sees — minted with human presence at launch, usable
@@ -150,9 +154,9 @@ neighbors stay put.
    than the target system itself can express**. GitHub's permission model cannot say "may
    update issues, but only ones carrying this label"; a delegated fetch through vaultkeeper
    can, because each invocation is evaluated against your policy before the key is ever used.
-   This level requires the consuming tool to speak vaultkeeper; today that means first-party
-   tooling, by choice (a language-agnostic local redemption endpoint is a named future epic,
-   gated on an installed base worth integrating against).
+   This level requires the consuming tool to speak vaultkeeper — natively, through its SDKs,
+   or through the local redemption endpoint that lets any tool in any language trade a lease
+   for what it needs in one call.
 
 ### What is a profile?
 
@@ -222,14 +226,14 @@ Secret-store integrations aren't untestable — they're *annoying and difficult*
 hardware to touch, sessions to authenticate, prompts that hang CI. The idea is that
 vaultkeeper owns those annoying tests so you don't have to write them.
 
-vaultkeeper treats its test doubles as products. Shipped today: an in-memory backend and a
-test-vault harness for hermetic consumer tests. In review as of this writing: that backend
-gaining real Ed25519 signing and scriptable fault injection (throwing the same typed errors
-production throws), plus a presence simulator built to be structurally unreachable from
-production code. Planned behind those: backend-flavored doubles carrying real data shapes and
-choreography, held to the *same conformance corpus* as the real adapters — at which point
-manual testing reduces to a minutes-scale, tool-upgrade-triggered audit: "does the real
-adapter still match its double?"
+vaultkeeper treats its test doubles as products: an in-memory backend with real Ed25519
+signing and scriptable fault injection (throwing the same typed errors production throws), a
+presence simulator that is structurally unreachable from production code, and backend-flavored
+doubles carrying real data shapes and choreography — every double held to the *same
+conformance corpus* as the real adapter it stands in for. Test artifacts are self-announcing
+(a test-minted lease is unmistakably marked, and production refuses marked artifacts), so test
+data can never pass as real. Manual testing reduces to a minutes-scale, tool-upgrade-triggered
+audit: "does the real adapter still match its double?"
 
 ### What are the non-goals?
 
@@ -240,19 +244,14 @@ cert-based auth are also out of scope: users there cannot add servers or edit co
 not have the secret-handling problem vaultkeeper solves. Single machine, single developer,
 policy-enforced: that is the product.
 
-### What exists today, and what is in flight?
+### Is everything here real today?
 
-Shipped: the Rust core (backends, JWE capability tokens, key management and rotation, trust
-tiers/TOFU, presence model, detached-JWS signing with backend-held keys, the opaque handle
-table), the TypeScript SDK and CLI, the WASM bridge, encrypted key-state persistence, the
-environment-profile primitive, and the conformance suite. Policy-resolved injection ships
-today as the single-secret `vaultkeeper exec`; the profile-based `run` wrapper described
-above is its in-flight, multi-secret generalization. Also in flight: session signing leases
-with tamper-evident revocation, native-CLI backend parity (keychain, secret-tool, DPAPI,
-YubiKey ports to the shared core), and the paired-double test strategy. Committed roadmap:
-verifier-visible assurance (presence-bound keys and the signed assurance assertion — see "Can
-a signature prove a human was present?"). Future: the local redemption endpoint, external key
-import with custody provenance.
+No — and that is the point of this document. This PRFAQ describes **vaultkeeper 1.0** and is
+written from its launch perspective: it is the target the project builds toward, and the
+artifact its owner gives product feedback against. Some of what it describes has shipped;
+some is in flight; some is not yet started. The one place to learn which is which is the
+repository itself — releases, epics, and the issue tracker — which stays current the way a
+durable document cannot.
 
 ### What does it cost?
 

--- a/docs/product/PRFAQ.md
+++ b/docs/product/PRFAQ.md
@@ -22,19 +22,26 @@ service tokens, dedicated vaults, per-use biometric approval — largely gate th
 behind paid business tiers or cloud subscriptions.
 
 vaultkeeper unbundles **storage** from **policy**. Your secrets live in whatever backend you
-already trust — macOS Keychain, 1Password, a YubiKey, Windows DPAPI, libsecret, or an encrypted
-file store — and vaultkeeper supplies the governance layer those stores lack: capability tokens
+already trust — today: macOS Keychain, 1Password, a YubiKey, Windows DPAPI, the Linux Secret
+Service (`secret-tool`), or an encrypted file store, with further stores (Dashlane and others)
+on the table wherever demand appears, since a backend is a small adapter over a stable
+interface — and vaultkeeper supplies the governance layer those stores lack: capability tokens
 scoped by expiry, usage count, and executable identity; per-use human-presence requirements
 (a Touch ID tap or YubiKey touch *for this operation, right now*); delegated access patterns
 where the raw secret never enters the calling process at all; and full local revocation.
 
-Adoption is a gradient, not a rewrite. `vaultkeeper run --profile github-mcp -- npx
-@github/mcp-server` wraps any unmodified tool: the plaintext token leaves the config file and is
-materialized only into the child process, under policy, with nothing at rest. Tools that
-integrate further can hold a **VaultKeeper lease** instead of the secret itself — an encrypted,
-expiring, revocable capability that is worthless off the machine and worthless after its window
-closes. Signing keys go further still: the private key never leaves the backend at all;
-consumers request signatures, never key material.
+Adoption is a gradient, not a rewrite, and the wrapper works on anything that reads
+environment variables. Wrap an MCP server so the PAT leaves the config file
+(`vaultkeeper run --profile github-mcp -- npx @github/mcp-server`); wrap an ordinary CLI for
+one policy-resolved invocation (`vaultkeeper run --profile deploy -- terraform apply`); or
+wrap the command that launches an agentic coding session, so the agent's whole environment —
+real secrets and vaultkeeper leases alike — is resolved under policy at launch and nothing
+lives in a dotfile. In every case the tool is unmodified: secrets are materialized only into
+the child process, under policy, with nothing at rest. Tools that integrate further can hold a
+**VaultKeeper lease** instead of the secret itself — an encrypted, expiring, revocable
+capability that is worthless off the machine and worthless after its window closes. Signing
+keys go further still: the private key never leaves the backend at all; consumers request
+signatures, never key material.
 
 The same identity primitives serve human and automation signers alike. An agent fleet can hold
 signing identities whose keys are born inside vaultkeeper and cannot be extracted by the
@@ -69,35 +76,66 @@ floor dramatically without pretending to be a sandbox.
 
 ### How is this different from dotenvx / `op run` / SOPS?
 
-Those tools solve *encrypted at rest, injected at runtime* — and solve it well. vaultkeeper's
-differences are: (1) **policy at resolution** — trust tiers on the calling executable, TTLs,
-usage limits, per-use presence — not just decryption; (2) **storage-agnostic** — the same policy
-over Keychain, 1Password, YubiKey, DPAPI, libsecret, or a file, rather than one blessed store;
-(3) **the lease rung** — consumers can hold a capability instead of the secret, which nothing
-env-injection-shaped offers; (4) **no subscription** — the scoped-token/dedicated-vault posture
-that 1Password gates behind Business tiers, locally and free. What those tools have that
-vaultkeeper deliberately does not: team sync and cloud distribution (see non-goals).
+Those tools solve *encrypted at rest, injected at runtime* — and solve it well. But they are
+not context-aware: they decrypt for whoever invokes them, so in practice you choose between
+security and friction (lock things down and pay for it on every invocation, or loosen them
+and hope). Because vaultkeeper's resolution step evaluates *policy* — who is asking, with
+what trust, for how long — it can offer both at once: strong defaults with low-friction
+day-to-day use. The concrete differences:
+
+1. **Policy at resolution** — trust tiers on the calling executable, TTLs, usage limits,
+   per-use presence — not just decryption.
+2. **Storage-agnostic** — the same policy over Keychain, 1Password, YubiKey, DPAPI, the
+   Linux Secret Service, or a file, rather than one blessed store.
+3. **The lease rung** — consumers can hold a capability instead of the secret, which nothing
+   env-injection-shaped offers.
+4. **No subscription** — the scoped-token/dedicated-vault posture that 1Password gates behind
+   Business tiers, locally and free.
+
+What those tools have that vaultkeeper deliberately does not: team sync and cloud
+distribution (see non-goals).
 
 ### What is a VaultKeeper lease?
 
 An encrypted, serializable capability token that occupies the env-var slot *instead of* a
-secret. It carries expiry, a usage limit, and revocation state; redeeming it requires the local
-vault key, so a lease captured into a log aggregator or bug report is dead on arrival anywhere
-else. Signing leases authorize signature operations for a bounded session — minted with human
-presence at launch, usable non-interactively until expiry, revocable individually or per-key.
+secret. It carries expiry, a usage limit, and revocation state; redeeming it requires the
+local vault key (the encryption key vaultkeeper generates at setup and keeps in your
+configured backend — only the vaultkeeper process on this machine can use it, enforced by the
+backend's own access control plus owner-only file permissions on the encrypted key state), so
+a lease captured into a log aggregator or bug report is dead on arrival anywhere else. Signing
+leases are the same idea for signing keys: holding one lets a process *ask vaultkeeper to
+produce signatures* with a key it never sees — minted with human presence at launch, usable
+non-interactively until expiry, revocable individually or per-key.
 
-### What is the adoption gradient?
+### How do I adopt this without rewriting my tools?
 
-Three rungs, chosen **per secret**, permanently mixable in one profile:
+You don't adopt vaultkeeper wholesale — you upgrade **one secret at a time**, and each secret
+sits at whichever of three levels fits it. Nothing forces a migration: a single profile can
+hold secrets at different levels side by side, indefinitely, so there is no cliff where
+everything must convert at once and no penalty for upgrading one credential while its
+neighbors stay put.
 
-1. **Plaintext on disk** — the status quo being replaced.
-2. **Resolved environment** — the real secret, never at rest, materialized under policy into
-   one process. Works with any unmodified tool. This is the on-ramp, and the MCP-server wrapper
-   is its headline: point `mcp.json` at `vaultkeeper run` and the PAT leaves the file.
-3. **Lease** — the env var carries a capability, not the secret. Requires the consumer to speak
-   vaultkeeper; today that means first-party tooling, by choice (a language-agnostic local
-   redemption endpoint is a named future epic, gated on an installed base worth integrating
-   against).
+1. **Environment variables holding plaintext secrets in your terminal or tool config** (an
+   `export GITHUB_TOKEN=ghp_…` in `.bashrc`, a token pasted into `mcp.json` or a `.env`) —
+   the status quo being replaced. The secret sits on disk in plaintext, readable by anything,
+   forever.
+2. **Resolved at launch, never on disk.** You run the same tool through
+   `vaultkeeper run`, and the secret is fetched from your backend and handed *only to that
+   one process, for that one run*. If you have ever thought "I just need to pass this key to
+   this one command without leaving it lying around in a file" — this is that, made routine.
+   The tool is unmodified; the difference from level 1 is that the secret is no longer
+   floating around on disk for every other process, backup, and sync client to see.
+3. **The process gets a lease, not the secret.** At level 2 the chosen process still holds
+   the real GitHub key. At level 3 it holds a vaultkeeper lease instead: a token that — under
+   the right conditions — lets operations be performed *with* a key the process never has any
+   direct access to. Those "right conditions" are yours to define: a time window, a usage
+   count, and — because vaultkeeper sits in the middle of every call — policy **more granular
+   than the target system itself can express**. GitHub's permission model cannot say "may
+   update issues, but only ones carrying this label"; a delegated fetch through vaultkeeper
+   can, because each invocation is evaluated against your policy before the key is ever used.
+   This level requires the consuming tool to speak vaultkeeper; today that means first-party
+   tooling, by choice (a language-agnostic local redemption endpoint is a named future epic,
+   gated on an installed base worth integrating against).
 
 ### Does this work for AI-agent fleets?
 
@@ -111,11 +149,18 @@ the processes it governs — custody cannot substitute for process isolation, an
 
 ### Can a signature prove a human was present?
 
-Not yet, and not claimed. Presence is enforced at signing time by capable backends and is
-visible to the local caller, but a verifier of the resulting signature cannot currently
-distinguish a presence-backed signature from an automation one. Making assurance
-verifier-visible is a known, deliberately-deferred design question shared with downstream
-attestation tooling.
+Not in what ships today, but the path exists and is on the roadmap. Presence is enforced at
+signing time by capable backends and is visible to the local caller; the resulting signature,
+however, does not yet carry that fact to a verifier. Two mechanisms can close the gap. The
+strongest is **presence-bound keys**: when a key lives in hardware whose signing policy
+requires a physical touch (a YubiKey with touch-required, a Secure-Enclave key gated on
+biometrics) and that policy is attested at enrollment, then *every* valid signature from that
+key is proof of presence by construction — nothing extra to encode, nothing to forge. The
+complementary mechanism is a **vaultkeeper-signed assurance assertion** bound into the signed
+payload, covering backends where the property is enforced by vaultkeeper rather than by the
+hardware itself (with the honest caveat that its trust root is the vault, not the physical
+token). Sequencing verifier-visible assurance is a design question shared with downstream
+attestation tooling, which currently treats the distinction as consumer-side convention.
 
 ### How do humans and automation coexist as signers?
 
@@ -127,12 +172,14 @@ verifying system's policy, not to vaultkeeper.
 
 ### What about testing? Secrets tooling is notoriously untestable.
 
-vaultkeeper ships its own test doubles as products: an in-memory backend with real Ed25519
-signing and scriptable fault injection (throwing the same typed errors production throws), a
-presence simulator that is structurally unreachable from production code, and — in flight —
-backend-flavored doubles carrying real data shapes and choreography, held to the *same
-conformance corpus* as the real adapters. Manual testing reduces to a minutes-scale,
-tool-upgrade-triggered audit: "does the real adapter still match its double?"
+vaultkeeper treats its test doubles as products. Shipped today: an in-memory backend and a
+test-vault harness for hermetic consumer tests. In review as of this writing: that backend
+gaining real Ed25519 signing and scriptable fault injection (throwing the same typed errors
+production throws), plus a presence simulator built to be structurally unreachable from
+production code. Planned behind those: backend-flavored doubles carrying real data shapes and
+choreography, held to the *same conformance corpus* as the real adapters — at which point
+manual testing reduces to a minutes-scale, tool-upgrade-triggered audit: "does the real
+adapter still match its double?"
 
 ### What are the non-goals?
 

--- a/docs/product/PRFAQ.md
+++ b/docs/product/PRFAQ.md
@@ -1,0 +1,160 @@
+# vaultkeeper PRFAQ
+
+> Internal working document. The press release is aspirational-at-launch framing; the FAQ is
+> honest about what exists today versus what is in flight. Kept current by the maintainers.
+
+---
+
+## Press Release
+
+### vaultkeeper brings policy-enforced secret custody to every developer — using the credential store you already own
+
+**Developers can now get the secret-handling posture that previously required a business-tier
+subscription — scoped tokens, expiring grants, per-use approval — locally, offline, and free,
+on top of macOS Keychain, 1Password, a YubiKey, or an encrypted file.**
+
+Today, the standard way to give a tool a secret is still an environment variable holding a
+plaintext credential, sourced from a dotfile or pasted into a config. Every MCP server config
+with a `GITHUB_TOKEN` in it, every `.env` in a backup, every API key in shell history is the
+same story: a long-lived, unscoped credential at rest in plaintext, readable by anything and
+revocable only by rotating it everywhere at once. The tools that fix this properly — scoped
+service tokens, dedicated vaults, per-use biometric approval — largely gate those capabilities
+behind paid business tiers or cloud subscriptions.
+
+vaultkeeper unbundles **storage** from **policy**. Your secrets live in whatever backend you
+already trust — macOS Keychain, 1Password, a YubiKey, Windows DPAPI, libsecret, or an encrypted
+file store — and vaultkeeper supplies the governance layer those stores lack: capability tokens
+scoped by expiry, usage count, and executable identity; per-use human-presence requirements
+(a Touch ID tap or YubiKey touch *for this operation, right now*); delegated access patterns
+where the raw secret never enters the calling process at all; and full local revocation.
+
+Adoption is a gradient, not a rewrite. `vaultkeeper run --profile github-mcp -- npx
+@github/mcp-server` wraps any unmodified tool: the plaintext token leaves the config file and is
+materialized only into the child process, under policy, with nothing at rest. Tools that
+integrate further can hold a **VaultKeeper lease** instead of the secret itself — an encrypted,
+expiring, revocable capability that is worthless off the machine and worthless after its window
+closes. Signing keys go further still: the private key never leaves the backend at all;
+consumers request signatures, never key material.
+
+The same identity primitives serve human and automation signers alike. An agent fleet can hold
+signing identities whose keys are born inside vaultkeeper and cannot be extracted by the
+processes they govern — with human presence proven once at session establishment rather than
+demanded per signature.
+
+vaultkeeper is a single Rust core reachable from a native CLI and from TypeScript via
+WebAssembly, with a data-driven conformance suite holding every implementation to the same
+behavior. It is open source, local-first, and has no cloud component: nothing about your
+secrets ever leaves your machine.
+
+---
+
+## FAQ
+
+### What problem does vaultkeeper actually solve?
+
+Plaintext credentials at rest, and the absence of policy between a secret and the processes that
+use it. The realistic adversaries it defeats are **exfiltration-at-rest** (dotfiles, backups,
+synced folders, committed configs, shell history) and **accidental disclosure** (logs, bug
+reports, telemetry, copy-paste). It also bounds the blast radius of what a process holds: an
+expiring, usage-limited, revocable lease instead of a forever-credential.
+
+### What does it *not* defend against?
+
+An attacker with arbitrary code execution as your own user, on your unlocked machine. A
+same-UID process can read a child's environment on some platforms, attach a debugger, or drive
+vaultkeeper's own APIs. Presence-gated backends (YubiKey touch, Touch ID) are the exception —
+they force a fresh physical action per operation that no same-UID software can fake. We state
+this plainly because a secrets tool that overclaims is worse than none: vaultkeeper raises the
+floor dramatically without pretending to be a sandbox.
+
+### How is this different from dotenvx / `op run` / SOPS?
+
+Those tools solve *encrypted at rest, injected at runtime* — and solve it well. vaultkeeper's
+differences are: (1) **policy at resolution** — trust tiers on the calling executable, TTLs,
+usage limits, per-use presence — not just decryption; (2) **storage-agnostic** — the same policy
+over Keychain, 1Password, YubiKey, DPAPI, libsecret, or a file, rather than one blessed store;
+(3) **the lease rung** — consumers can hold a capability instead of the secret, which nothing
+env-injection-shaped offers; (4) **no subscription** — the scoped-token/dedicated-vault posture
+that 1Password gates behind Business tiers, locally and free. What those tools have that
+vaultkeeper deliberately does not: team sync and cloud distribution (see non-goals).
+
+### What is a VaultKeeper lease?
+
+An encrypted, serializable capability token that occupies the env-var slot *instead of* a
+secret. It carries expiry, a usage limit, and revocation state; redeeming it requires the local
+vault key, so a lease captured into a log aggregator or bug report is dead on arrival anywhere
+else. Signing leases authorize signature operations for a bounded session — minted with human
+presence at launch, usable non-interactively until expiry, revocable individually or per-key.
+
+### What is the adoption gradient?
+
+Three rungs, chosen **per secret**, permanently mixable in one profile:
+
+1. **Plaintext on disk** — the status quo being replaced.
+2. **Resolved environment** — the real secret, never at rest, materialized under policy into
+   one process. Works with any unmodified tool. This is the on-ramp, and the MCP-server wrapper
+   is its headline: point `mcp.json` at `vaultkeeper run` and the PAT leaves the file.
+3. **Lease** — the env var carries a capability, not the secret. Requires the consumer to speak
+   vaultkeeper; today that means first-party tooling, by choice (a language-agnostic local
+   redemption endpoint is a named future epic, gated on an installed base worth integrating
+   against).
+
+### Does this work for AI-agent fleets?
+
+It is one of the primary design cases. Agents need credentials but must not *hold* them in any
+durable way; some agents (e.g. an adjudicator that signs policy-change proposals) need signing
+identities that the agents they govern cannot extract or invoke. vaultkeeper's answer: keys born
+inside a backend and never exported; signatures produced backend-side; session-scoped signing
+leases minted at harness launch with presence proven once; and honest documentation that
+*non-invocability* additionally requires OS-level isolation between the privileged harness and
+the processes it governs — custody cannot substitute for process isolation, and we say so.
+
+### Can a signature prove a human was present?
+
+Not yet, and not claimed. Presence is enforced at signing time by capable backends and is
+visible to the local caller, but a verifier of the resulting signature cannot currently
+distinguish a presence-backed signature from an automation one. Making assurance
+verifier-visible is a known, deliberately-deferred design question shared with downstream
+attestation tooling.
+
+### How do humans and automation coexist as signers?
+
+Identically. An identity is an Ed25519 keypair; nothing about being a human or an agent pins an
+identity to a role. What differs is **custody** — an attribute of the identity that can
+strengthen over time (file-backed today, presence-gated hardware tomorrow) without the identity
+becoming a different actor. Role semantics (who may author, who may approve) belong to the
+verifying system's policy, not to vaultkeeper.
+
+### What about testing? Secrets tooling is notoriously untestable.
+
+vaultkeeper ships its own test doubles as products: an in-memory backend with real Ed25519
+signing and scriptable fault injection (throwing the same typed errors production throws), a
+presence simulator that is structurally unreachable from production code, and — in flight —
+backend-flavored doubles carrying real data shapes and choreography, held to the *same
+conformance corpus* as the real adapters. Manual testing reduces to a minutes-scale,
+tool-upgrade-triggered audit: "does the real adapter still match its double?"
+
+### What are the non-goals?
+
+Team sync, cloud storage, and cross-device distribution — that is where subscription products
+genuinely earn their fee, and competing there would require becoming the cloud service
+vaultkeeper exists to not be. Locked-down corporate environments behind MCP proxies with
+cert-based auth are also out of scope: users there cannot add servers or edit configs, and do
+not have the secret-handling problem vaultkeeper solves. Single machine, single developer,
+policy-enforced: that is the product.
+
+### What exists today, and what is in flight?
+
+Shipped: the Rust core (backends, JWE capability tokens, key management and rotation, trust
+tiers/TOFU, presence model, detached-JWS signing with backend-held keys, the opaque handle
+table), the TypeScript SDK and CLI, the WASM bridge, encrypted key-state persistence, the
+environment-profile primitive, and the conformance suite. In flight: the `run` wrapper verb,
+session signing leases with tamper-evident revocation, native-CLI backend parity (keychain,
+secret-tool, DPAPI, YubiKey ports to the shared core), and the paired-double test strategy.
+Future: the local redemption endpoint, external key import with custody provenance, and
+verifier-visible assurance.
+
+### What does it cost?
+
+Nothing. Open source, no tiers, no cloud account. The premise is that this security posture
+should not be a subscription feature.

--- a/docs/product/PRFAQ.md
+++ b/docs/product/PRFAQ.md
@@ -1,7 +1,8 @@
 # vaultkeeper PRFAQ
 
-> Internal working document. The press release is aspirational-at-launch framing; the FAQ is
-> honest about what exists today versus what is in flight. Kept current by the maintainers.
+> Product reference document, written from the launch perspective: the press release and FAQ
+> describe vaultkeeper as it lands at launch. The "What exists today" question anchors current
+> implementation status against that. Kept current by the maintainers.
 
 ---
 
@@ -9,9 +10,10 @@
 
 ### vaultkeeper brings policy-enforced secret custody to every developer — using the credential store you already own
 
-**Developers can now get the secret-handling posture that previously required a business-tier
-subscription — scoped tokens, expiring grants, per-use approval — locally, offline, and free,
-on top of macOS Keychain, 1Password, a YubiKey, or an encrypted file.**
+**Developers can now get — and go beyond — the secret-handling posture that previously
+required a business-tier subscription: scoped tokens, expiring grants, per-use approval, and
+per-invocation policy that no subscription tier offers at any price. Locally, offline, and
+free, on top of macOS Keychain, 1Password, a YubiKey, or an encrypted file.**
 
 Today, the standard way to give a tool a secret is still an environment variable holding a
 plaintext credential, sourced from a dotfile or pasted into a config. Every MCP server config
@@ -19,7 +21,9 @@ with a `GITHUB_TOKEN` in it, every `.env` in a backup, every API key in shell hi
 same story: a long-lived, unscoped credential at rest in plaintext, readable by anything and
 revocable only by rotating it everywhere at once. The tools that fix this properly — scoped
 service tokens, dedicated vaults, per-use biometric approval — largely gate those capabilities
-behind paid business tiers or cloud subscriptions.
+behind paid business tiers or cloud subscriptions. And even the paid tiers only offer stronger
+*mechanisms* for who may access which secrets; none of them let you define policy over the
+conditions of each individual use.
 
 vaultkeeper unbundles **storage** from **policy**. Your secrets live in whatever backend you
 already trust — today: macOS Keychain, 1Password, a YubiKey, Windows DPAPI, the Linux Secret
@@ -48,10 +52,11 @@ signing identities whose keys are born inside vaultkeeper and cannot be extracte
 processes they govern — with human presence proven once at session establishment rather than
 demanded per signature.
 
-vaultkeeper is a single Rust core reachable from a native CLI and from TypeScript via
-WebAssembly, with a data-driven conformance suite holding every implementation to the same
-behavior. It is open source, local-first, and has no cloud component: nothing about your
-secrets ever leaves your machine.
+vaultkeeper is open source and fully auditable, local-first, with no cloud component: nothing
+about your secrets ever leaves your machine. It runs wherever your environment already permits
+— as a library inside Node.js where Node is the approved runtime (compatible with binary
+authorization tooling such as Santa), or as a single native binary where you can run one — and
+a data-driven conformance suite holds every implementation to the same behavior.
 
 ---
 
@@ -83,12 +88,17 @@ and hope). Because vaultkeeper's resolution step evaluates *policy* — who is a
 what trust, for how long — it can offer both at once: strong defaults with low-friction
 day-to-day use. The concrete differences:
 
-1. **Policy at resolution** — trust tiers on the calling executable, TTLs, usage limits,
-   per-use presence — not just decryption.
-2. **Storage-agnostic** — the same policy over Keychain, 1Password, YubiKey, DPAPI, the
-   Linux Secret Service, or a file, rather than one blessed store.
-3. **The lease rung** — consumers can hold a capability instead of the secret, which nothing
-   env-injection-shaped offers.
+1. **Policy at resolution, per invocation** — trust tiers on the calling executable, time
+   windows, use counts, per-use presence — evaluated for each use, not just each grant, with
+   custom rule expressions as the roadmap direction (policy as expressive as your rules, not
+   as coarse as a permission checkbox).
+2. **Works with the store you already use, with no lock-in** — the same policy over Keychain,
+   1Password, YubiKey, DPAPI, the Linux Secret Service, or a file. Script against vaultkeeper
+   once and mix stores freely — Keychain for some secrets, 1Password for others, a YubiKey at
+   work — one unified facade, and changing stores never changes your tooling.
+3. **The lease rung** — consumers can hold a capability (a token that permits specific
+   operations to be performed on the holder's behalf — not the secret itself) instead of the
+   secret, which nothing env-injection-shaped offers.
 4. **No subscription** — the scoped-token/dedicated-vault posture that 1Password gates behind
    Business tiers, locally and free.
 
@@ -97,20 +107,26 @@ distribution (see non-goals).
 
 ### What is a VaultKeeper lease?
 
-An encrypted, serializable capability token that occupies the env-var slot *instead of* a
-secret. It carries expiry, a usage limit, and revocation state; redeeming it requires the
-local vault key (the encryption key vaultkeeper generates at setup and keeps in your
-configured backend — only the vaultkeeper process on this machine can use it, enforced by the
-backend's own access control plus owner-only file permissions on the encrypted key state), so
-a lease captured into a log aggregator or bug report is dead on arrival anywhere else. Signing
-leases are the same idea for signing keys: holding one lets a process *ask vaultkeeper to
-produce signatures* with a key it never sees — minted with human presence at launch, usable
+It starts at setup: when vaultkeeper is set up on a machine, it creates an encryption key that
+only it can use — the **minting key** — held in your configured backend behind that backend's
+own access control, with the encrypted key state further protected by owner-only file
+permissions. Every lease begins and ends with this key.
+
+A lease is an encrypted token, **minted** with the minting key, that occupies the env-var slot
+*instead of* a secret. It carries expiry, a usage limit, and revocation state, and it can only
+be **redeemed** — decrypted and honored — by the vaultkeeper that holds the minting key. That
+is why you should care: a lease captured into a log aggregator, a telemetry payload, or a bug
+report is dead on arrival anywhere else, because no other machine's vaultkeeper can redeem it.
+That is the leak class that actually happens, and it simply stops mattering.
+
+Signing leases are the same idea for signing keys: holding one lets a process *ask vaultkeeper
+to produce signatures* with a key it never sees — minted with human presence at launch, usable
 non-interactively until expiry, revocable individually or per-key.
 
 ### How do I adopt this without rewriting my tools?
 
-You don't adopt vaultkeeper wholesale — you upgrade **one secret at a time**, and each secret
-sits at whichever of three levels fits it. Nothing forces a migration: a single profile can
+You don't have to adopt vaultkeeper wholesale — you may upgrade **one secret at a time**, and
+each secret sits at whichever of three levels fits it. Nothing forces a migration: a single profile can
 hold secrets at different levels side by side, indefinitely, so there is no cliff where
 everything must convert at once and no penalty for upgrading one credential while its
 neighbors stay put.
@@ -123,10 +139,11 @@ neighbors stay put.
    `vaultkeeper run`, and the secret is fetched from your backend and handed *only to that
    one process, for that one run*. If you have ever thought "I just need to pass this key to
    this one command without leaving it lying around in a file" — this is that, made routine.
-   The tool is unmodified; the difference from level 1 is that the secret is no longer
-   floating around on disk for every other process, backup, and sync client to see.
-3. **The process gets a lease, not the secret.** At level 2 the chosen process still holds
-   the real GitHub key. At level 3 it holds a vaultkeeper lease instead: a token that — under
+   The tool is unmodified; the difference from using `.env` files with secrets in plaintext is
+   that the secret is no longer floating around on disk for every other process, backup, and
+   sync client to see.
+3. **The process gets a lease, not the secret.** When raw secrets (e.g. API keys) are made
+   available to a process at launch, the chosen process still holds the real key. With a lease it holds a vaultkeeper token instead: one that — under
    the right conditions — lets operations be performed *with* a key the process never has any
    direct access to. Those "right conditions" are yours to define: a time window, a usage
    count, and — because vaultkeeper sits in the middle of every call — policy **more granular
@@ -136,6 +153,27 @@ neighbors stay put.
    This level requires the consuming tool to speak vaultkeeper; today that means first-party
    tooling, by choice (a language-agnostic local redemption endpoint is a named future epic,
    gated on an installed base worth integrating against).
+
+### What is a profile?
+
+A profile is a named, per-project file that describes the environment a command should
+receive: which env vars exist, which secret in your backend each one draws from, whether each
+materializes as the real value or as a lease, and the policy for that entry (expiry, trust
+requirement, presence). Profiles contain names and policy — never secret values — so they are
+safe to commit next to your code, which turns any weakening of policy into a reviewable diff.
+`vaultkeeper run --profile <name> -- <command>` resolves the profile and launches the command
+with that environment.
+
+### I build tools or libraries — why would I integrate vaultkeeper directly?
+
+Because it makes someone else's secret store your feature instead of your problem. Integrate
+against vaultkeeper once and your tool supports whatever secret-keeping backend each user
+already has — Keychain, 1Password, a YubiKey, an encrypted file — without you writing a line
+of keychain code, handling a biometric flow, or maintaining the notoriously annoying manual
+test rigs those integrations demand. vaultkeeper carries those tests (and ships test doubles
+so *your* integration tests run hermetically in CI, no hardware, no accounts). Your users
+choose how their secrets are protected; your tool doesn't have to know or care — it can even
+use vaultkeeper entirely under the hood, unbeknownst to the user.
 
 ### Does this work for AI-agent fleets?
 
@@ -147,20 +185,28 @@ leases minted at harness launch with presence proven once; and honest documentat
 *non-invocability* additionally requires OS-level isolation between the privileged harness and
 the processes it governs — custody cannot substitute for process isolation, and we say so.
 
+There is a companion need in agent-heavy development: some acts must remain *deterministically
+human* — provably performed by a person, not by an agent that discovered a workaround.
+vaultkeeper powers a solution there too, through its sibling project
+[`attest-it`](https://github.com/mike-north/attest-it): cryptographic proof that a designated
+identity performed a gated act, with vaultkeeper holding the signing keys.
+
 ### Can a signature prove a human was present?
 
-Not in what ships today, but the path exists and is on the roadmap. Presence is enforced at
-signing time by capable backends and is visible to the local caller; the resulting signature,
-however, does not yet carry that fact to a verifier. Two mechanisms can close the gap. The
-strongest is **presence-bound keys**: when a key lives in hardware whose signing policy
-requires a physical touch (a YubiKey with touch-required, a Secure-Enclave key gated on
-biometrics) and that policy is attested at enrollment, then *every* valid signature from that
-key is proof of presence by construction — nothing extra to encode, nothing to forge. The
-complementary mechanism is a **vaultkeeper-signed assurance assertion** bound into the signed
-payload, covering backends where the property is enforced by vaultkeeper rather than by the
-hardware itself (with the honest caveat that its trust root is the vault, not the physical
-token). Sequencing verifier-visible assurance is a design question shared with downstream
-attestation tooling, which currently treats the distinction as consumer-side convention.
+Yes — at two strengths. The strongest is **presence-bound keys**: when a key lives in hardware
+whose signing policy demands a human action at the moment of signing (a YubiKey with
+touch-required, a Secure-Enclave key gated on biometrics) and that policy is attested at
+enrollment, then *every* valid signature from that key is proof of presence by construction —
+nothing extra to encode, nothing to forge. The complementary mechanism is a
+**vaultkeeper-signed assurance assertion** bound into the signed payload, covering backends
+where the property is enforced by vaultkeeper rather than by the hardware (with the honest
+caveat that its trust root is the vault, not the physical token).
+
+"Presence" here is deliberately broader than a fingerprint or a touch: the aim is integration
+with the full range of human-in-the-loop approval mechanisms — a passkey ceremony, an
+authenticated web approval behind a CAPTCHA, anything that yields a trustworthy indication of
+a human's involvement at the moment of approval. This is a solved pattern in the e-signature
+world; vaultkeeper's job is to bind it to key use.
 
 ### How do humans and automation coexist as signers?
 
@@ -170,7 +216,11 @@ strengthen over time (file-backed today, presence-gated hardware tomorrow) witho
 becoming a different actor. Role semantics (who may author, who may approve) belong to the
 verifying system's policy, not to vaultkeeper.
 
-### What about testing? Secrets tooling is notoriously untestable.
+### What about testing?
+
+Secret-store integrations aren't untestable — they're *annoying and difficult* to test:
+hardware to touch, sessions to authenticate, prompts that hang CI. The idea is that
+vaultkeeper owns those annoying tests so you don't have to write them.
 
 vaultkeeper treats its test doubles as products. Shipped today: an in-memory backend and a
 test-vault harness for hermetic consumer tests. In review as of this writing: that backend
@@ -195,11 +245,14 @@ policy-enforced: that is the product.
 Shipped: the Rust core (backends, JWE capability tokens, key management and rotation, trust
 tiers/TOFU, presence model, detached-JWS signing with backend-held keys, the opaque handle
 table), the TypeScript SDK and CLI, the WASM bridge, encrypted key-state persistence, the
-environment-profile primitive, and the conformance suite. In flight: the `run` wrapper verb,
-session signing leases with tamper-evident revocation, native-CLI backend parity (keychain,
-secret-tool, DPAPI, YubiKey ports to the shared core), and the paired-double test strategy.
-Future: the local redemption endpoint, external key import with custody provenance, and
-verifier-visible assurance.
+environment-profile primitive, and the conformance suite. Policy-resolved injection ships
+today as the single-secret `vaultkeeper exec`; the profile-based `run` wrapper described
+above is its in-flight, multi-secret generalization. Also in flight: session signing leases
+with tamper-evident revocation, native-CLI backend parity (keychain, secret-tool, DPAPI,
+YubiKey ports to the shared core), and the paired-double test strategy. Committed roadmap:
+verifier-visible assurance (presence-bound keys and the signed assurance assertion — see "Can
+a signature prove a human was present?"). Future: the local redemption endpoint, external key
+import with custody provenance.
 
 ### What does it cost?
 

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -1,8 +1,10 @@
-# vaultkeeper Product Brief
+# vaultkeeper 1.0 Product Brief
 
-> The durable statement of what vaultkeeper is, who it serves, what it will not do, and how we
-> reason about its security claims. Companion to [PRFAQ.md](./PRFAQ.md); where the PRFAQ
-> persuades, this document decides. Kept current by the maintainers.
+> The durable statement of what **vaultkeeper 1.0** is, who it serves, what it will not do,
+> and how we reason about its security claims. Like its companion [PRFAQ.md](./PRFAQ.md),
+> this describes the 1.0 target — not the current state of the code — without distinguishing
+> landed from planned; the repository's releases, epics, and tracker own current status.
+> Where the PRFAQ persuades, this document decides.
 
 ## 1. The single value proposition
 
@@ -42,9 +44,7 @@ audiences.
 
 The rung is chosen **per entry** in a profile, and mixing is the permanent steady state, not a
 migration phase. Rung 2's delivery mechanism is the `vaultkeeper run` wrapper — most visibly as
-the `command` in an MCP server config. (`run` is in flight; today's shipped mechanism is the
-single-secret `vaultkeeper exec`, which `run` generalizes to profile-driven, multi-secret
-resolution.) Rung 3 is first-party-only today *by choice*; the
+the `command` in an MCP server config. Rung 3 is first-party-only today *by choice*; the
 language-agnostic local redemption endpoint that would open it to any consumer in any language
 is a named future epic, triggered by an installed base worth integrating against.
 
@@ -88,14 +88,11 @@ is a named future epic, triggered by an installed base worth integrating against
 ## 6. Architecture in one paragraph
 
 One semantic core in Rust (`vaultkeeper-core`), reached two ways: a native CLI, and TypeScript
-via a WASM bridge — with the TypeScript library's parallel logic being progressively retired as
-the core reaches parity (single-core consolidation). Backends are subprocess orchestration over
-a host-platform abstraction wherever the underlying store has a CLI (keychain, secret-tool,
-DPAPI, YubiKey); 1Password remains host-provided because its per-process desktop-app grant is
-reachable only through a mechanism the WASM sandbox cannot load. A data-driven conformance
-corpus runs against every implementation — and, by design, against every test double — so
-"the Rust and TypeScript flavors of the same experience" is enforced mechanically, not by
-promise.
+via a WASM bridge. The TypeScript library's parallel logic **will be retired** as the core
+reaches parity — single-core consolidation is the settled direction, not an open question.
+Backends are small adapters over a host-platform abstraction. A data-driven conformance corpus
+runs against every implementation — and, by design, against every test double — so "the Rust
+and TypeScript flavors of the same experience" is enforced mechanically, not by promise.
 
 ## 7. How we make security claims
 
@@ -105,10 +102,15 @@ appears to deliver a property is treated as a defect.** Standing consequences:
 - Per-rung threat honesty. Rung 2 provides essentially zero confidentiality against same-UID
   code execution; its real adversaries are exfiltration-at-rest and accidental disclosure. We
   say this everywhere the value proposition is stated.
-- A lease's decisive property is off-box worthlessness — the leak class that actually happens
-  (log aggregators, telemetry, bug reports).
-- Non-invocability of a privileged identity requires OS-level isolation; custody cannot
-  substitute for it, and every custody recommendation states the precondition.
+- A lease's decisive property is **worthlessness outside its intended holder**: off-box it
+  cannot even be decrypted, and on the same machine redemption verifies *who* presents it —
+  a lease lifted by a different process is refused. The leak classes that actually happen
+  (log aggregators, telemetry, bug reports) and the lateral-theft case are both covered.
+- Holding the only copy of a key does not help if any process on the machine can simply ask
+  vaultkeeper to use it. So when a privileged identity (like an adjudicating agent's signing
+  key) must be unusable by the processes it governs, those processes have to run under a
+  different OS user — vaultkeeper's custody cannot substitute for that separation, and every
+  custody recommendation says so up front.
 - Fail-closed is the default posture: unknown backends report no capabilities; corrupt or
   missing revocation state refuses lease validation; config naming an unavailable backend is an
   error, never a silent fallback.
@@ -116,53 +118,64 @@ appears to deliver a property is treated as a defect.** Standing consequences:
   structurally unreachable from production: separate dev-only package, no registry entry,
   opt-in-only construction, loud refusal under production environments. This is a standing
   requirement on any such aid, enforced by negative tests wherever one exists.
+- Test artifacts must be **self-announcing, and production must refuse them**: anything a test
+  aid emits that resembles a real security artifact (a lease, a token, an assertion) carries
+  an unmistakable test marking, and non-test code paths explicitly reject marked artifacts
+  rather than honoring them. Unreachability guards protect against test *code* leaking into
+  production; this guards against test *data* doing the same.
 
 ## 8. Non-goals
 
 - **Team sync, cloud storage, cross-device distribution.** Subscription products earn their fee
   there; competing would require becoming a cloud service and forfeiting "nothing leaves your
   machine." Single-machine, single-developer parity is the scope.
-- **Locked-down corporate MCP environments** (proxy, cert auth, curated servers) — users there
-  cannot edit configs and do not have this problem.
-- **Matching 1Password's UX breadth.** Biometric ergonomics, browser integration, and sharing
-  are not the competition; custody policy is.
-- **Modeling signature *semantics*** (authorship vs approval). What a signature means belongs to
-  the verifying system's per-gate policy; vaultkeeper makes identities distinguishable and
-  their keys non-transferable, and stops there.
+- **Governing auth that isn't secret-material.** Where access rests on client certificates,
+  platform-attested identity, or other non-secret mechanisms, there is no key for vaultkeeper
+  to custody and no policy for it to enforce. Wherever an API-key-shaped secret exists —
+  including in otherwise locked-down corporate environments — vaultkeeper aims to be usable.
+- **Competing with 1Password — vaultkeeper is complementary to it.** 1Password is one of
+  vaultkeeper's best backends, and vaultkeeper is a power tool *for* 1Password users: policy,
+  leases, and delegated use layered over the vault they already trust. (The same goes for
+  every store vaultkeeper fronts.)
+- **Modeling signature *semantics*** (authorship vs approval). Such things can absolutely be
+  built *on top of* vaultkeeper — and are: that layer of meaning belongs, Unix-style, to tools
+  that leverage it (attest-it being the first). vaultkeeper aims to be excellent at its own
+  job — making identities distinguishable and their keys non-transferable — and stops there.
 
-## 9. State of the world
+## 9. What 1.0 means
 
-**Shipped** (through `vaultkeeper@0.7.x`): the Rust core — backends (file, in-memory,
-secret-tool), JWE capability tokens, key management and rotation, trust tiers/TOFU, the
-presence model, detached-JWS signing with backend-held Ed25519 keys, the opaque handle table
-with bearer-safe redaction, encrypted key-state persistence, the environment-profile
-primitive, the lease-aware claims validator; the TypeScript SDK/CLI with the full backend
-suite; the WASM bridge with host-callback contracts; OIDC trusted publishing; conformance and
-packaging test suites.
+1.0's scope is defined by this document and the PRFAQ, not by a feature checklist — but these
+pillars are its load-bearing walls. Each is a commitment a reader may hold us to:
 
-**In flight**: the `run` wrapper verb (stdio/signal-transparent); session signing leases with
-tamper-evident two-axis revocation; native backend parity (keychain via `security -i`, DPAPI,
-YubiKey ports); consumer test doubles (signing and fault-injection capabilities being added to
-the existing in-memory backend, plus a new presence simulator); the paired-double test
-strategy (stub framework, golden transcripts, flavored doubles, the manual-residue register).
-
-**Committed roadmap**: verifier-visible assurance — a signature provably presence-backed, via
-presence-bound hardware keys (signing policy attested at enrollment) and a vault-signed
-assurance assertion for software-enforced backends. Owner-decided 2026-07; presence here spans
-human-in-the-loop approval broadly (hardware touch, biometrics, passkey ceremonies,
-authenticated web approval), not only physical tokens.
-
-**Deliberately future**: the local redemption endpoint (opens rung 3 to any language);
-external key import with custody provenance modeled; issuance-side principal checks binding
-capabilities to the invoking context.
+- **Single-core consolidation** — one Rust semantic core behind every surface; the parallel
+  TypeScript logic will be retired.
+- **The profile-driven `run` wrapper** — the universal on-ramp for unmodified tools, MCP
+  servers first among them.
+- **Session signing leases** — presence-anchored at mint, non-interactive for the session,
+  with tamper-evident two-axis revocation.
+- **Per-process lease boundaries** — redemption verifies the presenter; a lease is worthless
+  outside its intended holder, not merely off-box.
+- **Backend parity in the native CLI** for every store the library fronts.
+- **The paired-double test strategy** — every production adapter has a double held to the
+  same conformance corpus; manual testing is a minutes-scale fidelity audit; test artifacts
+  are self-announcing and refused by production.
+- **Verifier-visible assurance** — signatures provably presence-backed, via presence-bound
+  hardware keys (signing policy attested at enrollment) and vault-signed assurance
+  assertions, with "presence" spanning human-in-the-loop approval broadly (hardware touch,
+  biometrics, passkey ceremonies, authenticated web approval).
+- **The local redemption endpoint** — leases redeemable by any tool in any language in one
+  call, opening the lease rung beyond first-party tooling.
 
 ## 10. How we measure success
 
+- Dramatically more secure secrets handling is brought to bear across an extremely wide range
+  of CLI and MCP tools — breadth of tools running under vaultkeeper is the headline measure.
 - A new user gets a secret out of plaintext and behind policy in under five minutes, without
   modifying the consuming tool.
+- Library and tool builders who need a secrets-backend integration achieve a high degree of
+  release confidence without building or maintaining their own manual test suites (for
+  1Password integration and the like) — they test against vaultkeeper's doubles instead.
 - The manual-testing residue stays a minutes-scale, tool-upgrade-triggered checklist — never a
   suite that can rot unrun.
-- Consumers (starting with attestation tooling) cover their vaultkeeper integration on every
-  PR using shipped doubles, with zero hardware.
 - Every security property claimed in this document has a test that fails when the property
   regresses.

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -42,7 +42,9 @@ audiences.
 
 The rung is chosen **per entry** in a profile, and mixing is the permanent steady state, not a
 migration phase. Rung 2's delivery mechanism is the `vaultkeeper run` wrapper — most visibly as
-the `command` in an MCP server config. Rung 3 is first-party-only today *by choice*; the
+the `command` in an MCP server config. (`run` is in flight; today's shipped mechanism is the
+single-secret `vaultkeeper exec`, which `run` generalizes to profile-driven, multi-secret
+resolution.) Rung 3 is first-party-only today *by choice*; the
 language-agnostic local redemption endpoint that would open it to any consumer in any language
 is a named future epic, triggered by an installed base worth integrating against.
 
@@ -144,10 +146,15 @@ YubiKey ports); consumer test doubles (signing and fault-injection capabilities 
 the existing in-memory backend, plus a new presence simulator); the paired-double test
 strategy (stub framework, golden transcripts, flavored doubles, the manual-residue register).
 
+**Committed roadmap**: verifier-visible assurance — a signature provably presence-backed, via
+presence-bound hardware keys (signing policy attested at enrollment) and a vault-signed
+assurance assertion for software-enforced backends. Owner-decided 2026-07; presence here spans
+human-in-the-loop approval broadly (hardware touch, biometrics, passkey ceremonies,
+authenticated web approval), not only physical tokens.
+
 **Deliberately future**: the local redemption endpoint (opens rung 3 to any language);
-external key import with custody provenance modeled; verifier-visible assurance (a signature
-provably presence-backed); issuance-side principal checks binding capabilities to the invoking
-context.
+external key import with custody provenance modeled; issuance-side principal checks binding
+capabilities to the invoking context.
 
 ## 10. How we measure success
 

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -61,8 +61,10 @@ is a named future epic, triggered by an installed base worth integrating against
 ## 5. Core concepts
 
 - **Backend** — where secrets live. Pluggable: file (encrypted), macOS Keychain, 1Password,
-  YubiKey, DPAPI, libsecret. Backends self-report **capabilities**; policy fails closed when a
-  capability is absent rather than silently downgrading.
+  YubiKey, DPAPI, `secret-tool` (Linux Secret Service via libsecret); additional stores are
+  small adapters over the same interface, added where demand appears. Backends self-report
+  **capabilities**; policy fails closed when a capability is absent rather than silently
+  downgrading.
 - **Capability token / lease** — an encrypted JWE granting scoped access: expiry, usage limit,
   executable-identity binding at mint, revocation. The serialized, cross-process form is the
   **lease**; "lease" is the house term for any serialized, expiring, revocable capability.
@@ -71,8 +73,8 @@ is a named future epic, triggered by an installed base worth integrating against
   minimum (`minTrust`), or-stronger.
 - **Presence** — a backend's ability to force a *fresh physical human action* for a specific
   operation, right now (YubiKey touch, Touch ID, per-use biometric approval). Enforced
-  fail-closed; never simulated in production (the test simulator is structurally unreachable
-  there).
+  fail-closed; and any test aid capable of simulating presence is required to be structurally
+  unreachable from production code paths.
 - **Profile** — a named, committable, per-project set of env-var bindings, each entry carrying
   its secret source, its rung (`materialize: "secret" | "lease"`), and its policy. Profiles
   contain names and policy, never secrets; committing one makes policy loosening a reviewable
@@ -108,9 +110,10 @@ appears to deliver a property is treated as a defect.** Standing consequences:
 - Fail-closed is the default posture: unknown backends report no capabilities; corrupt or
   missing revocation state refuses lease validation; config naming an unavailable backend is an
   error, never a silent fallback.
-- Test aids that could forge a security signal (the presence simulator) ship structurally
-  unreachable from production: separate dev-only package, no registry entry, opt-in-only
-  construction, loud refusal under production environments.
+- Test aids that could forge a security signal (e.g. a presence simulator) must be
+  structurally unreachable from production: separate dev-only package, no registry entry,
+  opt-in-only construction, loud refusal under production environments. This is a standing
+  requirement on any such aid, enforced by negative tests wherever one exists.
 
 ## 8. Non-goals
 
@@ -137,9 +140,9 @@ packaging test suites.
 
 **In flight**: the `run` wrapper verb (stdio/signal-transparent); session signing leases with
 tamper-evident two-axis revocation; native backend parity (keychain via `security -i`, DPAPI,
-YubiKey ports); consumer test doubles (fault-injecting in-memory backend, presence simulator);
-the paired-double test strategy (stub framework, golden transcripts, flavored doubles, the
-manual-residue register).
+YubiKey ports); consumer test doubles (signing and fault-injection capabilities being added to
+the existing in-memory backend, plus a new presence simulator); the paired-double test
+strategy (stub framework, golden transcripts, flavored doubles, the manual-residue register).
 
 **Deliberately future**: the local redemption endpoint (opens rung 3 to any language);
 external key import with custody provenance modeled; verifier-visible assurance (a signature

--- a/docs/product/product-brief.md
+++ b/docs/product/product-brief.md
@@ -1,0 +1,158 @@
+# vaultkeeper Product Brief
+
+> The durable statement of what vaultkeeper is, who it serves, what it will not do, and how we
+> reason about its security claims. Companion to [PRFAQ.md](./PRFAQ.md); where the PRFAQ
+> persuades, this document decides. Kept current by the maintainers.
+
+## 1. The single value proposition
+
+**A massive step up in security and control over secrets, relative to plaintext keys sitting in
+a shell environment or on disk.**
+
+Everything vaultkeeper builds serves that sentence. The environment variable is the universal
+interface every tool already reads; vaultkeeper progressively upgrades *what occupies that
+slot* — from a plaintext credential, to a policy-resolved value that never rests on disk, to a
+capability lease that is not the secret at all.
+
+## 2. Positioning: unbundle storage from policy
+
+The products that offer scoped service tokens, dedicated vaults, and per-use approval bundle
+those capabilities with their storage — and price the bundle as a business subscription.
+Meanwhile the storage most developers already own (macOS Keychain, a YubiKey, DPAPI, libsecret,
+a 1Password personal account) is good, hardware-backed, and free — but ships with no governance
+layer: no scoped tokens, no expiry, no usage limits, no policy on who may resolve what.
+
+vaultkeeper is that governance layer, over the backend you already have. **Upgrade your storage
+independently of your policy**: Keychain today, hardware tomorrow, 1Password if you later want
+it — the policy vocabulary never changes. Local, offline, no cloud component, no subscription.
+
+The honest comparison boundary: versus plaintext-in-config (the actual status quo for most
+developers, including most MCP-server configs), rung 2 alone is a large, obvious win. Versus a
+user already on `op run` with a business account, the delta is policy, audit, expiry, and
+backend independence — real, but different. Both claims are true; we do not swap their
+audiences.
+
+## 3. The adoption gradient (three rungs, per secret)
+
+| Rung | Env var contains | Works with | What it buys |
+|---|---|---|---|
+| 1 | The plaintext secret, from a file | Everything | Nothing. The status quo being replaced. |
+| 2 | The real secret, resolved at launch | **Any unmodified tool** | No plaintext at rest; exposure bounded to a process lifetime; a policy decision (trust tier, TTL, presence) at every resolution; centralized rotation; kills the copy-paste-into-files habit. |
+| 3 | A **VaultKeeper lease** — an encrypted, expiring, revocable capability | vaultkeeper-aware consumers | The secret never enters the consumer's process; the lease is worthless off-box and after expiry; usage-limited; revocable per-lease and per-key. |
+
+The rung is chosen **per entry** in a profile, and mixing is the permanent steady state, not a
+migration phase. Rung 2's delivery mechanism is the `vaultkeeper run` wrapper — most visibly as
+the `command` in an MCP server config. Rung 3 is first-party-only today *by choice*; the
+language-agnostic local redemption endpoint that would open it to any consumer in any language
+is a named future epic, triggered by an installed base worth integrating against.
+
+## 4. Who it serves
+
+- **The individual developer with credential-bearing configs** — MCP servers, CLIs, local
+  services. Wants the PAT out of `mcp.json` with zero changes to the tools. Rung 2.
+- **The agent-fleet operator** — runs autonomous coding agents that need credentials but must
+  not durably hold them, and privileged automation identities (reviewers, adjudicators) whose
+  signing keys must be neither extractable nor invocable by the agents they govern. Rungs 2+3,
+  signing leases, presence-at-session-establishment.
+- **The consuming toolmaker** — builds software (e.g. attestation tooling) on vaultkeeper
+  custody and needs to test its integration without hardware or accounts. Served by the shipped
+  test doubles and the paired-double conformance strategy.
+
+## 5. Core concepts
+
+- **Backend** — where secrets live. Pluggable: file (encrypted), macOS Keychain, 1Password,
+  YubiKey, DPAPI, libsecret. Backends self-report **capabilities**; policy fails closed when a
+  capability is absent rather than silently downgrading.
+- **Capability token / lease** — an encrypted JWE granting scoped access: expiry, usage limit,
+  executable-identity binding at mint, revocation. The serialized, cross-process form is the
+  **lease**; "lease" is the house term for any serialized, expiring, revocable capability.
+- **Trust tier** — classification of the calling executable: `sigstore` (cryptographic
+  provenance) > `registry` (approved-hash manifest, TOFU) > `unverified`. Policy expresses a
+  minimum (`minTrust`), or-stronger.
+- **Presence** — a backend's ability to force a *fresh physical human action* for a specific
+  operation, right now (YubiKey touch, Touch ID, per-use biometric approval). Enforced
+  fail-closed; never simulated in production (the test simulator is structurally unreachable
+  there).
+- **Profile** — a named, committable, per-project set of env-var bindings, each entry carrying
+  its secret source, its rung (`materialize: "secret" | "lease"`), and its policy. Profiles
+  contain names and policy, never secrets; committing one makes policy loosening a reviewable
+  event.
+- **Delegated access** — `fetch`/`exec`/`sign` patterns where vaultkeeper performs the
+  operation and the raw secret never appears in the caller's memory; signing keys never leave
+  their backend at all.
+
+## 6. Architecture in one paragraph
+
+One semantic core in Rust (`vaultkeeper-core`), reached two ways: a native CLI, and TypeScript
+via a WASM bridge — with the TypeScript library's parallel logic being progressively retired as
+the core reaches parity (single-core consolidation). Backends are subprocess orchestration over
+a host-platform abstraction wherever the underlying store has a CLI (keychain, secret-tool,
+DPAPI, YubiKey); 1Password remains host-provided because its per-process desktop-app grant is
+reachable only through a mechanism the WASM sandbox cannot load. A data-driven conformance
+corpus runs against every implementation — and, by design, against every test double — so
+"the Rust and TypeScript flavors of the same experience" is enforced mechanically, not by
+promise.
+
+## 7. How we make security claims
+
+The rule: **a claim appears in docs only if the code enforces it; a mechanism that only
+appears to deliver a property is treated as a defect.** Standing consequences:
+
+- Per-rung threat honesty. Rung 2 provides essentially zero confidentiality against same-UID
+  code execution; its real adversaries are exfiltration-at-rest and accidental disclosure. We
+  say this everywhere the value proposition is stated.
+- A lease's decisive property is off-box worthlessness — the leak class that actually happens
+  (log aggregators, telemetry, bug reports).
+- Non-invocability of a privileged identity requires OS-level isolation; custody cannot
+  substitute for it, and every custody recommendation states the precondition.
+- Fail-closed is the default posture: unknown backends report no capabilities; corrupt or
+  missing revocation state refuses lease validation; config naming an unavailable backend is an
+  error, never a silent fallback.
+- Test aids that could forge a security signal (the presence simulator) ship structurally
+  unreachable from production: separate dev-only package, no registry entry, opt-in-only
+  construction, loud refusal under production environments.
+
+## 8. Non-goals
+
+- **Team sync, cloud storage, cross-device distribution.** Subscription products earn their fee
+  there; competing would require becoming a cloud service and forfeiting "nothing leaves your
+  machine." Single-machine, single-developer parity is the scope.
+- **Locked-down corporate MCP environments** (proxy, cert auth, curated servers) — users there
+  cannot edit configs and do not have this problem.
+- **Matching 1Password's UX breadth.** Biometric ergonomics, browser integration, and sharing
+  are not the competition; custody policy is.
+- **Modeling signature *semantics*** (authorship vs approval). What a signature means belongs to
+  the verifying system's per-gate policy; vaultkeeper makes identities distinguishable and
+  their keys non-transferable, and stops there.
+
+## 9. State of the world
+
+**Shipped** (through `vaultkeeper@0.7.x`): the Rust core — backends (file, in-memory,
+secret-tool), JWE capability tokens, key management and rotation, trust tiers/TOFU, the
+presence model, detached-JWS signing with backend-held Ed25519 keys, the opaque handle table
+with bearer-safe redaction, encrypted key-state persistence, the environment-profile
+primitive, the lease-aware claims validator; the TypeScript SDK/CLI with the full backend
+suite; the WASM bridge with host-callback contracts; OIDC trusted publishing; conformance and
+packaging test suites.
+
+**In flight**: the `run` wrapper verb (stdio/signal-transparent); session signing leases with
+tamper-evident two-axis revocation; native backend parity (keychain via `security -i`, DPAPI,
+YubiKey ports); consumer test doubles (fault-injecting in-memory backend, presence simulator);
+the paired-double test strategy (stub framework, golden transcripts, flavored doubles, the
+manual-residue register).
+
+**Deliberately future**: the local redemption endpoint (opens rung 3 to any language);
+external key import with custody provenance modeled; verifier-visible assurance (a signature
+provably presence-backed); issuance-side principal checks binding capabilities to the invoking
+context.
+
+## 10. How we measure success
+
+- A new user gets a secret out of plaintext and behind policy in under five minutes, without
+  modifying the consuming tool.
+- The manual-testing residue stays a minutes-scale, tool-upgrade-triggered checklist — never a
+  suite that can rot unrun.
+- Consumers (starting with attestation tooling) cover their vaultkeeper integration on every
+  PR using shipped doubles, with zero hardware.
+- Every security property claimed in this document has a test that fails when the property
+  regresses.


### PR DESCRIPTION
Adds the two durable product documents the repo has lacked: a statement of what vaultkeeper is for, and the reference against which scope and security claims get decided.

**`docs/product/PRFAQ.md`** — press-release framing of the value proposition (policy-enforced secret custody over the credential store you already own, no subscription), plus an FAQ that is deliberately honest about limits: what the tool does and does not defend against, what exists today versus what is in flight, and the non-goals.

**`docs/product/product-brief.md`** — the deciding document: single value proposition, storage-vs-policy positioning, the three-rung adoption gradient (plaintext → resolved environment → lease), personas, core concepts in the house vocabulary (lease, minTrust, presence, profiles), the security-claim policy (a claim appears in docs only if code enforces it), non-goals, current state, and success measures.

Docs-only; no package changes, no changeset. Content reflects the shipped 0.7.x surface and the active epics (profiles/run, signing leases, backend consolidation, test strategy) without internal process references.