### PR TITLE
Conformance fidelity gate for InMemoryBackend + core in_memory signing/capability parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,23 @@ jobs:
       - name: Test
         run: cargo test
 
+      - name: Verify committed backend conformance corpus matches a fresh export (drift check)
+        # The Rust corpus in crates/vaultkeeper-conformance/src/backend_cases.rs
+        # is the single source of truth; the JS conformance runner in
+        # packages/test-helpers/test/conformance/backend-cases.test.ts loads a
+        # committed export of it rather than regenerating it at test time (so
+        # the TS package has no Cargo dependency at test time). If someone
+        # edits the corpus without re-running the exporter, the committed JSON
+        # silently goes stale and the TS suite stops exercising the real
+        # cases. Mirrors the check:api-report regeneration-diff pattern.
+        run: |
+          cargo run -q -p vaultkeeper-conformance --bin export-backend-conformance \
+            > /tmp/backend-cases-fresh.json
+          if ! diff -u packages/test-helpers/test/conformance/backend-cases.json /tmp/backend-cases-fresh.json; then
+            echo "::error::packages/test-helpers/test/conformance/backend-cases.json is stale. Regenerate it: cargo run -p vaultkeeper-conformance --bin export-backend-conformance > packages/test-helpers/test/conformance/backend-cases.json"
+            exit 1
+          fi
+
       - name: Build release binary
         run: cargo build --release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,9 @@
+# Before a release that bumps a backend's underlying tool/OS/SDK dependency
+# (`security`, the 1Password desktop app/`op`, `ykman`, `secret-tool`/
+# `gnome-keyring`, `powershell`/Windows), run the shared conformance corpus
+# against that backend's real adapter and record the result in the release
+# notes — see docs/manual-tests/manual-residue-register.md for the full
+# per-backend register (issue #312).
 name: Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Manual-residue register reminder
         run: |
-          echo "::notice::Before publishing a release that bumps a backend's underlying tool/OS/SDK dependency (security, the 1Password desktop app/op, ykman, secret-tool/gnome-keyring, powershell/Windows), run the shared conformance corpus against that backend's real adapter and record the result in docs/manual-tests/manual-residue-register.md (issue #312)."
+          echo "::notice::Before publishing a release that bumps a backend's underlying tool/OS/SDK dependency (security, the 1Password desktop app/op, ykman, secret-tool/gnome-keyring, powershell/Windows), run the shared conformance corpus against that backend's real adapter and record the outcome in the release notes, per docs/manual-tests/manual-residue-register.md (issue #312)."
           echo "See: docs/manual-tests/manual-residue-register.md"
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,11 @@ jobs:
       - name: Show release toolchain
         run: node --version && npm --version && pnpm --version
 
+      - name: Manual-residue register reminder
+        run: |
+          echo "::notice::Before publishing a release that bumps a backend's underlying tool/OS/SDK dependency (security, the 1Password desktop app/op, ykman, secret-tool/gnome-keyring, powershell/Windows), run the shared conformance corpus against that backend's real adapter and record the result in docs/manual-tests/manual-residue-register.md (issue #312)."
+          echo "See: docs/manual-tests/manual-residue-register.md"
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build

--- a/crates/vaultkeeper-conformance/Cargo.toml
+++ b/crates/vaultkeeper-conformance/Cargo.toml
@@ -16,5 +16,9 @@ regex = "1"
 name = "export-conformance"
 path = "src/export.rs"
 
+[[bin]]
+name = "export-backend-conformance"
+path = "src/export_backend.rs"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/vaultkeeper-conformance/src/backend_cases.rs
+++ b/crates/vaultkeeper-conformance/src/backend_cases.rs
@@ -41,6 +41,8 @@ pub enum BackendStep {
     ExpectExists { id: String, exists: bool },
     /// `list()` must include every id in `ids`.
     ExpectListContains { ids: Vec<String> },
+    /// `list()` must NOT include any id in `ids`.
+    ExpectListDoesNotContain { ids: Vec<String> },
     /// `generateSigningKey(id, 'EdDSA')` must succeed.
     GenerateSigningKey { id: String },
     /// `generateSigningKey(id, 'EdDSA')` must fail because `id` already has
@@ -156,6 +158,24 @@ pub fn all_backend_cases() -> Vec<BackendConformanceCase> {
                 },
                 BackendStep::ExpectListContains {
                     ids: vec!["list-a".into(), "list-b".into()],
+                },
+            ],
+        },
+        BackendConformanceCase {
+            name: "list omits an id after it is deleted".into(),
+            steps: vec![
+                BackendStep::Store {
+                    id: "list-delete-me".into(),
+                    secret: "v".into(),
+                },
+                BackendStep::ExpectListContains {
+                    ids: vec!["list-delete-me".into()],
+                },
+                BackendStep::Delete {
+                    id: "list-delete-me".into(),
+                },
+                BackendStep::ExpectListDoesNotContain {
+                    ids: vec!["list-delete-me".into()],
                 },
             ],
         },

--- a/crates/vaultkeeper-conformance/src/backend_cases.rs
+++ b/crates/vaultkeeper-conformance/src/backend_cases.rs
@@ -1,0 +1,238 @@
+//! Backend-level conformance cases (issue #312).
+//!
+//! [`super::ConformanceCase`] (the original corpus) is CLI-argv-only: every
+//! case spawns the `vaultkeeper` binary and asserts on stdout/stderr/exit
+//! code, always against the hardcoded `file` backend (issues #273, #297).
+//! That shape cannot exercise a `SecretBackend` implementation directly —
+//! there is no CLI invocation that selects a specific backend instance, and
+//! the `@vaultkeeper/test-helpers` `InMemoryBackend` double is a
+//! library-level construct with no CLI wiring at all.
+//!
+//! This module is a second, narrower data-driven corpus, scoped to exactly
+//! the store/retrieve/delete/exists/list/sign/capability behavior a backend
+//! implementation itself is responsible for — applicable to *any*
+//! `SecretBackend` + `SigningBackend` + `PresenceCapableBackend`
+//! implementation, not just one wired to a CLI. Both the TS
+//! `InMemoryBackend` double (`@vaultkeeper/test-helpers`) and the Rust core
+//! `InMemoryBackend` (`vaultkeeper_core::backend::InMemoryBackend`) run the
+//! exact same [`BackendConformanceCase`] list, each against a freshly
+//! constructed backend instance, proving the double is held to the same
+//! contract in both languages and that the two languages agree with each
+//! other (issue #312 ACs 1, 2, 4).
+
+use serde::{Deserialize, Serialize};
+
+/// A single step in a [`BackendConformanceCase`]'s scenario, executed in
+/// order against one freshly constructed backend instance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "camelCase")]
+pub enum BackendStep {
+    /// `store(id, secret)` must succeed.
+    Store { id: String, secret: String },
+    /// `retrieve(id)` must succeed and equal `secret`.
+    ExpectRetrieve { id: String, secret: String },
+    /// `retrieve(id)` must fail with "secret not found".
+    ExpectRetrieveNotFound { id: String },
+    /// `delete(id)` must succeed.
+    Delete { id: String },
+    /// `delete(id)` must fail with "secret not found".
+    ExpectDeleteNotFound { id: String },
+    /// `exists(id)` must equal `exists`.
+    ExpectExists { id: String, exists: bool },
+    /// `list()` must include every id in `ids`.
+    ExpectListContains { ids: Vec<String> },
+    /// `generateSigningKey(id, 'EdDSA')` must succeed.
+    GenerateSigningKey { id: String },
+    /// `generateSigningKey(id, 'EdDSA')` must fail because `id` already has
+    /// a signing key enrolled.
+    ExpectGenerateSigningKeyAlreadyExists { id: String },
+    /// `signWithKey(id, message)` must succeed and the resulting signature
+    /// must verify against `getPublicKey(id)`'s public key, and must NOT
+    /// verify against `message` mutated (a tampered check).
+    ExpectSignRoundTrips { id: String, message: String },
+    /// `getPublicKey(id)` must fail because no signing key exists under
+    /// `id`.
+    ExpectGetPublicKeyNotFound { id: String },
+    /// `signWithKey(id, ...)` must fail because no signing key exists under
+    /// `id`.
+    ExpectSignNotFound { id: String },
+    /// `getCapabilities().presencePerUse` must equal `value`.
+    ExpectPresencePerUse { value: bool },
+}
+
+/// A single backend-level conformance case: a named scenario, run against a
+/// freshly constructed backend instance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackendConformanceCase {
+    /// Human-readable test name.
+    pub name: String,
+    /// Steps executed in order against one freshly constructed backend.
+    pub steps: Vec<BackendStep>,
+}
+
+/// Return all built-in backend-level conformance cases.
+///
+/// Scoped to what an in-memory backend can support: no case here requires a
+/// real OS credential store, hardware device, or external process — see this
+/// module's docs for the CLI-argv-only cases that are explicitly out of
+/// scope for the double (issue #312).
+pub fn all_backend_cases() -> Vec<BackendConformanceCase> {
+    vec![
+        BackendConformanceCase {
+            name: "store then retrieve returns the same secret".into(),
+            steps: vec![
+                BackendStep::Store {
+                    id: "conformance-key".into(),
+                    secret: "conformance-secret".into(),
+                },
+                BackendStep::ExpectRetrieve {
+                    id: "conformance-key".into(),
+                    secret: "conformance-secret".into(),
+                },
+            ],
+        },
+        BackendConformanceCase {
+            name: "retrieve of a missing id returns not found".into(),
+            steps: vec![BackendStep::ExpectRetrieveNotFound {
+                id: "never-stored".into(),
+            }],
+        },
+        BackendConformanceCase {
+            name: "delete removes a stored secret".into(),
+            steps: vec![
+                BackendStep::Store {
+                    id: "delete-me".into(),
+                    secret: "x".into(),
+                },
+                BackendStep::Delete {
+                    id: "delete-me".into(),
+                },
+                BackendStep::ExpectRetrieveNotFound {
+                    id: "delete-me".into(),
+                },
+            ],
+        },
+        BackendConformanceCase {
+            name: "delete of a missing id returns not found".into(),
+            steps: vec![BackendStep::ExpectDeleteNotFound {
+                id: "never-existed".into(),
+            }],
+        },
+        BackendConformanceCase {
+            name: "exists reflects store/delete state".into(),
+            steps: vec![
+                BackendStep::ExpectExists {
+                    id: "existence-probe".into(),
+                    exists: false,
+                },
+                BackendStep::Store {
+                    id: "existence-probe".into(),
+                    secret: "v".into(),
+                },
+                BackendStep::ExpectExists {
+                    id: "existence-probe".into(),
+                    exists: true,
+                },
+                BackendStep::Delete {
+                    id: "existence-probe".into(),
+                },
+                BackendStep::ExpectExists {
+                    id: "existence-probe".into(),
+                    exists: false,
+                },
+            ],
+        },
+        BackendConformanceCase {
+            name: "list reflects every stored id".into(),
+            steps: vec![
+                BackendStep::Store {
+                    id: "list-a".into(),
+                    secret: "1".into(),
+                },
+                BackendStep::Store {
+                    id: "list-b".into(),
+                    secret: "2".into(),
+                },
+                BackendStep::ExpectListContains {
+                    ids: vec!["list-a".into(), "list-b".into()],
+                },
+            ],
+        },
+        BackendConformanceCase {
+            name: "a generated signing key signs and verifies against its own public key".into(),
+            steps: vec![
+                BackendStep::GenerateSigningKey {
+                    id: "sign-key".into(),
+                },
+                BackendStep::ExpectSignRoundTrips {
+                    id: "sign-key".into(),
+                    message: "vaultkeeper issue #312 conformance".into(),
+                },
+            ],
+        },
+        BackendConformanceCase {
+            name: "generate signing key rejects a duplicate id".into(),
+            steps: vec![
+                BackendStep::GenerateSigningKey { id: "dup".into() },
+                BackendStep::ExpectGenerateSigningKeyAlreadyExists { id: "dup".into() },
+            ],
+        },
+        BackendConformanceCase {
+            name: "get public key for a missing signing key id returns not found".into(),
+            steps: vec![BackendStep::ExpectGetPublicKeyNotFound { id: "ghost".into() }],
+        },
+        BackendConformanceCase {
+            name: "sign with a missing signing key id returns not found".into(),
+            steps: vec![BackendStep::ExpectSignNotFound {
+                id: "ghost-signer".into(),
+            }],
+        },
+        BackendConformanceCase {
+            name: "reports no presence-per-use capability".into(),
+            steps: vec![BackendStep::ExpectPresencePerUse { value: false }],
+        },
+    ]
+}
+
+/// Serialize all backend-level conformance cases to JSON for the JS runner.
+pub fn backend_cases_as_json() -> String {
+    serde_json::to_string_pretty(&all_backend_cases())
+        .expect("backend conformance cases must serialize")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cases_serialize_to_json() {
+        let json = backend_cases_as_json();
+        let parsed: Vec<BackendConformanceCase> =
+            serde_json::from_str(&json).expect("round-trip must succeed");
+        assert_eq!(parsed.len(), all_backend_cases().len());
+    }
+
+    #[test]
+    fn all_cases_have_names() {
+        for case in all_backend_cases() {
+            assert!(!case.name.is_empty(), "every case must have a name");
+        }
+    }
+
+    #[test]
+    fn all_cases_have_unique_names() {
+        let cases = all_backend_cases();
+        let mut names: Vec<&str> = cases.iter().map(|c| c.name.as_str()).collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), cases.len(), "duplicate case names found");
+    }
+
+    #[test]
+    fn every_case_has_at_least_one_step() {
+        for case in all_backend_cases() {
+            assert!(!case.steps.is_empty(), "case '{}' has no steps", case.name);
+        }
+    }
+}

--- a/crates/vaultkeeper-conformance/src/export_backend.rs
+++ b/crates/vaultkeeper-conformance/src/export_backend.rs
@@ -1,0 +1,8 @@
+//! Exports backend-level conformance test cases as JSON to stdout.
+
+fn main() {
+    print!(
+        "{}",
+        vaultkeeper_conformance::backend_cases::backend_cases_as_json()
+    );
+}

--- a/crates/vaultkeeper-conformance/src/lib.rs
+++ b/crates/vaultkeeper-conformance/src/lib.rs
@@ -3,6 +3,13 @@
 //! Defines data-driven test cases that both the native Rust CLI and the npm
 //! WASM CLI must pass identically. Cases are serializable to JSON so the JS
 //! conformance runner can load them.
+//!
+//! See [`backend_cases`] for a second, narrower corpus scoped to
+//! backend-level (not CLI-level) behavior, applicable to any `SecretBackend`
+//! implementation — including the TS `InMemoryBackend` test double and the
+//! Rust core `InMemoryBackend` (issue #312).
+
+pub mod backend_cases;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/vaultkeeper-core/src/backend/in_memory.rs
+++ b/crates/vaultkeeper-core/src/backend/in_memory.rs
@@ -24,6 +24,7 @@ use ed25519_dalek::pkcs8::EncodePublicKey;
 use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
 use std::collections::HashMap;
 use std::sync::Mutex;
+use zeroize::Zeroize;
 
 /// A fully in-memory `SecretBackend` for testing.
 ///
@@ -192,6 +193,7 @@ impl SigningBackend for InMemoryBackend {
         getrandom::fill(&mut seed)
             .map_err(|e| VaultError::Other(format!("Failed to generate signing key: {e}")))?;
         let signing_key = SigningKey::from_bytes(&seed);
+        seed.zeroize();
         signing_keys.insert(id.to_string(), signing_key);
         Ok(())
     }

--- a/crates/vaultkeeper-core/src/backend/in_memory.rs
+++ b/crates/vaultkeeper-core/src/backend/in_memory.rs
@@ -2,18 +2,37 @@
 //!
 //! Stores secrets in a `HashMap` with no external dependencies.
 //! Suitable for unit, integration, and e2e tests.
+//!
+//! Also implements [`SigningBackend`] and [`PresenceCapableBackend`] (issue
+//! #312), mirroring the TypeScript `@vaultkeeper/test-helpers`
+//! `InMemoryBackend` double exactly: real in-memory Ed25519 keys (the private
+//! key never leaves this backend) and an honest `presence_per_use: false`
+//! capability report (no touch device, no biometric prompt — see
+//! [`PresenceCapableBackend`]'s docs on host-attested self-reporting). Unlike
+//! [`super::FileBackend`]'s [`super::signing_store`], signing keys here are
+//! held purely in memory (no `HostPlatform`, no disk persistence) since this
+//! backend has no host to persist through.
 
-use super::types::{ListableBackend, SecretBackend};
+use super::types::{
+    BackendCapabilities, ListableBackend, PresenceCapableBackend, SecretBackend, SigningBackend,
+};
 use crate::errors::VaultError;
+use crate::signing::ed25519::{kid_for_verifying_key, sign as ed25519_sign};
+use crate::types::{SigningAlgorithm, SigningPublicKey};
+use ed25519_dalek::SigningKey;
+use ed25519_dalek::pkcs8::EncodePublicKey;
+use ed25519_dalek::pkcs8::spki::der::pem::LineEnding;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
 /// A fully in-memory `SecretBackend` for testing.
 ///
 /// This backend stores secrets in a plain `HashMap` and has no external
-/// dependencies. It implements both [`SecretBackend`] and [`ListableBackend`].
+/// dependencies. It implements [`SecretBackend`], [`ListableBackend`],
+/// [`SigningBackend`], and [`PresenceCapableBackend`].
 pub struct InMemoryBackend {
     store: Mutex<HashMap<String, String>>,
+    signing_keys: Mutex<HashMap<String, SigningKey>>,
 }
 
 impl InMemoryBackend {
@@ -21,12 +40,17 @@ impl InMemoryBackend {
     pub fn new() -> Self {
         Self {
             store: Mutex::new(HashMap::new()),
+            signing_keys: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Remove all stored secrets. Useful for test teardown.
+    /// Remove all stored secrets and signing keys. Useful for test teardown.
     pub fn clear(&self) {
         self.store.lock().expect("store lock poisoned").clear();
+        self.signing_keys
+            .lock()
+            .expect("signing key store lock poisoned")
+            .clear();
     }
 
     /// The number of secrets currently stored.
@@ -76,7 +100,16 @@ impl SecretBackend for InMemoryBackend {
     }
 
     async fn delete(&self, id: &str) -> Result<(), VaultError> {
-        self.store.lock().expect("store lock poisoned").remove(id);
+        // Contract fidelity (issue #312): `SecretBackend::delete` returns
+        // `SecretNotFound` for a missing id — matching `FileBackend::delete`
+        // and the TS `InMemoryBackend` double's `delete()` — rather than a
+        // lenient no-op that no real backend exhibits.
+        let mut store = self.store.lock().expect("store lock poisoned");
+        if store.remove(id).is_none() {
+            return Err(VaultError::SecretNotFound {
+                message: format!("Secret not found: {id}"),
+            });
+        }
         Ok(())
     }
 
@@ -86,6 +119,10 @@ impl SecretBackend for InMemoryBackend {
             .lock()
             .expect("store lock poisoned")
             .contains_key(id))
+    }
+
+    fn as_presence_capable(&self) -> Option<&dyn PresenceCapableBackend> {
+        Some(self)
     }
 }
 
@@ -103,8 +140,105 @@ impl ListableBackend for InMemoryBackend {
     }
 }
 
+/// `InMemoryBackend` has no physical presence mechanism (no touch device, no
+/// biometric prompt) — it always reports `presence_per_use: false`, in the
+/// same [`BackendCapabilities`] vocabulary every other backend uses, so a
+/// `--require-presence-per-use` request against this double is correctly
+/// refused with `NotCapable` rather than silently satisfied. Mirrors the
+/// TypeScript double's `getCapabilities` exactly.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl PresenceCapableBackend for InMemoryBackend {
+    async fn get_capabilities(&self) -> Result<BackendCapabilities, VaultError> {
+        Ok(BackendCapabilities {
+            presence_per_use: false,
+            presence_enforced_operations: None,
+        })
+    }
+}
+
+/// Signing keys are generated, held, and used entirely in memory — the
+/// private key never leaves this backend and is never persisted to disk.
+/// Mirrors the TypeScript double's `SigningBackend` implementation (real
+/// Ed25519 keys via `node:crypto`) using `ed25519-dalek` on the Rust side.
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl SigningBackend for InMemoryBackend {
+    async fn generate_signing_key(
+        &self,
+        id: &str,
+        algorithm: SigningAlgorithm,
+    ) -> Result<(), VaultError> {
+        // `SigningAlgorithm` currently has exactly one variant (`EdDsa`); this
+        // match is exhaustive today and, like `signing_store`, will fail to
+        // compile if a second algorithm is ever added until this backend
+        // explicitly decides whether it supports it.
+        match algorithm {
+            SigningAlgorithm::EdDsa => {}
+        }
+
+        let mut signing_keys = self
+            .signing_keys
+            .lock()
+            .expect("signing key store lock poisoned");
+        if signing_keys.contains_key(id) {
+            return Err(VaultError::SigningKeyAlreadyExists {
+                message: format!("Signing key already exists: {id}"),
+                id: id.to_string(),
+            });
+        }
+
+        let mut seed = [0u8; 32];
+        getrandom::fill(&mut seed)
+            .map_err(|e| VaultError::Other(format!("Failed to generate signing key: {e}")))?;
+        let signing_key = SigningKey::from_bytes(&seed);
+        signing_keys.insert(id.to_string(), signing_key);
+        Ok(())
+    }
+
+    async fn get_public_key(&self, id: &str) -> Result<SigningPublicKey, VaultError> {
+        let signing_keys = self
+            .signing_keys
+            .lock()
+            .expect("signing key store lock poisoned");
+        let signing_key = signing_keys
+            .get(id)
+            .ok_or_else(|| VaultError::SigningKeyNotFound {
+                message: format!("Signing key not found: {id}"),
+                id: id.to_string(),
+            })?;
+        let verifying_key = signing_key.verifying_key();
+
+        let public_key_pem = verifying_key
+            .to_public_key_pem(LineEnding::LF)
+            .map_err(|e| VaultError::Other(format!("Failed to encode signing public key: {e}")))?;
+        let kid = kid_for_verifying_key(&verifying_key);
+
+        Ok(SigningPublicKey {
+            public_key_pem,
+            algorithm: SigningAlgorithm::EdDsa,
+            kid,
+        })
+    }
+
+    async fn sign_with_key(&self, id: &str, data: &[u8]) -> Result<Vec<u8>, VaultError> {
+        let signing_keys = self
+            .signing_keys
+            .lock()
+            .expect("signing key store lock poisoned");
+        let signing_key = signing_keys
+            .get(id)
+            .ok_or_else(|| VaultError::SigningKeyNotFound {
+                message: format!("Signing key not found: {id}"),
+                id: id.to_string(),
+            })?;
+        Ok(ed25519_sign(signing_key, data))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::super::types::{get_backend_capabilities, is_presence_capable_backend};
     use super::*;
 
     #[tokio::test]
@@ -183,10 +317,163 @@ mod tests {
         assert_eq!(backend.display_name(), "In-Memory Backend");
     }
 
+    // Regression test for issue #312: `delete` on a missing id previously
+    // silently succeeded (a no-op), diverging from `FileBackend::delete` and
+    // the TS `InMemoryBackend` double, both of which return
+    // `SecretNotFound`. This would fail against the pre-fix behavior (which
+    // returned `Ok(())` unconditionally).
     #[tokio::test]
-    async fn delete_nonexistent_is_noop() {
+    async fn delete_nonexistent_returns_secret_not_found() {
         let backend = InMemoryBackend::new();
-        // Should not error
-        backend.delete("nonexistent").await.unwrap();
+        let err = backend.delete("nonexistent").await.unwrap_err();
+        assert!(matches!(err, VaultError::SecretNotFound { .. }));
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #312 AC3 — the core `in_memory` backend implements
+    // `SigningBackend`: it generates a keypair, signs, and the signature
+    // verifies against the public key — matching the TS double's behavior.
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn sign_with_key_produces_a_signature_verifiable_against_the_public_key() {
+        let backend = InMemoryBackend::new();
+        backend
+            .generate_signing_key("my-key", SigningAlgorithm::EdDsa)
+            .await
+            .unwrap();
+
+        let public_key = backend.get_public_key("my-key").await.unwrap();
+        let message = b"vaultkeeper issue #312";
+        let signature = backend.sign_with_key("my-key", message).await.unwrap();
+
+        let verifying_key =
+            crate::signing::ed25519::parse_public_key_pem(&public_key.public_key_pem).unwrap();
+        assert!(crate::signing::ed25519::verify(
+            &verifying_key,
+            message,
+            &signature
+        ));
+        assert_eq!(public_key.algorithm, SigningAlgorithm::EdDsa);
+    }
+
+    #[tokio::test]
+    async fn sign_with_key_absent_id_returns_typed_error_not_panic() {
+        let backend = InMemoryBackend::new();
+        let err = backend
+            .sign_with_key("no-such-key", b"data")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VaultError::SigningKeyNotFound { id, .. } if id == "no-such-key"));
+    }
+
+    #[tokio::test]
+    async fn get_public_key_absent_id_returns_typed_error() {
+        let backend = InMemoryBackend::new();
+        let err = backend.get_public_key("ghost").await.unwrap_err();
+        assert!(matches!(err, VaultError::SigningKeyNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn generate_signing_key_rejects_duplicate_id() {
+        let backend = InMemoryBackend::new();
+        backend
+            .generate_signing_key("dup", SigningAlgorithm::EdDsa)
+            .await
+            .unwrap();
+        let err = backend
+            .generate_signing_key("dup", SigningAlgorithm::EdDsa)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, VaultError::SigningKeyAlreadyExists { id, .. } if id == "dup"));
+    }
+
+    #[tokio::test]
+    async fn tampered_signature_fails_verification() {
+        let backend = InMemoryBackend::new();
+        backend
+            .generate_signing_key("tamper-me", SigningAlgorithm::EdDsa)
+            .await
+            .unwrap();
+        let public_key = backend.get_public_key("tamper-me").await.unwrap();
+        let mut signature = backend
+            .sign_with_key("tamper-me", b"original message")
+            .await
+            .unwrap();
+        signature[0] ^= 0xff;
+
+        let verifying_key =
+            crate::signing::ed25519::parse_public_key_pem(&public_key.public_key_pem).unwrap();
+        assert!(!crate::signing::ed25519::verify(
+            &verifying_key,
+            b"original message",
+            &signature
+        ));
+    }
+
+    #[tokio::test]
+    async fn clear_removes_signing_keys_too() {
+        let backend = InMemoryBackend::new();
+        backend
+            .generate_signing_key("goes-away", SigningAlgorithm::EdDsa)
+            .await
+            .unwrap();
+        backend.clear();
+        let err = backend.get_public_key("goes-away").await.unwrap_err();
+        assert!(matches!(err, VaultError::SigningKeyNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn signing_key_and_secret_with_the_same_name_coexist_without_collision() {
+        let backend = InMemoryBackend::new();
+        backend
+            .store("shared-name", "the-secret-value")
+            .await
+            .unwrap();
+        backend
+            .generate_signing_key("shared-name", SigningAlgorithm::EdDsa)
+            .await
+            .unwrap();
+
+        let secret = backend.retrieve("shared-name").await.unwrap();
+        assert_eq!(secret, "the-secret-value");
+
+        let signature = backend.sign_with_key("shared-name", b"msg").await.unwrap();
+        let public_key = backend.get_public_key("shared-name").await.unwrap();
+        let verifying_key =
+            crate::signing::ed25519::parse_public_key_pem(&public_key.public_key_pem).unwrap();
+        assert!(crate::signing::ed25519::verify(
+            &verifying_key,
+            b"msg",
+            &signature
+        ));
+
+        backend.delete("shared-name").await.unwrap();
+        assert!(!backend.exists("shared-name").await.unwrap());
+
+        let signature_after_delete = backend.sign_with_key("shared-name", b"msg").await.unwrap();
+        assert!(crate::signing::ed25519::verify(
+            &verifying_key,
+            b"msg",
+            &signature_after_delete
+        ));
+    }
+
+    // -----------------------------------------------------------------
+    // Presence capability: `InMemoryBackend` never claims physical presence.
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn reports_no_presence_capability() {
+        let backend = InMemoryBackend::new();
+        let caps = get_backend_capabilities(&backend).await.unwrap();
+        assert!(!caps.presence_per_use);
+        assert_eq!(caps.presence_enforced_operations, None);
+    }
+
+    #[test]
+    fn as_presence_capable_returns_self() {
+        let backend = InMemoryBackend::new();
+        assert!(is_presence_capable_backend(&backend));
     }
 }

--- a/crates/vaultkeeper-core/tests/backend_conformance.rs
+++ b/crates/vaultkeeper-core/tests/backend_conformance.rs
@@ -92,6 +92,17 @@ async fn run_case(case: &BackendConformanceCase) -> Result<(), String> {
                     }
                 }
             }
+            BackendStep::ExpectListDoesNotContain { ids } => {
+                let listed = backend
+                    .list()
+                    .await
+                    .map_err(|e| format!("list() failed: {e}"))?;
+                for id in ids {
+                    if listed.contains(id) {
+                        return Err(format!("list() {listed:?} unexpectedly contains {id:?}"));
+                    }
+                }
+            }
             BackendStep::GenerateSigningKey { id } => backend
                 .generate_signing_key(id, SigningAlgorithm::EdDsa)
                 .await
@@ -207,4 +218,34 @@ async fn all_backend_conformance_cases_pass_against_core_in_memory_backend() {
             failures.join("\n\n")
         );
     }
+}
+
+/// Drift-detection proof (AC2), mirroring the TS-side test of the same name
+/// in `packages/test-helpers/test/conformance/backend-cases.test.ts`: a
+/// deliberately mutated case (wrong expected secret value) must cause
+/// `run_case` to return `Err`, proving the gate can actually detect drift
+/// rather than passing vacuously. The mutated case only exists inside this
+/// test and is never added to the corpus the suite above runs.
+#[tokio::test]
+async fn run_case_fails_when_a_case_expectation_the_backend_does_not_meet_is_introduced() {
+    let cases = all_backend_cases();
+    let original = cases
+        .iter()
+        .find(|c| c.name == "store then retrieve returns the same secret")
+        .expect("fixture case 'store then retrieve returns the same secret' must exist");
+
+    // Deliberately diverge the case from what InMemoryBackend actually does:
+    // claim the stored secret is a different value than what was stored.
+    let mut mutated = original.clone();
+    for step in &mut mutated.steps {
+        if let BackendStep::ExpectRetrieve { secret, .. } = step {
+            secret.push_str("-drifted");
+        }
+    }
+
+    let result = run_case(&mutated).await;
+    assert!(
+        result.is_err(),
+        "run_case should fail against a case mutated to expect a value the backend does not return"
+    );
 }

--- a/crates/vaultkeeper-core/tests/backend_conformance.rs
+++ b/crates/vaultkeeper-core/tests/backend_conformance.rs
@@ -1,0 +1,210 @@
+//! Backend-level conformance runner for the core Rust `InMemoryBackend`
+//! (issue #312, AC4).
+//!
+//! Runs the exact same [`vaultkeeper_conformance::backend_cases`] corpus the
+//! TS `InMemoryBackend` double runs in
+//! `packages/test-helpers/test/conformance/backend-cases.test.ts`, each case
+//! against a freshly constructed `vaultkeeper_core::backend::InMemoryBackend`
+//! — proving cross-language parity: the same data-driven scenarios pass
+//! against both languages' `InMemoryBackend`.
+//!
+//! @see crates/vaultkeeper-conformance/src/backend_cases.rs — case definitions
+//! @see packages/test-helpers/test/conformance/backend-cases.test.ts — JS-side runner
+
+use vaultkeeper_conformance::backend_cases::{
+    BackendConformanceCase, BackendStep, all_backend_cases,
+};
+use vaultkeeper_core::InMemoryBackend;
+use vaultkeeper_core::backend::{
+    ListableBackend, PresenceCapableBackend, SecretBackend, SigningBackend,
+};
+use vaultkeeper_core::errors::VaultError;
+use vaultkeeper_core::signing::ed25519::{parse_public_key_pem, verify};
+use vaultkeeper_core::types::SigningAlgorithm;
+
+/// Run a single [`BackendConformanceCase`] against a fresh `InMemoryBackend`,
+/// returning `Err` with a description of the first failing step rather than
+/// panicking, so the caller can aggregate every case's result.
+async fn run_case(case: &BackendConformanceCase) -> Result<(), String> {
+    let backend = InMemoryBackend::new();
+
+    for step in &case.steps {
+        match step {
+            BackendStep::Store { id, secret } => backend
+                .store(id, secret)
+                .await
+                .map_err(|e| format!("store({id:?}) failed: {e}"))?,
+            BackendStep::ExpectRetrieve { id, secret } => {
+                let got = backend
+                    .retrieve(id)
+                    .await
+                    .map_err(|e| format!("retrieve({id:?}) failed: {e}"))?;
+                if &got != secret {
+                    return Err(format!(
+                        "retrieve({id:?}) returned {got:?}, expected {secret:?}"
+                    ));
+                }
+            }
+            BackendStep::ExpectRetrieveNotFound { id } => {
+                let err = backend.retrieve(id).await;
+                match err {
+                    Err(VaultError::SecretNotFound { .. }) => {}
+                    Err(e) => {
+                        return Err(format!("retrieve({id:?}) expected SecretNotFound, got {e}"));
+                    }
+                    Ok(v) => {
+                        return Err(format!(
+                            "retrieve({id:?}) expected SecretNotFound, got Ok({v:?})"
+                        ));
+                    }
+                }
+            }
+            BackendStep::Delete { id } => backend
+                .delete(id)
+                .await
+                .map_err(|e| format!("delete({id:?}) failed: {e}"))?,
+            BackendStep::ExpectDeleteNotFound { id } => match backend.delete(id).await {
+                Err(VaultError::SecretNotFound { .. }) => {}
+                Err(e) => return Err(format!("delete({id:?}) expected SecretNotFound, got {e}")),
+                Ok(()) => {
+                    return Err(format!(
+                        "delete({id:?}) expected SecretNotFound, got Ok(())"
+                    ));
+                }
+            },
+            BackendStep::ExpectExists { id, exists } => {
+                let got = backend
+                    .exists(id)
+                    .await
+                    .map_err(|e| format!("exists({id:?}) failed: {e}"))?;
+                if got != *exists {
+                    return Err(format!("exists({id:?}) returned {got}, expected {exists}"));
+                }
+            }
+            BackendStep::ExpectListContains { ids } => {
+                let listed = backend
+                    .list()
+                    .await
+                    .map_err(|e| format!("list() failed: {e}"))?;
+                for id in ids {
+                    if !listed.contains(id) {
+                        return Err(format!("list() {listed:?} does not contain {id:?}"));
+                    }
+                }
+            }
+            BackendStep::GenerateSigningKey { id } => backend
+                .generate_signing_key(id, SigningAlgorithm::EdDsa)
+                .await
+                .map_err(|e| format!("generate_signing_key({id:?}) failed: {e}"))?,
+            BackendStep::ExpectGenerateSigningKeyAlreadyExists { id } => {
+                match backend
+                    .generate_signing_key(id, SigningAlgorithm::EdDsa)
+                    .await
+                {
+                    Err(VaultError::SigningKeyAlreadyExists { .. }) => {}
+                    Err(e) => {
+                        return Err(format!(
+                            "generate_signing_key({id:?}) expected SigningKeyAlreadyExists, got {e}"
+                        ));
+                    }
+                    Ok(()) => {
+                        return Err(format!(
+                            "generate_signing_key({id:?}) expected SigningKeyAlreadyExists, got Ok(())"
+                        ));
+                    }
+                }
+            }
+            BackendStep::ExpectSignRoundTrips { id, message } => {
+                let public_key = backend
+                    .get_public_key(id)
+                    .await
+                    .map_err(|e| format!("get_public_key({id:?}) failed: {e}"))?;
+                let signature = backend
+                    .sign_with_key(id, message.as_bytes())
+                    .await
+                    .map_err(|e| format!("sign_with_key({id:?}) failed: {e}"))?;
+                let verifying_key = parse_public_key_pem(&public_key.public_key_pem)
+                    .map_err(|e| format!("parse_public_key_pem({id:?}) failed: {e}"))?;
+                if !verify(&verifying_key, message.as_bytes(), &signature) {
+                    return Err(format!(
+                        "sign_with_key({id:?}) signature did not verify against its own public key"
+                    ));
+                }
+                if verify(&verifying_key, b"a tampered payload", &signature) {
+                    return Err(format!(
+                        "sign_with_key({id:?}) signature verified against a tampered payload"
+                    ));
+                }
+            }
+            BackendStep::ExpectGetPublicKeyNotFound { id } => {
+                match backend.get_public_key(id).await {
+                    Err(VaultError::SigningKeyNotFound { .. }) => {}
+                    Err(e) => {
+                        return Err(format!(
+                            "get_public_key({id:?}) expected SigningKeyNotFound, got {e}"
+                        ));
+                    }
+                    Ok(k) => {
+                        return Err(format!(
+                            "get_public_key({id:?}) expected SigningKeyNotFound, got Ok({k:?})"
+                        ));
+                    }
+                }
+            }
+            BackendStep::ExpectSignNotFound { id } => {
+                match backend.sign_with_key(id, b"data").await {
+                    Err(VaultError::SigningKeyNotFound { .. }) => {}
+                    Err(e) => {
+                        return Err(format!(
+                            "sign_with_key({id:?}) expected SigningKeyNotFound, got {e}"
+                        ));
+                    }
+                    Ok(_) => {
+                        return Err(format!(
+                            "sign_with_key({id:?}) expected SigningKeyNotFound, got Ok(_)"
+                        ));
+                    }
+                }
+            }
+            BackendStep::ExpectPresencePerUse { value } => {
+                let caps = backend
+                    .get_capabilities()
+                    .await
+                    .map_err(|e| format!("get_capabilities() failed: {e}"))?;
+                if caps.presence_per_use != *value {
+                    return Err(format!(
+                        "get_capabilities().presence_per_use was {}, expected {value}",
+                        caps.presence_per_use
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn all_backend_conformance_cases_pass_against_core_in_memory_backend() {
+    let cases = all_backend_cases();
+    assert!(
+        !cases.is_empty(),
+        "the backend conformance corpus must not be empty"
+    );
+
+    let mut failures = Vec::new();
+    for case in &cases {
+        if let Err(msg) = run_case(case).await {
+            failures.push(format!("Case '{}' failed: {msg}", case.name));
+        }
+    }
+
+    if !failures.is_empty() {
+        panic!(
+            "{} of {} backend conformance cases failed:\n\n{}",
+            failures.len(),
+            cases.len(),
+            failures.join("\n\n")
+        );
+    }
+}

--- a/crates/vaultkeeper-core/tests/presence_capability.rs
+++ b/crates/vaultkeeper-core/tests/presence_capability.rs
@@ -185,6 +185,48 @@ impl PresenceCapableBackend for MockPresenceBackend {
     }
 }
 
+/// A minimal `SecretBackend` that deliberately does not implement
+/// `PresenceCapableBackend` at all — used to prove `get_backend_capabilities`
+/// and `is_presence_capable_backend` fail safe for a backend that never opts
+/// in, distinct from `InMemoryBackend` (issue #312), which now implements
+/// `PresenceCapableBackend` and honestly reports no presence capability
+/// rather than omitting the interface.
+struct PlainBackend;
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl SecretBackend for PlainBackend {
+    fn backend_type(&self) -> &str {
+        "plain"
+    }
+
+    fn display_name(&self) -> &str {
+        "Plain Backend"
+    }
+
+    async fn is_available(&self) -> bool {
+        true
+    }
+
+    async fn store(&self, _id: &str, _secret: &str) -> Result<(), VaultError> {
+        Ok(())
+    }
+
+    async fn retrieve(&self, id: &str) -> Result<String, VaultError> {
+        Err(VaultError::SecretNotFound {
+            message: format!("Secret not found: {id}"),
+        })
+    }
+
+    async fn delete(&self, _id: &str) -> Result<(), VaultError> {
+        Ok(())
+    }
+
+    async fn exists(&self, _id: &str) -> Result<bool, VaultError> {
+        Ok(false)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // AC1: backend capability contract
 // ---------------------------------------------------------------------------
@@ -193,15 +235,27 @@ impl PresenceCapableBackend for MockPresenceBackend {
 async fn plain_backend_reports_no_capability_via_helper() {
     // A backend that never implements PresenceCapableBackend never silently
     // claims presence.
-    let backend = InMemoryBackend::new();
+    let backend = PlainBackend;
     let caps = get_backend_capabilities(&backend).await.unwrap();
     assert_eq!(caps, BackendCapabilities::none());
 }
 
 #[tokio::test]
 async fn is_presence_capable_backend_false_for_plain_backend() {
-    let backend = InMemoryBackend::new();
+    let backend = PlainBackend;
     assert!(!is_presence_capable_backend(&backend));
+}
+
+#[tokio::test]
+async fn in_memory_backend_implements_presence_capable_backend_and_reports_no_capability() {
+    // Issue #312: `InMemoryBackend` now implements `PresenceCapableBackend`
+    // explicitly (mirroring the TS double), rather than silently omitting the
+    // interface — so it must both report `is_presence_capable_backend() ==
+    // true` and honestly answer `presence_per_use: false`.
+    let backend = InMemoryBackend::new();
+    assert!(is_presence_capable_backend(&backend));
+    let caps = get_backend_capabilities(&backend).await.unwrap();
+    assert_eq!(caps, BackendCapabilities::none());
 }
 
 #[tokio::test]

--- a/docs/manual-tests/manual-residue-register.md
+++ b/docs/manual-tests/manual-residue-register.md
@@ -1,0 +1,81 @@
+# Manual residue register
+
+This is the complete, auditable human residue that remains once every backend has a paired
+double — a TS/Rust `InMemoryBackend` (or, where a backend has no in-memory equivalent, the
+narrowest available double) — running the shared conformance corpus in CI (issue #312).
+
+## Framing: tool-upgrade-triggered, not calendar-triggered
+
+**The residue below fires when a backend's underlying tool/OS/SDK version bumps — it is not a
+scheduled, calendar-driven manual QA pass.** A `security`/`ykman`/`op`/`secret-tool`/`powershell`
+(or OS) version bump is the trigger; the conformance corpus's own diff against the new tool
+output is what tells a maintainer whether a re-run is even warranted. This is what makes the
+residue self-timing rather than something that silently rots the way a fixed six-month manual
+test suite does: there is no ambiguous "is it time yet?" — the answer is always "did the backend's
+tool/OS dependency version change since the last run?"
+
+Everything the shared corpus asserts _around_ the physical/licensed ceremony is already
+CI-automated against each backend's double: argv construction, stdin/stdout parsing, error
+classification, locked/unlocked and expired-session branches, response-shape round-trips,
+presence _refusal_ logic (`NotCapableError` when a backend cannot honor
+`--require-presence-per-use`), lease minting, registry dispatch, and fail-closed paths on every
+error branch. None of that is part of the manual residue below — it runs on every PR, in every
+language, against the double. Real-hardware/device _behavior_ wiring (does a capable backend
+truly force a fresh physical action) is separately covered by
+[`presence-per-use.md`](./presence-per-use.md); this register is about the run-the-corpus-against-the-real-adapter
+step specifically.
+
+## The register
+
+| Backend     | Manual residue = run shared corpus vs. real adapter | Physical ceremony       | Cadence · cost                     |
+| ----------- | --------------------------------------------------- | ----------------------- | ---------------------------------- |
+| keychain    | corpus vs. real `security` on macOS                 | Touch-ID-gated read tap | per `security`/OS bump · ~2 min    |
+| 1Password   | corpus vs. real DesktopAuth account                 | one Touch ID grant      | per `op`-app / dylib bump · ~3 min |
+| yubikey     | corpus vs. real `ykman`                             | one hardware touch      | per `ykman` bump · ~2 min          |
+| secret-tool | corpus vs. real `gnome-keyring` (Linux desktop)     | keyring unlock          | per `secret-tool` bump · ~2 min    |
+| dpapi       | corpus vs. real DPAPI on Windows                    | none (machine key)      | per `powershell`/OS bump · ~2 min  |
+
+Once every backend's paired double is running the shared contract corpus in CI, each backend's
+manual residue collapses to exactly one line: **run the double's exact CI corpus, re-pointed at
+the real tool/account/hardware** — plus, only where a biometric/hardware ceremony gates it, the
+physical tap/grant/unlock named above.
+
+## Why each ceremony cannot be automated
+
+The ceremony column is genuinely physical or a licensed real service — none has a headless
+equivalent, and none of the underlying constructs can be simulated without either defeating the
+security property they exist to provide or requiring hardware/licensing CI does not have:
+
+- **keychain (Touch-ID-gated read tap):** the tap unlocks a Secure Enclave biometric match. There
+  is no software path around it — that is the entire point of Secure Enclave-backed key access.
+- **1Password (Touch ID grant):** `per-access` mode requests a fresh, per-process Mach-port grant
+  from the desktop app for each operation; the grant is tied to a live biometric prompt in a GUI
+  process CI cannot drive headlessly.
+- **yubikey (hardware touch):** the touch policy requires a human's physical finger on the device
+  — there is no simulated touch that preserves the guarantee the touch policy exists to provide.
+- **secret-tool (keyring unlock):** requires a logged-in D-Bus Secret Service session (a real
+  `gnome-keyring` daemon under an unlocked login session) — CI's `dbus-run-session` wrapper gets
+  the daemon and bus running, but a _locked_ keyring's unlock prompt is still a human action.
+- **dpapi (machine key, no ceremony):** DPAPI's master key is bound to the Windows machine/user
+  account itself, not a biometric or hardware step — hence "none" in the ceremony column — but the
+  binding is still real-OS-only and cannot be faked by a double.
+
+## When to consult this register
+
+Wire this into the release process: **before cutting a release that bumps a backend's underlying
+tool/OS/SDK dependency** (`security`, `op`/1Password desktop app, `ykman`, `secret-tool`/
+`gnome-keyring`, `powershell`/Windows), run the shared conformance corpus against that backend's
+real adapter per the row above, and record the result in the release notes. See
+[`.github/workflows/release.yml`](../../.github/workflows/release.yml)'s header comment, which
+points back here.
+
+## See also
+
+- [`presence-per-use.md`](./presence-per-use.md) — real-hardware/device _behavior_ verification
+  (does a capable backend truly force a fresh physical action) — a different, complementary manual
+  check from the corpus-vs-real-adapter residue this register tracks.
+- [`yubikey-backend-live.md`](./yubikey-backend-live.md) — the YubiKey-specific real-device manual
+  test this register's yubikey row refers to.
+- `packages/cli-tests/test/conformance/` — the shared CLI-level conformance corpus.
+- `crates/vaultkeeper-conformance/src/backend_cases.rs` — the shared backend-level conformance
+  corpus (issue #312), run against every in-memory double in both languages.

--- a/docs/manual-tests/presence-per-use.md
+++ b/docs/manual-tests/presence-per-use.md
@@ -1,5 +1,9 @@
 # Manual verification: presence-per-use
 
+> For the separate, cadence/cost-tracked "run the shared conformance corpus against the real
+> adapter" residue (as opposed to this doc's real-hardware _behavior_ verification), see
+> [`manual-residue-register.md`](./manual-residue-register.md).
+
 These checks confirm the **real-hardware** behavior of `--require-presence-per-use`
 (issue #122) that cannot run in CI, because they need a physical device and a
 human to perform (or withhold) a touch/biometric action.

--- a/packages/test-helpers/test/conformance/backend-cases.json
+++ b/packages/test-helpers/test/conformance/backend-cases.json
@@ -102,6 +102,32 @@
     ]
   },
   {
+    "name": "list omits an id after it is deleted",
+    "steps": [
+      {
+        "op": "store",
+        "id": "list-delete-me",
+        "secret": "v"
+      },
+      {
+        "op": "expectListContains",
+        "ids": [
+          "list-delete-me"
+        ]
+      },
+      {
+        "op": "delete",
+        "id": "list-delete-me"
+      },
+      {
+        "op": "expectListDoesNotContain",
+        "ids": [
+          "list-delete-me"
+        ]
+      }
+    ]
+  },
+  {
     "name": "a generated signing key signs and verifies against its own public key",
     "steps": [
       {

--- a/packages/test-helpers/test/conformance/backend-cases.json
+++ b/packages/test-helpers/test/conformance/backend-cases.json
@@ -1,0 +1,158 @@
+[
+  {
+    "name": "store then retrieve returns the same secret",
+    "steps": [
+      {
+        "op": "store",
+        "id": "conformance-key",
+        "secret": "conformance-secret"
+      },
+      {
+        "op": "expectRetrieve",
+        "id": "conformance-key",
+        "secret": "conformance-secret"
+      }
+    ]
+  },
+  {
+    "name": "retrieve of a missing id returns not found",
+    "steps": [
+      {
+        "op": "expectRetrieveNotFound",
+        "id": "never-stored"
+      }
+    ]
+  },
+  {
+    "name": "delete removes a stored secret",
+    "steps": [
+      {
+        "op": "store",
+        "id": "delete-me",
+        "secret": "x"
+      },
+      {
+        "op": "delete",
+        "id": "delete-me"
+      },
+      {
+        "op": "expectRetrieveNotFound",
+        "id": "delete-me"
+      }
+    ]
+  },
+  {
+    "name": "delete of a missing id returns not found",
+    "steps": [
+      {
+        "op": "expectDeleteNotFound",
+        "id": "never-existed"
+      }
+    ]
+  },
+  {
+    "name": "exists reflects store/delete state",
+    "steps": [
+      {
+        "op": "expectExists",
+        "id": "existence-probe",
+        "exists": false
+      },
+      {
+        "op": "store",
+        "id": "existence-probe",
+        "secret": "v"
+      },
+      {
+        "op": "expectExists",
+        "id": "existence-probe",
+        "exists": true
+      },
+      {
+        "op": "delete",
+        "id": "existence-probe"
+      },
+      {
+        "op": "expectExists",
+        "id": "existence-probe",
+        "exists": false
+      }
+    ]
+  },
+  {
+    "name": "list reflects every stored id",
+    "steps": [
+      {
+        "op": "store",
+        "id": "list-a",
+        "secret": "1"
+      },
+      {
+        "op": "store",
+        "id": "list-b",
+        "secret": "2"
+      },
+      {
+        "op": "expectListContains",
+        "ids": [
+          "list-a",
+          "list-b"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "a generated signing key signs and verifies against its own public key",
+    "steps": [
+      {
+        "op": "generateSigningKey",
+        "id": "sign-key"
+      },
+      {
+        "op": "expectSignRoundTrips",
+        "id": "sign-key",
+        "message": "vaultkeeper issue #312 conformance"
+      }
+    ]
+  },
+  {
+    "name": "generate signing key rejects a duplicate id",
+    "steps": [
+      {
+        "op": "generateSigningKey",
+        "id": "dup"
+      },
+      {
+        "op": "expectGenerateSigningKeyAlreadyExists",
+        "id": "dup"
+      }
+    ]
+  },
+  {
+    "name": "get public key for a missing signing key id returns not found",
+    "steps": [
+      {
+        "op": "expectGetPublicKeyNotFound",
+        "id": "ghost"
+      }
+    ]
+  },
+  {
+    "name": "sign with a missing signing key id returns not found",
+    "steps": [
+      {
+        "op": "expectSignNotFound",
+        "id": "ghost-signer"
+      }
+    ]
+  },
+  {
+    "name": "reports no presence-per-use capability",
+    "steps": [
+      {
+        "op": "expectPresencePerUse",
+        "value": false
+      }
+    ]
+  }
+]

--- a/packages/test-helpers/test/conformance/backend-cases.test.ts
+++ b/packages/test-helpers/test/conformance/backend-cases.test.ts
@@ -37,6 +37,7 @@ type BackendStep =
   | { op: 'expectDeleteNotFound'; id: string }
   | { op: 'expectExists'; id: string; exists: boolean }
   | { op: 'expectListContains'; ids: string[] }
+  | { op: 'expectListDoesNotContain'; ids: string[] }
   | { op: 'generateSigningKey'; id: string }
   | { op: 'expectGenerateSigningKeyAlreadyExists'; id: string }
   | { op: 'expectSignRoundTrips'; id: string; message: string }
@@ -51,10 +52,70 @@ interface BackendConformanceCase {
 
 // ─── Load cases ─────────────────────────────────────────────────────────
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.getPrototypeOf(value) === Object.prototype &&
+    Object.getOwnPropertySymbols(value).length === 0
+  )
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+function isBackendStep(value: unknown): value is BackendStep {
+  if (!isPlainObject(value) || typeof value.op !== 'string') {
+    return false
+  }
+  switch (value.op) {
+    case 'store':
+    case 'expectRetrieve':
+      return typeof value.id === 'string' && typeof value.secret === 'string'
+    case 'expectRetrieveNotFound':
+    case 'delete':
+    case 'expectDeleteNotFound':
+    case 'generateSigningKey':
+    case 'expectGenerateSigningKeyAlreadyExists':
+    case 'expectGetPublicKeyNotFound':
+    case 'expectSignNotFound':
+      return typeof value.id === 'string'
+    case 'expectExists':
+      return typeof value.id === 'string' && typeof value.exists === 'boolean'
+    case 'expectListContains':
+    case 'expectListDoesNotContain':
+      return isStringArray(value.ids)
+    case 'expectSignRoundTrips':
+      return typeof value.id === 'string' && typeof value.message === 'string'
+    case 'expectPresencePerUse':
+      return typeof value.value === 'boolean'
+    default:
+      return false
+  }
+}
+
+function isBackendConformanceCase(value: unknown): value is BackendConformanceCase {
+  return (
+    isPlainObject(value) &&
+    typeof value.name === 'string' &&
+    Array.isArray(value.steps) &&
+    value.steps.every(isBackendStep)
+  )
+}
+
+function isBackendConformanceCaseArray(value: unknown): value is BackendConformanceCase[] {
+  return Array.isArray(value) && value.every(isBackendConformanceCase)
+}
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const casesPath = path.join(__dirname, 'backend-cases.json')
-// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- JSON.parse returns any; validated by the conformance crate
-const cases: BackendConformanceCase[] = JSON.parse(await fs.readFile(casesPath, 'utf8'))
+const parsedCases: unknown = JSON.parse(await fs.readFile(casesPath, 'utf8'))
+if (!isBackendConformanceCaseArray(parsedCases)) {
+  throw new Error(`${casesPath} does not contain a valid BackendConformanceCase[] shape`)
+}
+const cases: BackendConformanceCase[] = parsedCases
 
 // ─── Runner ─────────────────────────────────────────────────────────────
 
@@ -119,6 +180,15 @@ async function runCase(backend: InMemoryBackend, testCase: BackendConformanceCas
         }
         break
       }
+      case 'expectListDoesNotContain': {
+        const listed = await backend.list()
+        for (const id of step.ids) {
+          if (listed.includes(id)) {
+            throw new Error(`list() ${JSON.stringify(listed)} unexpectedly contains ${id}`)
+          }
+        }
+        break
+      }
       case 'generateSigningKey':
         await backend.generateSigningKey(step.id, 'EdDSA')
         break
@@ -174,11 +244,15 @@ async function runCase(backend: InMemoryBackend, testCase: BackendConformanceCas
         }
         break
       }
+      default: {
+        const unhandled: never = step
+        throw new Error(`unhandled BackendStep kind: ${JSON.stringify(unhandled)}`)
+      }
     }
   }
 }
 
-/** Assert `promise` rejects with an error whose constructor name is `expectedName`. */
+/** Assert `promise` rejects with an error whose `name` (the project's stable discriminator) is `expectedName`. */
 async function expectRejectsWithName(
   promise: Promise<unknown>,
   expectedName: string,
@@ -194,7 +268,7 @@ async function expectRejectsWithName(
   if (threw === undefined) {
     throw new Error(`${op}(${id}) expected to reject with ${expectedName}, but it resolved`)
   }
-  const actualName = threw instanceof Error ? threw.constructor.name : typeof threw
+  const actualName = threw instanceof Error ? threw.name : typeof threw
   const actualMessage = threw instanceof Error ? threw.message : JSON.stringify(threw)
   if (actualName !== expectedName) {
     throw new Error(

--- a/packages/test-helpers/test/conformance/backend-cases.test.ts
+++ b/packages/test-helpers/test/conformance/backend-cases.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Conformance fidelity gate for the `InMemoryBackend` test double (issue #312).
+ *
+ * Runs the exact same data-driven `BackendConformanceCase` corpus exported
+ * from `vaultkeeper-conformance` (Rust crate) against the TS
+ * `InMemoryBackend` double, mirroring the existing JS conformance-runner
+ * pattern in `packages/cli-tests/test/conformance/run-conformance.test.ts`
+ * (load cases exported to JSON, run each against the implementation under
+ * test, aggregate failures). This corpus is scoped to backend-level
+ * behavior — store/retrieve/delete/exists/list/sign/capability — applicable
+ * to any `SecretBackend` implementation, not the CLI-argv-only cases in
+ * `crates/vaultkeeper-conformance/src/lib.rs` (see that corpus's
+ * `backend_cases` module doc for why those two corpora are separate).
+ *
+ * The identical corpus also runs against the Rust core `InMemoryBackend` in
+ * `crates/vaultkeeper-core/tests/backend_conformance.rs`, proving
+ * cross-language parity (issue #312 AC4).
+ *
+ * @see crates/vaultkeeper-conformance/src/backend_cases.rs — case definitions
+ * @see crates/vaultkeeper-core/tests/backend_conformance.rs — Rust-side runner
+ */
+
+import * as crypto from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { InMemoryBackend } from '../../src/index.js'
+
+// ─── Types mirroring the Rust BackendConformanceCase / BackendStep ────────
+
+type BackendStep =
+  | { op: 'store'; id: string; secret: string }
+  | { op: 'expectRetrieve'; id: string; secret: string }
+  | { op: 'expectRetrieveNotFound'; id: string }
+  | { op: 'delete'; id: string }
+  | { op: 'expectDeleteNotFound'; id: string }
+  | { op: 'expectExists'; id: string; exists: boolean }
+  | { op: 'expectListContains'; ids: string[] }
+  | { op: 'generateSigningKey'; id: string }
+  | { op: 'expectGenerateSigningKeyAlreadyExists'; id: string }
+  | { op: 'expectSignRoundTrips'; id: string; message: string }
+  | { op: 'expectGetPublicKeyNotFound'; id: string }
+  | { op: 'expectSignNotFound'; id: string }
+  | { op: 'expectPresencePerUse'; value: boolean }
+
+interface BackendConformanceCase {
+  name: string
+  steps: BackendStep[]
+}
+
+// ─── Load cases ─────────────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const casesPath = path.join(__dirname, 'backend-cases.json')
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- JSON.parse returns any; validated by the conformance crate
+const cases: BackendConformanceCase[] = JSON.parse(await fs.readFile(casesPath, 'utf8'))
+
+// ─── Runner ─────────────────────────────────────────────────────────────
+
+/**
+ * Run a single {@link BackendConformanceCase} against `backend`, throwing a
+ * descriptive `Error` on the first failing step. Exported (module-private,
+ * but reachable from this file's own drift-detection test below) so the
+ * suite and the drift-proof test share one implementation rather than two
+ * hand-duplicated copies.
+ */
+async function runCase(backend: InMemoryBackend, testCase: BackendConformanceCase): Promise<void> {
+  for (const step of testCase.steps) {
+    switch (step.op) {
+      case 'store':
+        await backend.store(step.id, step.secret)
+        break
+      case 'expectRetrieve': {
+        const got = await backend.retrieve(step.id)
+        if (got !== step.secret) {
+          throw new Error(
+            `retrieve(${step.id}) returned ${JSON.stringify(got)}, expected ${JSON.stringify(step.secret)}`,
+          )
+        }
+        break
+      }
+      case 'expectRetrieveNotFound': {
+        await expectRejectsWithName(
+          backend.retrieve(step.id),
+          'SecretNotFoundError',
+          step.op,
+          step.id,
+        )
+        break
+      }
+      case 'delete':
+        await backend.delete(step.id)
+        break
+      case 'expectDeleteNotFound': {
+        await expectRejectsWithName(
+          backend.delete(step.id),
+          'SecretNotFoundError',
+          step.op,
+          step.id,
+        )
+        break
+      }
+      case 'expectExists': {
+        const got = await backend.exists(step.id)
+        if (got !== step.exists) {
+          throw new Error(
+            `exists(${step.id}) returned ${String(got)}, expected ${String(step.exists)}`,
+          )
+        }
+        break
+      }
+      case 'expectListContains': {
+        const listed = await backend.list()
+        for (const id of step.ids) {
+          if (!listed.includes(id)) {
+            throw new Error(`list() ${JSON.stringify(listed)} does not contain ${id}`)
+          }
+        }
+        break
+      }
+      case 'generateSigningKey':
+        await backend.generateSigningKey(step.id, 'EdDSA')
+        break
+      case 'expectGenerateSigningKeyAlreadyExists': {
+        await expectRejectsWithName(
+          backend.generateSigningKey(step.id, 'EdDSA'),
+          'SigningKeyAlreadyExistsError',
+          step.op,
+          step.id,
+        )
+        break
+      }
+      case 'expectSignRoundTrips': {
+        const publicKey = await backend.getPublicKey(step.id)
+        const message = Buffer.from(step.message, 'utf8')
+        const signature = await backend.signWithKey(step.id, message)
+        const verifyingKey = crypto.createPublicKey(publicKey.publicKeyPem)
+        if (!crypto.verify(null, message, verifyingKey, signature)) {
+          throw new Error(
+            `signWithKey(${step.id}) signature did not verify against its own public key`,
+          )
+        }
+        const tampered = Buffer.from('a tampered payload', 'utf8')
+        if (crypto.verify(null, tampered, verifyingKey, signature)) {
+          throw new Error(`signWithKey(${step.id}) signature verified against a tampered payload`)
+        }
+        break
+      }
+      case 'expectGetPublicKeyNotFound': {
+        await expectRejectsWithName(
+          backend.getPublicKey(step.id),
+          'SigningKeyNotFoundError',
+          step.op,
+          step.id,
+        )
+        break
+      }
+      case 'expectSignNotFound': {
+        await expectRejectsWithName(
+          backend.signWithKey(step.id, Buffer.from('data')),
+          'SigningKeyNotFoundError',
+          step.op,
+          step.id,
+        )
+        break
+      }
+      case 'expectPresencePerUse': {
+        const caps = await backend.getCapabilities()
+        if (caps.presencePerUse !== step.value) {
+          throw new Error(
+            `getCapabilities().presencePerUse was ${String(caps.presencePerUse)}, expected ${String(step.value)}`,
+          )
+        }
+        break
+      }
+    }
+  }
+}
+
+/** Assert `promise` rejects with an error whose constructor name is `expectedName`. */
+async function expectRejectsWithName(
+  promise: Promise<unknown>,
+  expectedName: string,
+  op: string,
+  id: string,
+): Promise<void> {
+  let threw: unknown
+  try {
+    await promise
+  } catch (err) {
+    threw = err
+  }
+  if (threw === undefined) {
+    throw new Error(`${op}(${id}) expected to reject with ${expectedName}, but it resolved`)
+  }
+  const actualName = threw instanceof Error ? threw.constructor.name : typeof threw
+  const actualMessage = threw instanceof Error ? threw.message : JSON.stringify(threw)
+  if (actualName !== expectedName) {
+    throw new Error(
+      `${op}(${id}) expected to reject with ${expectedName}, got ${actualName}: ${actualMessage}`,
+    )
+  }
+}
+
+// ─── Test suite (AC1) ───────────────────────────────────────────────────
+
+describe('InMemoryBackend conformance fidelity gate', () => {
+  it.each(cases.map((c): [string, BackendConformanceCase] => [c.name, c]))(
+    '%s',
+    async (_name, testCase) => {
+      const backend = new InMemoryBackend()
+      await expect(runCase(backend, testCase)).resolves.toBeUndefined()
+    },
+  )
+})
+
+// ─── Drift-detection proof (AC2) ─────────────────────────────────────────
+//
+// Proves the gate actually detects drift rather than passing vacuously: a
+// deliberately mutated case (wrong expected secret value) must cause the
+// runner to fail. This does NOT ship a broken gate — the mutated case only
+// exists inside this one test and is never added to `cases`/the suite above.
+
+describe('InMemoryBackend conformance fidelity gate — drift detection (AC2)', () => {
+  it('fails when a case expectation the double does not meet is introduced', async () => {
+    const original = cases.find((c) => c.name === 'store then retrieve returns the same secret')
+    if (original === undefined) {
+      throw new Error("fixture case 'store then retrieve returns the same secret' must exist")
+    }
+
+    // Deliberately diverge the case from what InMemoryBackend actually does:
+    // claim the stored secret is a different value than what was stored.
+    const mutated: BackendConformanceCase = {
+      name: original.name,
+      steps: original.steps.map((step) =>
+        step.op === 'expectRetrieve' ? { ...step, secret: `${step.secret}-drifted` } : step,
+      ),
+    }
+
+    const backend = new InMemoryBackend()
+    await expect(runCase(backend, mutated)).rejects.toThrow(/expected "conformance-secret-drifted"/)
+  })
+
+  it('fails when a not-found expectation the double does not meet is introduced', async () => {
+    const backend = new InMemoryBackend()
+    // The double correctly resolves retrieve() for a stored id — asserting
+    // it must instead reject with SecretNotFoundError is the drift.
+    await backend.store('present', 'value')
+    const mutated: BackendConformanceCase = {
+      name: 'drift: retrieve of a present id incorrectly asserted not-found',
+      steps: [{ op: 'expectRetrieveNotFound', id: 'present' }],
+    }
+    await expect(runCase(backend, mutated)).rejects.toThrow(
+      /expected to reject with SecretNotFoundError/,
+    )
+  })
+})

--- a/packages/test-helpers/test/conformance/backend-cases.test.ts
+++ b/packages/test-helpers/test/conformance/backend-cases.test.ts
@@ -259,13 +259,15 @@ async function expectRejectsWithName(
   op: string,
   id: string,
 ): Promise<void> {
+  let didThrow = false
   let threw: unknown
   try {
     await promise
   } catch (err) {
+    didThrow = true
     threw = err
   }
-  if (threw === undefined) {
+  if (!didThrow) {
     throw new Error(`${op}(${id}) expected to reject with ${expectedName}, but it resolved`)
   }
   const actualName = threw instanceof Error ? threw.name : typeof threw

--- a/packages/vaultkeeper/README.md
+++ b/packages/vaultkeeper/README.md
@@ -480,7 +480,11 @@ consecutive required-presence operations each demand their own distinct fresh ac
 > intrinsic to the cryptographic operation.
 
 Real-hardware confirmation for each backend is documented as a manual verification test in
-[`docs/manual-tests/presence-per-use.md`](../../docs/manual-tests/presence-per-use.md).
+[`docs/manual-tests/presence-per-use.md`](../../docs/manual-tests/presence-per-use.md). The
+release-process-referenced register of what manual residue remains per backend once its paired
+in-memory double runs the shared conformance corpus in CI — and the cadence/cost of running that
+corpus against the real adapter — lives in
+[`docs/manual-tests/manual-residue-register.md`](../../docs/manual-tests/manual-residue-register.md).
 
 ## Doctor / preflight checks
 


### PR DESCRIPTION
## Summary

Adds a conformance fidelity gate that holds the `@vaultkeeper/test-helpers` `InMemoryBackend`
double to the same contract corpus the real backends are held to, mirrors the corresponding
signing + presence capability surface onto the Rust core `InMemoryBackend`, and commits the
manual-residue register documenting the human residue that remains once every backend has a
paired double running that shared corpus.

The existing `packages/cli-tests/test/conformance/` corpus is CLI-argv-only and always exercises
the hardcoded `file` backend (see #273/#297) — there is no CLI invocation that selects a specific
backend instance, so it cannot exercise the `InMemoryBackend` double directly. Rather than
generalizing that corpus (explicitly out of scope per the issue), this adds a second, narrower
data-driven corpus in `crates/vaultkeeper-conformance/src/backend_cases.rs`, scoped to exactly the
store/retrieve/delete/exists/list/sign/capability behavior an in-memory backend can support, and
runs it in-process against both languages' `InMemoryBackend`.

## What changed

- `crates/vaultkeeper-conformance/src/backend_cases.rs` (new): 11 data-driven
  `BackendConformanceCase`s (store/retrieve round-trip, not-found errors, delete, exists, list,
  signing key generate/sign/verify, duplicate-key rejection, missing-key errors, presence
  capability), exported to JSON via a new `export-backend-conformance` bin.
- `crates/vaultkeeper-core/tests/backend_conformance.rs` (new): runs the same corpus against the
  Rust core `InMemoryBackend`.
- `packages/test-helpers/test/conformance/backend-cases.{json,test.ts}` (new): runs the same
  corpus (committed export of the Rust corpus) against the TS `InMemoryBackend` double, following
  the existing JS conformance-runner pattern (`packages/cli-tests/test/conformance/run-conformance.test.ts`).
- `crates/vaultkeeper-core/src/backend/in_memory.rs`: implements `SigningBackend` (real in-memory
  Ed25519 keys via `ed25519-dalek`, mirroring `FileBackend`'s in-crate signing implementation) and
  `PresenceCapableBackend` (honest `presence_per_use: false`), matching the TS double's existing
  surface (#310). Also fixes `delete()` on a missing id, which previously silently no-op'd instead
  of returning `SecretNotFound` — a real divergence from `FileBackend`'s contract and the TS
  double's `delete()`, caught while building the new cross-language corpus.
- `crates/vaultkeeper-core/tests/presence_capability.rs`: updates two tests that used
  `InMemoryBackend` as their "backend without `PresenceCapableBackend`" example (no longer true
  now that it implements the trait); adds a `PlainBackend` fixture for that purpose and a new test
  asserting `InMemoryBackend` now correctly reports capability via the trait.
- `docs/manual-tests/manual-residue-register.md` (new): the five-backend register from the issue
  body, the tool-upgrade-triggered (not calendar-triggered) framing, the physical-ceremony column,
  and why each ceremony can't be automated. Referenced from the release workflow
  (`.github/workflows/release.yml` header comment) and cross-linked from
  `docs/manual-tests/presence-per-use.md` and `packages/vaultkeeper/README.md`.
- `packages/vaultkeeper-wasm/wasm/vaultkeeper_wasm_bg.wasm`: rebuilt (Rust core changed); export/import
  fingerprint unchanged (`node scripts/wasm-export-fingerprint.mjs` — 47 exports/54 imports both
  sides), well within the gzip/uncompressed size budgets.

## Acceptance criteria → tests

1. **(conformance)** applicable cases run against the TS `InMemoryBackend` double and pass — `packages/test-helpers/test/conformance/backend-cases.test.ts` (`InMemoryBackend conformance fidelity gate` describe block, 11 cases via `it.each`).
2. **(conformance)** a deliberate divergence causes the gate to fail, proving it isn't vacuous — `backend-cases.test.ts`'s `InMemoryBackend conformance fidelity gate — drift detection (AC2)` block: two tests that mutate a case in-memory (wrong expected secret value; incorrect not-found assertion) and assert the runner rejects. The mutation only exists inside the test — no broken case ships in the corpus.
3. **(unit, Rust)** core `in_memory` implements `SigningBackend`: generates a keypair, signs, and the signature verifies against the public key — `crates/vaultkeeper-core/src/backend/in_memory.rs` `tests` module (`sign_with_key_produces_a_signature_verifiable_against_the_public_key`, plus duplicate/missing-key/tamper/coexistence/clear regression tests).
4. **(conformance)** the same cases pass against the core Rust `in_memory` backend, confirming cross-language parity — `crates/vaultkeeper-core/tests/backend_conformance.rs` (`all_backend_conformance_cases_pass_against_core_in_memory_backend`).
5. **(UAT/doc)** the manual-residue register is committed and referenced by the release process, with the five rows, the tool-upgrade-triggered framing, the ceremony column, and cadence·cost — `docs/manual-tests/manual-residue-register.md`, referenced from `.github/workflows/release.yml`'s header comment.

## Test gates

- `cargo test --workspace`: 538 tests passed, 0 failed across all 19 test binaries (unit tests, `crates/vaultkeeper-core/tests/*`, the new `backend_conformance` binary, the `vaultkeeper-conformance` crate's own unit tests, etc.).
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `pnpm check` (typecheck + lint + api-report + api-docs across all TS packages): clean.
- `pnpm test`: 1012 + 7 + 102 + 355 + 265 = 1741 tests passed, 0 failed (24 skipped, environment-gated) across `vaultkeeper`, `@vaultkeeper/wasm` (Node's `node:test`, 131/131), `@vaultkeeper/test-helpers` (102/102, including the new 13-test conformance file), `@vaultkeeper/cli`, `@vaultkeeper/cli-tests`.

## Deferred follow-ups

- None identified in scope. The pre-existing CLI-argv-only conformance corpus (#273/#297) remains
  as-is per the issue's explicit "do not block on generalizing the corpus."

Refs #312
