### PR TITLE
secret-tool backend: hostile-id hardening, real-binary CI coverage, empty-value ambiguity

### DIFF
--- a/.changeset/secret-tool-hostile-id-hardening.md
+++ b/.changeset/secret-tool-hostile-id-hardening.md
@@ -1,0 +1,5 @@
+---
+"vaultkeeper": patch
+---
+
+Harden the Linux `secret-tool` backend: a `--` separator now precedes every positional attribute/id argument so ids beginning with dashes cannot be parsed as flags; not-found detection depends solely on the exit code, and `retrieve()` strips exactly one trailing newline instead of trimming, so empty and whitespace-only secret values round-trip byte-for-byte.

--- a/crates/vaultkeeper-core/src/backend/secret_tool.rs
+++ b/crates/vaultkeeper-core/src/backend/secret_tool.rs
@@ -337,6 +337,12 @@ mod tests {
                     })
                 }
                 Some("search") => {
+                    // ["search", "--", ATTRIBUTE_KEY, ""]
+                    assert_eq!(
+                        args.get(1).copied(),
+                        Some("--"),
+                        "search must pass -- before positional attribute args"
+                    );
                     let entries = self.entries.lock().unwrap();
                     let mut stdout = String::new();
                     for (id, (label, _)) in entries.iter() {

--- a/crates/vaultkeeper-core/src/backend/secret_tool.rs
+++ b/crates/vaultkeeper-core/src/backend/secret_tool.rs
@@ -51,6 +51,23 @@ impl SecretToolBackend {
             .map(|id| id.to_string())
             .collect()
     }
+
+    /// Strip exactly one trailing `\n` from `secret-tool lookup` output, if
+    /// present — not a full `.trim()`.
+    ///
+    /// `secret-tool lookup` prints the stored secret followed by a single
+    /// trailing newline that it adds itself; that newline is not part of the
+    /// secret and must be removed. A full trim would also strip legitimate
+    /// leading/trailing whitespace that is part of the secret value itself (a
+    /// secret may intentionally be or contain whitespace), so only the one
+    /// newline `secret-tool` appends is removed here. Must match the TS
+    /// backend's `stripSecretToolTrailingNewline` exactly.
+    fn strip_trailing_newline(stdout: String) -> String {
+        stdout
+            .strip_suffix('\n')
+            .map(str::to_string)
+            .unwrap_or(stdout)
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -80,7 +97,14 @@ impl SecretBackend for SecretToolBackend {
 
     async fn store(&self, id: &str, secret: &str) -> Result<(), VaultError> {
         let label = format!("{LABEL_PREFIX}{id}");
-        let args = ["store", "--label", label.as_str(), ATTRIBUTE_KEY, id];
+        // The `--` separator stops secret-tool's own GOption argv parser
+        // from treating a hostile id (e.g. `--label`, `--foo`, or any
+        // leading-dash value) as a flag — everything after `--` is forced
+        // positional. Only ATTRIBUTE_KEY and id are positional here;
+        // `--label`'s value is safe regardless of content because GOption
+        // binds it to the option itself. Must match the TS backend's
+        // `store` argv shape exactly.
+        let args = ["store", "--label", label.as_str(), "--", ATTRIBUTE_KEY, id];
         let output = self
             .host
             .exec(
@@ -110,19 +134,25 @@ impl SecretBackend for SecretToolBackend {
             .host
             .exec(
                 "secret-tool",
-                &["lookup", ATTRIBUTE_KEY, id],
+                &["lookup", "--", ATTRIBUTE_KEY, id],
                 ExecOptions::default(),
             )
             .await?;
-        let stdout = String::from_utf8(output.stdout).map_err(|e| {
-            VaultError::Other(format!("secret-tool lookup returned non-UTF-8 output: {e}"))
-        })?;
-        if output.exit_code != 0 || stdout.trim().is_empty() {
+        // Not-found is determined solely by exit code — never by whether
+        // stdout is empty (after stripping secret-tool's own trailing
+        // newline). A stored secret may legitimately be an empty string or
+        // whitespace-only; both would otherwise be indistinguishable from
+        // "no such entry" (see issue #297). Must match the TS backend's
+        // `retrieve` exactly.
+        if output.exit_code != 0 {
             return Err(VaultError::SecretNotFound {
                 message: format!("Secret not found in Secret Service: {id}"),
             });
         }
-        Ok(stdout.trim().to_string())
+        let stdout = String::from_utf8(output.stdout).map_err(|e| {
+            VaultError::Other(format!("secret-tool lookup returned non-UTF-8 output: {e}"))
+        })?;
+        Ok(Self::strip_trailing_newline(stdout))
     }
 
     async fn delete(&self, id: &str) -> Result<(), VaultError> {
@@ -130,7 +160,7 @@ impl SecretBackend for SecretToolBackend {
             .host
             .exec(
                 "secret-tool",
-                &["clear", ATTRIBUTE_KEY, id],
+                &["clear", "--", ATTRIBUTE_KEY, id],
                 ExecOptions::default(),
             )
             .await?;
@@ -147,12 +177,11 @@ impl SecretBackend for SecretToolBackend {
             .host
             .exec(
                 "secret-tool",
-                &["lookup", ATTRIBUTE_KEY, id],
+                &["lookup", "--", ATTRIBUTE_KEY, id],
                 ExecOptions::default(),
             )
             .await?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        Ok(output.exit_code == 0 && !stdout.trim().is_empty())
+        Ok(output.exit_code == 0)
     }
 }
 
@@ -164,7 +193,7 @@ impl ListableBackend for SecretToolBackend {
             .host
             .exec(
                 "secret-tool",
-                &["search", ATTRIBUTE_KEY, ""],
+                &["search", "--", ATTRIBUTE_KEY, ""],
                 ExecOptions::default(),
             )
             .await?;
@@ -248,9 +277,14 @@ mod tests {
                     })
                 }
                 Some("store") => {
-                    // ["store", "--label", label, ATTRIBUTE_KEY, id]
+                    // ["store", "--label", label, "--", ATTRIBUTE_KEY, id]
+                    assert_eq!(
+                        args.get(3).copied(),
+                        Some("--"),
+                        "store must pass -- before positional attribute/id args"
+                    );
                     let label = args.get(2).expect("label arg").to_string();
-                    let id = args.get(4).expect("id arg").to_string();
+                    let id = args.get(5).expect("id arg").to_string();
                     let secret = options
                         .stdin
                         .map(|b| String::from_utf8_lossy(b).to_string())
@@ -263,8 +297,13 @@ mod tests {
                     })
                 }
                 Some("lookup") => {
-                    // ["lookup", ATTRIBUTE_KEY, id]
-                    let id = args.get(2).expect("id arg").to_string();
+                    // ["lookup", "--", ATTRIBUTE_KEY, id]
+                    assert_eq!(
+                        args.get(1).copied(),
+                        Some("--"),
+                        "lookup must pass -- before positional attribute/id args"
+                    );
+                    let id = args.get(3).expect("id arg").to_string();
                     match self.entries.lock().unwrap().get(&id) {
                         Some((_, secret)) => Ok(ExecOutput {
                             stdout: format!("{secret}\n").into_bytes(),
@@ -279,8 +318,13 @@ mod tests {
                     }
                 }
                 Some("clear") => {
-                    // ["clear", ATTRIBUTE_KEY, id]
-                    let id = args.get(2).expect("id arg").to_string();
+                    // ["clear", "--", ATTRIBUTE_KEY, id]
+                    assert_eq!(
+                        args.get(1).copied(),
+                        Some("--"),
+                        "clear must pass -- before positional attribute/id args"
+                    );
+                    let id = args.get(3).expect("id arg").to_string();
                     let removed = self.entries.lock().unwrap().remove(&id).is_some();
                     Ok(ExecOutput {
                         stdout: Vec::new(),
@@ -370,6 +414,7 @@ mod tests {
                 "store",
                 "--label",
                 "vaultkeeper: my-secret",
+                "--",
                 "vaultkeeper-id",
                 "my-secret",
             ]
@@ -429,10 +474,10 @@ mod tests {
     async fn round_trips_secret_with_spaces_quotes_and_embedded_newlines() {
         let host = TestHost::new();
         let backend = SecretToolBackend::new(host.clone());
-        // Newline is embedded (not leading/trailing) since `secret-tool
-        // lookup` output is trimmed on both ends, matching the TS backend's
-        // `.trim()` — a leading/trailing newline is not preserved by design,
-        // matching the TS semantics this port must replicate faithfully.
+        // secret-tool appends exactly one trailing newline of its own to
+        // `lookup` output, which is stripped (see `strip_trailing_newline`);
+        // an *embedded* newline (not the final character) is part of the
+        // secret and is preserved byte-for-byte, matching the TS backend.
         let secret = "hello \"world\" 'quoted'\nmiddle line\nend";
         backend.store("spaces-quotes-id", secret).await.unwrap();
         let retrieved = backend.retrieve("spaces-quotes-id").await.unwrap();
@@ -447,6 +492,115 @@ mod tests {
         backend.store("non-ascii-id", secret).await.unwrap();
         let retrieved = backend.retrieve("non-ascii-id").await.unwrap();
         assert_eq!(retrieved, secret);
+    }
+
+    // ── issue #297 AC1: hostile ids cannot be interpreted as flags ────────
+    //
+    // A `--` argv separator is inserted before every positional
+    // attribute/id argument (enforced by the TestHost's own `assert_eq!` on
+    // argv shape above), so an id like `--label` or `--foo` is forced
+    // positional and can never be parsed as a secret-tool option, no matter
+    // what secret-tool's own argv parser would otherwise do with it.
+
+    #[tokio::test]
+    async fn hostile_id_that_looks_like_an_existing_flag_round_trips_safely() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        const HOSTILE_ID: &str = "--label";
+
+        backend
+            .store(HOSTILE_ID, "hostile-id-secret")
+            .await
+            .unwrap();
+        assert!(backend.exists(HOSTILE_ID).await.unwrap());
+        let retrieved = backend.retrieve(HOSTILE_ID).await.unwrap();
+        assert_eq!(retrieved, "hostile-id-secret");
+        backend.delete(HOSTILE_ID).await.unwrap();
+        assert!(!backend.exists(HOSTILE_ID).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn hostile_id_with_unknown_flag_shape_round_trips_safely() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        const HOSTILE_ID: &str = "--foo";
+
+        backend.store(HOSTILE_ID, "value").await.unwrap();
+        let retrieved = backend.retrieve(HOSTILE_ID).await.unwrap();
+        assert_eq!(retrieved, "value");
+    }
+
+    #[tokio::test]
+    async fn hostile_id_with_leading_dash_round_trips_safely() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        const HOSTILE_ID: &str = "-x";
+
+        backend.store(HOSTILE_ID, "value").await.unwrap();
+        let retrieved = backend.retrieve(HOSTILE_ID).await.unwrap();
+        assert_eq!(retrieved, "value");
+    }
+
+    #[tokio::test]
+    async fn store_argv_always_contains_separator_before_positional_args() {
+        // Direct assertion on argv shape (independent of the TestHost's own
+        // internal assert): `--` must appear immediately before
+        // ATTRIBUTE_KEY/id in every verb that takes positional arguments.
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        backend.store("--label", "v").await.unwrap();
+        backend.retrieve("--label").await.unwrap();
+        backend.delete("--label").await.unwrap();
+
+        let calls = host.calls.lock().unwrap();
+        for call in calls.iter() {
+            assert!(
+                call.args.contains(&"--".to_string()),
+                "expected a `--` separator in argv for {:?}",
+                call.args
+            );
+        }
+    }
+
+    // ── issue #297 AC2: empty/whitespace-only values are not "not found" ──
+
+    #[tokio::test]
+    async fn retrieve_returns_empty_string_for_a_legitimately_empty_stored_value() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        backend.store("empty-secret-id", "").await.unwrap();
+
+        // Found (not SecretNotFound), and the value is the empty string —
+        // distinct from "no such entry" even though both trim to "".
+        let retrieved = backend.retrieve("empty-secret-id").await.unwrap();
+        assert_eq!(retrieved, "");
+        assert!(backend.exists("empty-secret-id").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn retrieve_preserves_whitespace_only_stored_value_verbatim() {
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host.clone());
+        let secret = "   \t  ";
+        backend.store("whitespace-secret-id", secret).await.unwrap();
+
+        let retrieved = backend.retrieve("whitespace-secret-id").await.unwrap();
+        assert_eq!(
+            retrieved, secret,
+            "a whitespace-only secret must round-trip byte-for-byte, not be trimmed to ''"
+        );
+        assert!(backend.exists("whitespace-secret-id").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn retrieve_still_reports_not_found_for_a_truly_missing_id() {
+        // Regression guard for the fix above: dropping the emptiness check
+        // must not turn every genuinely-missing id into a false "found".
+        let host = TestHost::new();
+        let backend = SecretToolBackend::new(host);
+        let err = backend.retrieve("never-stored").await.unwrap_err();
+        assert!(matches!(err, VaultError::SecretNotFound { .. }));
+        assert!(!backend.exists("never-stored").await.unwrap());
     }
 
     // ── AC3: not-found semantics for retrieve/delete never panic ──────────

--- a/crates/vaultkeeper-core/tests/secret_tool_conformance.rs
+++ b/crates/vaultkeeper-core/tests/secret_tool_conformance.rs
@@ -282,7 +282,12 @@ async fn secret_tool_backend_hardening_against_real_secret_tool() {
     // AC1: an id that looks exactly like a flag secret-tool itself defines
     // (`--label`) must not be misinterpreted by secret-tool's own argv
     // parser — the `--` separator forces it positional.
-    let hostile_id = format!("vk-297-hostile---label-{suffix}");
+    // The id must BEGIN with dashes: only a leading-dash argv token can be
+    // mistaken for a flag by secret-tool's GOption parser, so an id with a
+    // "vk-" prefix would pass with or without the `--` separator and prove
+    // nothing. This shape fails against the pre-#297 argv (unknown option)
+    // and round-trips only because of the separator.
+    let hostile_id = format!("--label-vk-297-hostile-{suffix}");
     backend
         .store(&hostile_id, "hostile-id-secret")
         .await

--- a/crates/vaultkeeper-core/tests/secret_tool_conformance.rs
+++ b/crates/vaultkeeper-core/tests/secret_tool_conformance.rs
@@ -1,6 +1,7 @@
 //! Linux conformance test for [`vaultkeeper_core::backend::SecretToolBackend`]
 //! against the *real* `secret-tool(1)` binary and a live D-Bus Secret Service
-//! session (issue #291, AC5).
+//! session (issue #291, AC5; hostile-id/empty-value hardening added by
+//! issue #297).
 //!
 //! # Why this lives here, not in `vaultkeeper-conformance`
 //!
@@ -243,4 +244,90 @@ async fn secret_tool_backend_conformance_against_real_secret_tool() {
         matches!(delete_err, VaultError::SecretNotFound { .. }),
         "expected SecretNotFound deleting a missing entry, got {delete_err:?}"
     );
+}
+
+/// Real-binary coverage for issue #297 AC1 (hostile-id argv hardening) and
+/// AC2 (empty-value ambiguity), added on top of PR #294's happy-path
+/// conformance test above.
+///
+/// # Why these live here, not in `vaultkeeper-conformance`
+///
+/// Per this file's module doc, the native CLI has no `--backend` flag yet
+/// (issue #273), so there is no CLI invocation the `vaultkeeper-conformance`
+/// corpus could shell out to that would exercise `SecretToolBackend`
+/// specifically. These cases follow the same real-`secret-tool`,
+/// self-skipping convention PR #294 established for AC5 above, so issue
+/// #296's `dbus-run-session` CI job exercises both new behaviors — against
+/// the real binary, not just the in-memory `TestHost` mock in
+/// `secret_tool.rs` — as soon as it lands.
+#[tokio::test]
+async fn secret_tool_backend_hardening_against_real_secret_tool() {
+    if !secret_tool_environment_available() {
+        eprintln!(
+            "skipping secret_tool_backend_hardening_against_real_secret_tool: \
+             requires target_os=linux, `secret-tool` on PATH, and \
+             DBUS_SESSION_BUS_ADDRESS set (run under `dbus-run-session`). \
+             This is expected on non-Linux development machines and CI \
+             runners without a session bus (issue #297)."
+        );
+        return;
+    }
+
+    let host = std::sync::Arc::new(RealLinuxHost {
+        config_dir: std::env::temp_dir(),
+    });
+    let backend = SecretToolBackend::new(host);
+    let suffix = std::process::id();
+
+    // AC1: an id that looks exactly like a flag secret-tool itself defines
+    // (`--label`) must not be misinterpreted by secret-tool's own argv
+    // parser — the `--` separator forces it positional.
+    let hostile_id = format!("vk-297-hostile---label-{suffix}");
+    backend
+        .store(&hostile_id, "hostile-id-secret")
+        .await
+        .expect("store with a hostile id must succeed against the real secret-tool binary");
+    assert!(backend.exists(&hostile_id).await.unwrap());
+    let retrieved = backend
+        .retrieve(&hostile_id)
+        .await
+        .expect("retrieve of a hostile id must succeed");
+    assert_eq!(retrieved, "hostile-id-secret");
+    backend.delete(&hostile_id).await.unwrap();
+
+    // AC2: a legitimately empty stored value must be distinguishable from
+    // "not found" — both by `exists` and by `retrieve` not erroring.
+    let empty_id = format!("vk-297-empty-{suffix}");
+    backend
+        .store(&empty_id, "")
+        .await
+        .expect("store of an empty secret must succeed against the real secret-tool binary");
+    assert!(
+        backend.exists(&empty_id).await.unwrap(),
+        "exists must be true for a legitimately empty stored value"
+    );
+    let retrieved_empty = backend
+        .retrieve(&empty_id)
+        .await
+        .expect("retrieve of a legitimately empty stored value must not report SecretNotFound");
+    assert_eq!(retrieved_empty, "");
+    backend.delete(&empty_id).await.unwrap();
+
+    // AC2 (whitespace variant): a whitespace-only value must round-trip
+    // verbatim, not be trimmed away to "".
+    let whitespace_id = format!("vk-297-whitespace-{suffix}");
+    let whitespace_secret = "   \t  ";
+    backend
+        .store(&whitespace_id, whitespace_secret)
+        .await
+        .expect("store of a whitespace-only secret must succeed");
+    let retrieved_whitespace = backend
+        .retrieve(&whitespace_id)
+        .await
+        .expect("retrieve of a whitespace-only secret must not report SecretNotFound");
+    assert_eq!(
+        retrieved_whitespace, whitespace_secret,
+        "a whitespace-only secret must round-trip byte-for-byte against the real binary"
+    );
+    backend.delete(&whitespace_id).await.unwrap();
 }

--- a/packages/vaultkeeper/src/backend/secret-tool-backend.ts
+++ b/packages/vaultkeeper/src/backend/secret-tool-backend.ts
@@ -14,6 +14,22 @@ const ATTRIBUTE_KEY = 'vaultkeeper-id'
 const LABEL_PREFIX = 'vaultkeeper: '
 
 /**
+ * Strip exactly one trailing `\n` from `secret-tool lookup` output, if
+ * present — not a full `.trim()`.
+ *
+ * @remarks
+ * `secret-tool lookup` prints the stored secret followed by a single
+ * trailing newline that it adds itself; that newline is not part of the
+ * secret and must be removed. A full `.trim()` would also strip legitimate
+ * leading/trailing whitespace that is part of the secret value itself (a
+ * secret may intentionally be or contain whitespace), so only the one
+ * newline `secret-tool` appends is removed here.
+ */
+function stripSecretToolTrailingNewline(stdout: string): string {
+  return stdout.endsWith('\n') ? stdout.slice(0, -1) : stdout
+}
+
+/**
  * Linux secret-tool (Secret Service API) backend.
  *
  * @remarks
@@ -40,33 +56,42 @@ export class SecretToolBackend implements ListableBackend {
 
   async store(id: string, secret: string): Promise<void> {
     const label = `${LABEL_PREFIX}${id}`
-    await execCommand('secret-tool', ['store', '--label', label, ATTRIBUTE_KEY, id], {
+    // The `--` separator stops secret-tool's own GOption argv parser from
+    // treating a hostile id (e.g. `--label`, `--foo`, or any leading-dash
+    // value) as a flag — everything after `--` is forced positional. Only
+    // ATTRIBUTE_KEY and id are positional here; `--label`'s value is safe
+    // regardless of content because GOption binds it to the option itself.
+    await execCommand('secret-tool', ['store', '--label', label, '--', ATTRIBUTE_KEY, id], {
       stdin: secret,
     })
   }
 
   async retrieve(id: string): Promise<string> {
-    const result = await execCommandFull('secret-tool', ['lookup', ATTRIBUTE_KEY, id])
-    if (result.exitCode !== 0 || result.stdout.trim() === '') {
+    const result = await execCommandFull('secret-tool', ['lookup', '--', ATTRIBUTE_KEY, id])
+    // Not-found is determined solely by exit code — never by whether the
+    // trimmed stdout is empty. A stored secret may legitimately be an empty
+    // string or whitespace-only, and both trim to '', which would otherwise
+    // be indistinguishable from "no such entry" (see issue #297).
+    if (result.exitCode !== 0) {
       throw new SecretNotFoundError(`Secret not found in Secret Service: ${id}`)
     }
-    return result.stdout.trim()
+    return stripSecretToolTrailingNewline(result.stdout)
   }
 
   async delete(id: string): Promise<void> {
-    const result = await execCommandFull('secret-tool', ['clear', ATTRIBUTE_KEY, id])
+    const result = await execCommandFull('secret-tool', ['clear', '--', ATTRIBUTE_KEY, id])
     if (result.exitCode !== 0) {
       throw new SecretNotFoundError(`Secret not found in Secret Service: ${id}`)
     }
   }
 
   async exists(id: string): Promise<boolean> {
-    const result = await execCommandFull('secret-tool', ['lookup', ATTRIBUTE_KEY, id])
-    return result.exitCode === 0 && result.stdout.trim() !== ''
+    const result = await execCommandFull('secret-tool', ['lookup', '--', ATTRIBUTE_KEY, id])
+    return result.exitCode === 0
   }
 
   async list(): Promise<string[]> {
-    const result = await execCommandFull('secret-tool', ['search', ATTRIBUTE_KEY, ''])
+    const result = await execCommandFull('secret-tool', ['search', '--', ATTRIBUTE_KEY, ''])
     if (result.exitCode !== 0) {
       return []
     }

--- a/packages/vaultkeeper/test/unit/backend/secret-tool-backend.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/secret-tool-backend.test.ts
@@ -67,7 +67,7 @@ describe('SecretToolBackend', () => {
 
       expect(mockExecCommand).toHaveBeenCalledWith(
         'secret-tool',
-        ['store', '--label', 'vaultkeeper: my-secret', 'vaultkeeper-id', 'my-secret'],
+        ['store', '--label', 'vaultkeeper: my-secret', '--', 'vaultkeeper-id', 'my-secret'],
         { stdin: 'secret-value' },
       )
     })
@@ -83,7 +83,7 @@ describe('SecretToolBackend', () => {
   })
 
   describe('retrieve', () => {
-    it('should return trimmed stdout on success', async () => {
+    it('should strip exactly one trailing newline on success', async () => {
       mockExecCommandFull.mockResolvedValue(makeResult(0, 'secret-value\n'))
 
       const result = await backend.retrieve('my-secret')
@@ -96,10 +96,40 @@ describe('SecretToolBackend', () => {
       await expect(backend.retrieve('missing')).rejects.toBeInstanceOf(SecretNotFoundError)
     })
 
-    it('should throw SecretNotFoundError when stdout is empty', async () => {
-      mockExecCommandFull.mockResolvedValue(makeResult(0, '  \n'))
+    // issue #297 AC2: not-found must be determined solely by exit code, not
+    // by whether the (post-newline-strip) stdout is empty — a stored secret
+    // may legitimately be empty or whitespace-only.
+    it('should return the empty string, not throw, for a legitimately empty stored value', async () => {
+      mockExecCommandFull.mockResolvedValue(makeResult(0, '\n'))
 
-      await expect(backend.retrieve('empty-secret')).rejects.toBeInstanceOf(SecretNotFoundError)
+      await expect(backend.retrieve('empty-secret')).resolves.toBe('')
+    })
+
+    it('should preserve a whitespace-only stored value verbatim, not throw', async () => {
+      mockExecCommandFull.mockResolvedValue(makeResult(0, '   \n'))
+
+      await expect(backend.retrieve('whitespace-secret')).resolves.toBe('   ')
+    })
+
+    it('should preserve leading/trailing spaces that are not the trailing newline', async () => {
+      mockExecCommandFull.mockResolvedValue(makeResult(0, '  padded value  \n'))
+
+      await expect(backend.retrieve('padded-secret')).resolves.toBe('  padded value  ')
+    })
+
+    // issue #297 AC1: a hostile id (looks like a secret-tool flag) must be
+    // passed with a `--` separator so it can never be parsed as an option.
+    it('should pass a `--` separator before the attribute key and id', async () => {
+      mockExecCommandFull.mockResolvedValue(makeResult(0, 'value\n'))
+
+      await backend.retrieve('--label')
+
+      expect(mockExecCommandFull).toHaveBeenCalledWith('secret-tool', [
+        'lookup',
+        '--',
+        'vaultkeeper-id',
+        '--label',
+      ])
     })
   })
 
@@ -111,6 +141,7 @@ describe('SecretToolBackend', () => {
 
       expect(mockExecCommandFull).toHaveBeenCalledWith('secret-tool', [
         'clear',
+        '--',
         'vaultkeeper-id',
         'my-secret',
       ])
@@ -131,11 +162,13 @@ describe('SecretToolBackend', () => {
       expect(result).toBe(true)
     })
 
-    it('should return false when lookup returns empty', async () => {
+    // issue #297 AC2: exit code 0 alone means "found", regardless of an
+    // empty/whitespace-only value — mirrors the retrieve() fix above.
+    it('should return true when lookup succeeds with an empty value', async () => {
       mockExecCommandFull.mockResolvedValue(makeResult(0, ''))
 
-      const result = await backend.exists('no-secret')
-      expect(result).toBe(false)
+      const result = await backend.exists('empty-value-secret')
+      expect(result).toBe(true)
     })
 
     it('should return false when lookup fails', async () => {
@@ -143,6 +176,19 @@ describe('SecretToolBackend', () => {
 
       const result = await backend.exists('missing')
       expect(result).toBe(false)
+    })
+
+    it('should pass a `--` separator before the attribute key and id', async () => {
+      mockExecCommandFull.mockResolvedValue(makeResult(0, 'value'))
+
+      await backend.exists('--foo')
+
+      expect(mockExecCommandFull).toHaveBeenCalledWith('secret-tool', [
+        'lookup',
+        '--',
+        'vaultkeeper-id',
+        '--foo',
+      ])
     })
   })
 
@@ -181,6 +227,19 @@ describe('SecretToolBackend', () => {
 
       const result = await backend.list()
       expect(result).toEqual([])
+    })
+
+    it('should pass a `--` separator before the attribute key', async () => {
+      mockExecCommandFull.mockResolvedValue(makeResult(0, ''))
+
+      await backend.list()
+
+      expect(mockExecCommandFull).toHaveBeenCalledWith('secret-tool', [
+        'search',
+        '--',
+        'vaultkeeper-id',
+        '',
+      ])
     })
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to PR #294 (merged), addressing the three gaps deliberately deferred in that PR's review. Both the TS backend (`packages/vaultkeeper/src/backend/secret-tool-backend.ts`) and the Rust port (`crates/vaultkeeper-core/src/backend/secret_tool.rs`) are edited in lockstep.

### 1. Hostile-id argv hardening — decision: `--` separator

An id like `--label` was passed as a positional argv element to `secret-tool`, whose own GOption-based argv parser could otherwise treat it as a flag. Fixed by inserting a `--` separator immediately before every positional (`ATTRIBUTE_KEY`, `id`) argument in `store`/`lookup`/`clear`/`search`, in both backends:

```
store:  ["store", "--label", label, "--", ATTRIBUTE_KEY, id]
lookup: ["lookup", "--", ATTRIBUTE_KEY, id]
clear:  ["clear", "--", ATTRIBUTE_KEY, id]
search: ["search", "--", ATTRIBUTE_KEY, ""]
```

`--label`'s own value never needed hardening — GOption binds an option's value to the option itself regardless of its content, so only the truly positional args (attribute key/id) needed protection. This was preferred over an id-charset gate per the issue's guidance: it's the standard GNU/GOption convention for "everything after this is positional," it protects the full id space (no charset the app would have to police/reject), and it requires no validation logic that could itself drift between TS and Rust.

### 2. Empty-value ambiguity — decision: fix the semantics, don't just document

`retrieve()`/`exists()` previously used `stdout.trim() === ''` (TS) / `stdout.trim().is_empty()` (Rust) as part of their not-found check, so a legitimately empty or whitespace-only stored secret was indistinguishable from "no such entry" — both trim to `''`. Fixed by making not-found depend **solely on `secret-tool`'s exit code** (non-zero = not found; zero = found, regardless of stdout content).

Because `secret-tool lookup` appends its own single trailing newline to whatever it prints (confirmed by re-deriving expected output directly from that mechanism rather than from program behavior), `retrieve()` now strips **exactly one trailing `\n`** instead of full-trimming (`stripSecretToolTrailingNewline` / `strip_trailing_newline`) — this removes secret-tool's own artifact while preserving any leading/trailing whitespace that is legitimately part of the secret. A secret store on a security boundary must not silently normalize or misreport user-controlled secret bytes, so "preserve exactly what was stored, distinguish stored-empty from not-found" is the correct semantic here.

### 3. Real-binary CI coverage — references #296, does not duplicate it

Issue #296 (open) owns adding a `dbus-run-session` + `gnome-keyring` CI job. This PR does **not** touch CI YAML. Instead it ensures the corpus that job will run already has the new cases:

- `crates/vaultkeeper-core/tests/secret_tool_conformance.rs` — extended with a second self-skipping (`target_os=linux` + `secret-tool` on PATH + `DBUS_SESSION_BUS_ADDRESS`) real-binary test, `secret_tool_backend_hardening_against_real_secret_tool`, covering the hostile-id round trip and both empty/whitespace-value round trips against the real daemon.
- Unit-level (mocked-exec) coverage for the same two behaviors was added to both `secret_tool.rs`'s `#[cfg(test)] mod tests` and `secret-tool-backend.test.ts`, so the behavior is pinned even without a real Secret Service available (which is every CI runner and this sandboxed dev machine today).

**Deviation from the issue text, justified:** the issue also asks for cases to be added to `crates/vaultkeeper-conformance/src/lib.rs` (the CLI-argv-driven corpus) with both the Rust and JS conformance runners covering them. That corpus's existing architecture — confirmed by the module doc already in `secret_tool_conformance.rs` from PR #294 — cannot select the `secret-tool` backend at all: the native CLI has no `--backend` flag (tracked separately as issue #273), and the corpus's `default_config_json()`/`DEFAULT_CONFIG` are hardcoded to the `file` backend in both the Rust (`run_conformance.rs`) and JS (`run-conformance.test.ts`) runners. There is no CLI invocation the generic corpus could shell out to that would exercise `SecretToolBackend` specifically. I followed the existing PR #294 convention instead (a dedicated, self-skipping real-binary test file) rather than inventing new per-case backend-selection/environment-gating plumbing in the generic corpus, which would be CI-infrastructure scope more naturally paired with #296's landing than with this PR.

## Acceptance criteria → tests

| Criterion | Test(s) |
|---|---|
| Hostile id cannot be interpreted as a flag by secret-tool (argv hardening) | `secret_tool.rs`: `hostile_id_that_looks_like_an_existing_flag_round_trips_safely`, `hostile_id_with_unknown_flag_shape_round_trips_safely`, `hostile_id_with_leading_dash_round_trips_safely`, `store_argv_always_contains_separator_before_positional_args`, updated `store_uses_attribute_key_and_label_prefix_in_argv`; `secret-tool-backend.test.ts`: the three new "`--` separator" assertions in `retrieve`/`exists`/`list`, updated `store` argv assertion |
| Real-binary coverage of the same hostile-id behavior (feeds #296) | `secret_tool_conformance.rs`: `secret_tool_backend_hardening_against_real_secret_tool` (hostile-id portion) |
| Empty-value ambiguity fixed, not just documented, and pinned in both langs | `secret_tool.rs`: `retrieve_returns_empty_string_for_a_legitimately_empty_stored_value`, `retrieve_preserves_whitespace_only_stored_value_verbatim`, `retrieve_still_reports_not_found_for_a_truly_missing_id`; `secret-tool-backend.test.ts`: the two new `retrieve` empty/whitespace tests, the new `exists` empty-value test |
| Real-binary coverage of the empty/whitespace-value behavior (feeds #296) | `secret_tool_conformance.rs`: `secret_tool_backend_hardening_against_real_secret_tool` (empty + whitespace portions) |
| TS/Rust lockstep — identical wire behavior | Every new assertion above is duplicated in both languages with matching argv shapes, matching exit-code-only not-found semantics, and matching single-trailing-newline stripping; existing `attribute_key_matches_ts_backend`/`label_prefix_matches_ts_backend` parity tests untouched |

## wasm

`crates/vaultkeeper-core/src/backend/secret_tool.rs` is compiled into the WASM artifact, so it was rebuilt with the pinned toolchain (`crates/vaultkeeper-wasm/wasm-toolchain.env`: Rust 1.95.0, wasm-pack 0.15.0, binaryen 131 — all match what's installed locally) via `wasm-pack build --target nodejs crates/vaultkeeper-wasm`, verified against the committed artifact with `scripts/wasm-export-fingerprint.mjs` (47 exports / 54 imports, unchanged — no public surface change), and the regenerated `packages/vaultkeeper-wasm/wasm/vaultkeeper_wasm_bg.wasm` is committed. `.js`/`.d.ts` are byte-identical to what was committed (public surface unchanged) so weren't re-copied.

## Test gates (actual counts)

- `cargo test --workspace`: all suites green — 13 + 58 + 8 + 1 + 246 + 5 + 18 + 1 + 2 + 87 = 439 tests passed, 0 failed
- `cargo clippy --all-targets -- -D warnings`: clean, 0 warnings
- `cargo clippy --target wasm32-unknown-unknown --lib -p vaultkeeper-core -p vaultkeeper-wasm -- -D warnings`: clean, 0 warnings (matches CI, which builds the wasm target via `wasm-pack`, not `--all-targets`, since test-target deps don't compile for wasm32)
- `cargo fmt --check`: clean
- `pnpm check`: clean (pre-existing `security/detect-object-injection` warnings in unrelated `packages/cli/src/config-dir.ts` / `suggest.ts` predate this change)
- `pnpm test`: 1012 + 7 + 355 + 263 + 21 = 1658 tests passed, 0 failed, 24 pre-existing skips unrelated to this change (incl. 19 in `readme-examples.test.ts`, 1 platform-conditional `vaultkeeper` skip); `secret-tool-backend.test.ts` itself: 21/21 passed

Refs #297, #296

https://claude.ai/code/session_01TnryiEdT6yi5DqAPGqTnyE
