### PR TITLE
Add surface-governance and assurance specs (docs/specs 001, 002)

### DIFF
--- a/docs/specs/001-surface-governance.md
+++ b/docs/specs/001-surface-governance.md
@@ -28,7 +28,7 @@ surface change.
 | `doctor` | Run preflight checks and report whether vaultkeeper is ready to use on this machine. |
 | `trust approve` | Trust an executable: record its hash in the trust manifest. *(was `approve`; PATH positional)* |
 | `trust dev-mode` | Enable or disable relaxed identity verification for a script during development. *(was `dev-mode`)* |
-| `trust check` *(designed)* | Report whether trust in an executable is intact right now — recomputed hash vs manifest, tier, dev-mode status; scriptable exit code. |
+| `trust status` *(designed)* | Report the current trust state of an executable — recomputed hash vs manifest, tier, dev-mode status; scriptable exit code (0 intact / 2 mismatch-or-conflict). |
 | `key rotate` | Rotate the vault encryption key, re-sealing stored state under the new key. *(was `rotate-key`)* |
 | `key revoke` | Emergency-revoke the vault encryption key, invalidating all outstanding tokens. *(was `revoke-key`)* |
 | `config init` | Create a new configuration file with defaults. |
@@ -87,45 +87,79 @@ a whole with no sibling operations on a shared resource — after adjudication, 
 
 **G2 — The primary subject is positional; modifiers are flags.** A command's required primary subject — the
 resource it acts on — is a **positional argument**. Options, policy toggles, and alternate sources are
-**flags**. `profile show NAME`, `session mint PROFILE`, `approve --path` (see BROKEN-4). A secret value is
+**flags**. `profile show NAME`, `lease issue PROFILE`, `trust approve PATH` (see B4). A secret value is
 **never** a positional or a flag value (G6).
 
-**G3 — Flag naming is a stable vocabulary.** A concept has exactly one flag spelling across the whole surface.
-`--profile-file` for the explicit-path override, `--json` for machine output, `--profile`/`--entry` for
-profile addressing. The presence family is **one** name (see BROKEN-5).
+**G3 — Flags are a surface-wide vocabulary with defined levels.** A concept has exactly one flag spelling
+across the whole surface **and** a defined applicability *level*, and the two are inseparable — a flag's name
+carries a promise about where it applies. Three levels:
+
+- **Near-universal flags** — apply to nearly every command and mean the same thing everywhere: `--format`
+  (and its `--json` alias) for output-format selection (§G5).
+- **Family flags** — apply across a related group of commands with one fixed spelling: `--profile` is **the**
+  single way any command references a profile; `--profile-file` is the explicit-path override; the
+  `--require-presence-*` family (see B5) carries presence policy wherever presence applies.
+- **Command-local flags** — meaningful to a single command (e.g. `--entry` selecting within a profile).
+
+A new flag **must** state its level. Promoting a command-local flag to a family or near-universal level (or
+the reverse) is a **surface change** and therefore a spec change (§1.4), never an ad-hoc addition.
 
 **G4 — stdout is data; stderr is diagnostics.** stdout carries *only* the command's payload — a JWE
-(`session mint`), a JSON value (`--json`), a name list, or the child's own stream (`exec`/`run`). Every
+(`lease issue`), a structured value (`--format json`), a name list, or the child's own stream (`run`). Every
 human-facing message — progress, warnings, the file-only degradation notice, errors — goes to **stderr**.
 This is the #279 rule generalized to the whole surface, and it is what makes every data-producing command
 pipeable. `--dry-run` and human-report commands print their report to stdout (there is no child to protect),
 but a command that emits a machine artifact must never interleave diagnostics into it.
 
-**G5 — `--json` is opt-in and total.** Absent, output is human text. Present, stdout is a **single JSON
-value** and nothing else. `--json` is the only machine-output switch; no command invents a second one.
+**G5 — Output has an output-formatter architecture: generation is separated from formatting.** A command
+*generates* a value; a separate *formatter* renders it. This separation is the rule — no command hand-rolls
+its own serialization. Format selection is layered:
+
+- **Explicit `--format <human|toon|json>`** wins whenever present. `--json` is a defined alias for
+  `--format json`; no command invents a second machine-output switch.
+- **Absent an explicit choice**, the CLI detects agentic invocation — the environment variables catalogued by
+  [is-agentic-tui](https://github.com/mike-north/is-agentic-tui#supported-tools) — and defaults to
+  [toon](https://toonformat.dev/) for token efficiency; otherwise it renders human-readable text.
+
+When a structured format (`toon` or `json`) is selected, stdout is a **single well-formed document** and
+nothing else — the totality rule of §G4 stands: diagnostics never interleave into it. This is a shared
+output-formatter across the surface; its implementation lands as its own work item.
 
 **G6 — Secrets never appear in argv.** A CLI-surface invariant, not a per-command choice. A secret value
-enters only via **stdin** (`store`) and leaves only via **stdout** (`session mint` prints a lease, `exec`
-injects into a child's environment). No command accepts a secret as a positional or flag value; `--set
+enters only via **stdin** (`secret store`) and leaves only via **stdout** (`lease issue` prints a lease, `run`
+injects into a child's environment). No command accepts a **raw secret** as a positional or flag value; `--set
 VAR=SECRET` on `run` is the one deliberate exception and is documented as such, marked UNREVIEWED in
-`--dry-run`. (Backend implementations honor the same rule downstream, e.g. keychain `store` via `security
--i` stdin.)
+`--dry-run`. (Backend implementations honor the same rule downstream, e.g. keychain `secret store` via
+`security -i` stdin.) Lease tokens are a distinct case: they *do* travel as values — a `--token <JWE>` flag,
+a printed lease on stdout. This is unavoidable and permitted, because a lease is a scoped, expiring
+**capability**, not a raw secret; but it still warrants care — a lease authorizes use, so it must be handled
+deliberately and never logged casually.
 
 **G7 — Exit-code taxonomy.** `0` success; `1` a typed operational failure (the `VaultError` surface, §2.1);
-`2` reserved for clap usage errors; `exec`/`run` **propagate the child's exit code**, and a signal-terminated
+`2` reserved for clap usage errors; `run` **propagates the child's exit code**, and a signal-terminated
 child yields `128+N`. Advisory commands that cannot "fail" (`profile lint`) exit `0` on any successfully
 loaded input and signal concerns only through stderr warnings — this is deliberate and normative, not a bug.
 
-**G8 — Analysis-verb vocabulary: `lint` judges what you wrote; `check` verifies what is** *(owner-adjudicated)*.
+**G8 — `lint` judges what you wrote; `status` reports what is** *(owner-adjudicated)*.
 `lint` is **advisory static analysis of an authored artifact** (a profile file): opinions about a document,
-never a verdict — and it always exits `0`, because its baseline (this machine's `config.json` defaults) is
-machine-relative, so gating on it would crown one machine's defaults as project authority. `check` is
-**pass/fail verification of live state against an objective baseline** (a recomputed hash vs the committed
-manifest): a machine-independent verdict with a meaningful exit code, safe for scripts and CI to gate on.
-The exit-code semantics *derive from the subject* — machine-relative baselines cannot gate; objective
-baselines must. `doctor` remains the bundled whole-machine check. New commands must pick the verb that
-matches their subject; near-synonyms (`validate`, `verify`, `audit`) are reserved — propose them through
-this spec, not ad hoc.
+never a verdict — and it always exits `0`, because its baseline (this machine's config defaults) is
+machine-relative, so gating on it would crown one machine's defaults as project authority. `status` is a
+**factual state report against an objective baseline** (a recomputed hash vs the committed manifest): it does
+not opine, it reports what is — with **meaningful, gate-safe exit codes** (`0` intact, non-zero for a
+mismatch or conflict), safe for scripts and CI to gate on. The prior art is `git status` and `systemctl
+status`: a state report, not an advisory. The exit-code semantics *derive from the subject* — machine-relative
+baselines cannot gate; objective baselines must. `doctor` is the bundled whole-machine `status`. New commands
+must pick the verb that matches their subject; the near-synonyms `check`, `validate`, `verify`, and `audit`
+are **reserved pending a spec proposal** — propose them through this spec, not ad hoc.
+
+**G9 — YAML-first for structured configuration artifacts** *(owner-adjudicated)*. The committable structured
+artifacts — profiles and the config file — are **canonically YAML**: it carries comments (the policy intent a
+profile encodes deserves inline explanation) and is more token-efficient for the agentic readers that consume
+it. JSON is **accepted for compatibility** during the migration window, so an existing `.json` artifact keeps
+working, but new artifacts and all examples are YAML. Profile storage is therefore `profiles/<name>.yaml`
+canonical (`.json` still accepted); `config init` writes YAML. The JSON→YAML migration is a tracked work
+item. (This governs the on-disk *artifact* format; the *wire* encoding of config/claim JSON remains camelCase,
+§L5.)
 
 ### 1.3 Inconsistencies (BROKEN) — the review surface
 
@@ -138,7 +172,7 @@ on reflection, recorded to close the question.
 | B1 | `store --name`, `delete --name` | G2 | The primary subject (the secret name) is a **flag**, while `profile`/`session` make the subject positional. | **fix-now**: `store NAME` / `delete NAME` positional; keep `--name` as a hidden deprecated alias for one minor. |
 | B2 | `store`, `delete`, `rotate-key`, `revoke-key` as bare verbs | G1 | These act on addressable resource categories (secrets; keys) but are top-level verbs. | **ADJUDICATED (owner)**: promote — `secret store NAME`, `secret delete NAME` (future `secret list`); `key rotate`, `key revoke` (future `key show`, `key generations`). Hyphenated/bare forms become deprecated aliases, removed at 1.0. |
 | B3 | `dev-mode` as a bare top-level verb with `--enable` | G1/G2 | Trust-manifest operation stranded outside any namespace. | **ADJUDICATED (owner)**: joins the `trust` namespace — `trust dev-mode PATH …` (exact enable/disable shape settled at implementation under G2/G3). Deprecated alias until 1.0. |
-| B4 | `approve --path` (and `dev-mode --path`) | G1/G2 | The subject is a flag, and the verb names the act without its noun: approving is a *trust* decision. `command`/`bin` rejected as the noun — "command" is already load-bearing (`run … -- COMMAND`) and "bin" misdescribes interpreted scripts. | **ADJUDICATED (owner)**: `trust approve PATH` (positional). The `trust` namespace matches the domain's own vocabulary (trust manifest, trust tiers) and gains designed future members: `trust check PATH` (recompute + compare now; `--json`; exit 0 intact / non-zero mismatch — a scriptable gate primitive and the first-class surface for TOFU-conflict reporting), `trust list`, `trust revoke PATH`. Deprecated aliases until 1.0. |
+| B4 | `approve --path` (and `dev-mode --path`) | G1/G2 | The subject is a flag, and the verb names the act without its noun: approving is a *trust* decision. `command`/`bin` rejected as the noun — "command" is already load-bearing (`run … -- COMMAND`) and "bin" misdescribes interpreted scripts. | **ADJUDICATED (owner)**: `trust approve PATH` (positional). The `trust` namespace matches the domain's own vocabulary (trust manifest, trust tiers) and gains designed future members: `trust status PATH` (recompute + compare now; `--json`; exit 0 intact / non-zero mismatch — a scriptable gate primitive and the first-class surface for TOFU-conflict reporting), `trust list`, `trust revoke PATH`. Deprecated aliases until 1.0. |
 | B5 | `store`/`delete` `--require-presence-per-use` vs `run` `--require-presence` | G3 | Two spellings for the presence family. | **fix-now**: pick one before `run` lands. Recommend `--require-presence-per-use` (precise; "presence" alone is ambiguous about scope) across all commands, or a shared `--require-presence[=per-use]`. Resolve **before** #279 merges so `run` ships correct. |
 | B6 | `session mint PROFILE --entry E` vs `profile show NAME` | G2 | Reviewed in #328: `mint` takes the profile positionally (consistent) but the *entry* — arguably a co-primary subject — is a flag. | **leave** (documented): the profile is the addressed resource; the entry is a selector within it, legitimately a flag. Recorded so the #328 question is closed, not reopened. |
 | B7 | `backend capabilities` is the only `backend` verb | G1 | A noun namespace with a single verb is defensible only if more verbs are foreseen. | **leave**: `backend list`/`backend test` are natural future siblings; the namespace is intentional headroom, not premature. |
@@ -154,8 +188,8 @@ on reflection, recorded to close the question.
 - **E2 — Deprecation path.** A removed or renamed flag/command survives one minor release as a hidden alias
   emitting a stderr deprecation notice (never on stdout — G4), then is removed at the next minor. Renames land
   the new spelling and the alias together.
-- **E3 — Cross-implementation enforcement.** The native and TS CLIs are one surface; `crates/vaultkeeper-
-  conformance` is the mechanical proof of it. Every new command lands with conformance cases so the two CLIs
+- **E3 — Cross-implementation enforcement.** The native and TS CLIs are one surface;
+  `crates/vaultkeeper-conformance` is the mechanical proof of it. Every new command lands with conformance cases so the two CLIs
   cannot diverge — the surface is enforced by test, not by discipline.
 
 ---
@@ -177,6 +211,16 @@ on reflection, recorded to close the question.
   `@vaultkeeper/wasm` has none. New runtime deps require explicit owner approval (recorded in CLAUDE.md).
 - **L5 — Wire and type discipline.** Config/claim JSON is camelCase; public option shapes are
   `exactOptionalPropertyTypes`-safe (no `undefined`-assignable optionals); no `as` casts in the surface.
+- **L6 — No subpath exports.** Each TS package has exactly one public entry point — the package root. There
+  are no deep-import subpaths (`vaultkeeper/foo`); the conditional `exports` map exposes only the root, and
+  everything public flows through `index.ts`. A consumer never reaches into a package's internal file layout,
+  so that layout stays free to change without breaking anyone. This is L1 enforced at the package boundary:
+  `index.ts` is the surface, and it is the *only* door.
+- **L7 — TypeScript compiler support policy.** The library commits to compiling under the **latest minor of
+  each supported TS major** — currently the latest minors of TS 5.x, 6.x, and 7.x — plus `typescript@latest`.
+  A CI **test matrix** covers exactly these entries, and a **non-blocking** CI lane tracks the TS **nightly**
+  build as an early-warning signal (its failure never gates a PR). The consumer-facing guarantee: the public
+  types compile cleanly under every matrix entry. Adding or dropping a supported major is a spec change.
 
 ### 2.2 The surface by concept (IS)
 
@@ -184,15 +228,22 @@ The 88 `@public` symbols group into coherent concepts. The owner reviews whether
 whether membership is intentional.
 
 - **Entry & lifecycle:** `VaultKeeper` (the façade class), `VaultKeeper.init`, `VaultKeeperOptions`,
-  `VaultResponse`.
-- **Setup / identity / trust:** `setup`, `SetupOptions` (a discriminated union enforcing exactly one of
-  `executablePath`/`skipTrust` — a craft high point, keep as the pattern), `SetupOptionsBase`,
+  `VaultResponse` **⚠ name under workshop** — this operation-metadata wrapper's name collides with the
+  adjacent tools' "vault" noun and predates the glossary; the rename is adjudicated at the tiering pass (§2.3)
+  (candidate shapes: per-operation result/receipt types). Do not invent the final name here.
+- **Setup / identity / trust:** `setup` (**normative clarification:** `setup()` is **per-process
+  initialization by the embedding application** — load config, verify caller identity, wire the backend — run
+  each time a host process starts; it is **not** one-time user onboarding, which is the CLI's `config init`.
+  The *name* is under workshop for that ambiguity, see below), `SetupOptions` (a discriminated union enforcing
+  exactly one of `executablePath`/`skipTrust` — a craft high point, keep as the pattern), `SetupOptionsBase`,
   `approveExecutable`, `checkExecutableTrust`, `setDevelopmentMode`, `ExecutableTrustStatus`,
   `ExecutableTrustRequiredError`, `IdentityMismatchError`.
 - **Secrets & access tokens:** `store`, `delete`, `secretExists`, `authorize`, `getSecret`, `CapabilityToken`,
   `SecretAccessor`, `SecretTokenMap`, `AccessorConsumedError`, `SecretNotFoundError`.
-- **Delegated access patterns:** `fetch`, `exec`, `FetchRequest`, `ExecRequest`, `ExecResult`,
-  `redactSecrets`, `REDACTED`, `FetchError`, `ExecError`.
+- **Delegated access patterns:** `fetch`; the delegated-launch verb **aligns to `run`** (CLI ubiquitous
+  language — the library method today named `exec` and its `Exec*` request/result/error types rename to the
+  `run` family at the tiering pass, §2.3, so the launcher is spelled `run` in both surfaces), `FetchRequest`,
+  `ExecRequest`, `ExecResult`, `redactSecrets`, `REDACTED`, `FetchError`, `ExecError`.
 - **Signing & leases:** `createSigningKey`, `authorizeSigningKey`, `sign`, `exportPublicKey`,
   `VaultKeeper.verify`, `SigningAlgorithm`, `SigningPublicKey`, `SignRequest`, `SignResult`, `VerifyRequest`,
   `SigningBackend`, `isSigningBackend`, and the signing error family.
@@ -205,7 +256,18 @@ whether membership is intentional.
   `TrustTier`, `KeyStatus`, `Platform`.
 - **Doctor:** `runDoctor` / `VaultKeeper.doctor`, `RunDoctorOptions`, `PreflightResult`, `PreflightCheck`,
   `ScopedPreflightCheck`, `PreflightCheckError`, `PreflightCheckErrorKind`, `PreflightCheckStatus`.
-- **Error hierarchy:** `VaultError` plus ~30 subclasses — the sole failure surface (L3).
+- **Error hierarchy:** `VaultError` plus ~30 subclasses — the sole failure surface (L3). **Designed
+  addition:** `UnreachableError` — its constructor accepts a `never`, so a missed `enum`/union arm becomes a
+  **compile error at the switch site** (the value that should be `never` still has a type, and passing it
+  fails to typecheck) rather than a silent fall-through at runtime.
+
+**Names under workshop (⚠ owner-flagged, decision deferred — no surface change yet):**
+
+- `VaultResponse` — the "vault"-noun collision above; rename resolved at the tiering pass (§2.3).
+- `setup` (the name) — reads like one-time onboarding but denotes per-process initialization (see the
+  clarification above); the name is under review even though the semantics are settled.
+- **development mode** (`setDevelopmentMode`, CLI `trust dev-mode`) — the owner is not settled on the naming
+  ("I'm not sure I love it"); flagged for a later naming decision. No rename lands here.
 
 **Completeness gap (BROKEN-L1):** there is **no profile / resolution surface in the TS library** — profile
 schema and `resolve_profile` live in `vaultkeeper-core` (and are reaching the CLI), but the embedding library
@@ -219,11 +281,18 @@ don't let it arrive by accretion when a consumer files for it.**
 accretion, not craft: a symbol is `@public` because it was exported, not because it was chosen for a 1.0
 compatibility promise. **SHOULD BE:**
 
-- `@public` — a 1.0 compatibility commitment; breaking it is a major-version event.
+- `@public` — conventional SemVer stability commitment; breaking it is a major-version event.
 - `@beta` — intended-public, shape may still change before promotion; opt-in acknowledged.
 - `@alpha` / `@internal` — not for external use; may change or vanish any release.
 - **Promotion policy:** `@alpha → @beta → @public` only by an explicit PR that names the symbol and updates
   this spec; nothing reaches `@public` by default.
+- **Breaking-change policy (tested in CI).** The tiers are only meaningful if the compatibility promise each
+  makes is *enforced*, so the project adopts a **defined breaking-change policy** gated in CI via
+  [@api-extractor-tools/change-detector](https://github.com/mike-north/api-extractor-tools/tree/main/tools/change-detector).
+  Enforcement grows to an **API report per maturity stage** — `internal`, `alpha`, `beta`, `public` — and the
+  change-detector applies each stage's rules to its report: a breaking change to a `@public` symbol fails CI
+  unless the PR is a deliberate major-version event, while lower stages permit the churn their contract allows.
+  This turns "don't break `@public`" from a review-time judgment into a mechanical gate.
 
 **Named craft-vs-accretion judgment calls (owner adjudicates):**
 
@@ -242,7 +311,7 @@ compatibility on surface we never deliberately chose.
 
 | Persona (product brief) | Primary surface | Status |
 |---|---|---|
-| **Tool user** (unmodified tool via CLI) | Part 1 — `run`/`exec`/`store`/`profile` | served (pending `run`) |
+| **Tool user** (unmodified tool via CLI) | Part 1 — `run`/`secret store`/`profile` | served (pending `run`) |
 | **Library / tool author** (embeds vaultkeeper) | `VaultKeeper` façade + access patterns + `SecretBackend` for a custom store | served for secrets/signing; **gap: profile resolution (§2.2 BROKEN-L1)** |
 | **Backend author** (new OS/store) | `SecretBackend` + `BackendRegistry` + `Setup*` + capability/signing extension interfaces | served; stabilize `Setup*` (§2.3) |
 | **Redemption-endpoint consumer** (future, any language) | — | **no designed entry point.** The local redemption socket (env-epic §7) is the intended home; until it is specced, this persona has no surface. **Flag, do not improvise.** |
@@ -251,9 +320,12 @@ compatibility on surface we never deliberately chose.
 
 Two gates, one rule.
 
-- **Mechanical gate (exists):** the per-package `api-report/*.api.md` is regenerated and diff-checked in CI; a
-  surface change that does not update the committed report fails the build. This catches *that* the surface
-  changed.
+- **Mechanical gate (exists, growing):** the per-package `api-report/*.api.md` is regenerated and diff-checked
+  in CI; a surface change that does not update the committed report fails the build. This catches *that* the
+  surface changed. It grows to a **per-maturity-stage report** (`internal`/`alpha`/`beta`/`public`, §2.3) with
+  [@api-extractor-tools/change-detector](https://github.com/mike-north/api-extractor-tools/tree/main/tools/change-detector)
+  gating each stage's breaking-change rules — so the gate catches not just *that* the surface changed but
+  whether the change is *allowed* at that symbol's committed stability.
 - **Design gate (this spec):** §2.1–§2.4 (and Part 1 for the CLI) say *whether the change is well-formed*.
 - **The connecting rule (G-L):** a surface-changing PR updates **both** the api-report **and** this spec — the
   mechanical diff proves the change happened; the spec diff proves it was designed. A PR that moves one
@@ -304,10 +376,15 @@ help snapshots make every such change a reviewable diff that fails CI until deli
 
 - **Coverage:** `--help` for the top-level command and **every** subcommand, for both CLIs while the TS one
   lives (its retirement removes its snapshots, itself a reviewable diff).
+- **Typed surface, not just names (owner requirement).** The `--help` output — and therefore the snapshot —
+  **must render the value type / placeholder of every positional and flag** (e.g. `--ttl <SECONDS>`,
+  `PATH`, `--set <VAR=SECRET>`), not the bare flag name. The snapshot then pins the *typed* surface: a change
+  to an argument's expected type or placeholder is a surface change and shows up as a reviewable diff, exactly
+  like a rename.
 - **Host: dedicated golden files, not the conformance corpus.** The conformance corpus is behavior cases
   (argv/stdin → stdout/exit); help text is large multi-line rendered output better held as one golden file
   per command, mirroring the `docs/api/` generate-and-diff pattern. Layout:
-  `crates/vaultkeeper-cli/tests/help/<command-path>.txt` (e.g. `session-mint.txt`).
+  `crates/vaultkeeper-cli/tests/help/<command-path>.txt` (e.g. `lease-issue.txt`).
 - **Determinism (the real engineering point):** clap renders width-dependently and embeds the crate version.
   The regen and check **must** pin rendering: set a fixed terminal width (`COLUMNS`/clap `.term_width(80)`)
   and **normalize the version token** to a placeholder (`<VERSION>`) before writing/diffing, so a version bump
@@ -326,17 +403,18 @@ edits and ratifies each line.** Tensions are flagged **⚠ OWNER-DECIDES**, not 
 |---|---|---|---|
 | **vaultkeeper** | The product and the semantic core. | product name; `VaultKeeper` (the orchestrator class) | ⚠ OWNER-DECIDES: is bare **"vault"** a sanctioned noun for the product, or only in compounds (`vault key`)? And is **"keeper"** ever standalone? *Rec:* product = "vaultkeeper"; `VaultKeeper` = the type; "vault" only adjectivally. |
 | **secret** | The protected value at rest/in a backend. | `secret` (CLI noun, see B2); `materialize: "secret"`; `SecretBackend`, `SecretNotFoundError` | ⚠ OWNER-DECIDES: **secret vs value.** `store(name, value)` uses "value" for the raw string. *Rec:* "secret" is the domain noun; "value" only as the raw-string parameter. |
-| **lease** | A serialized, expiring, revocable capability presented back to the issuer to redeem. | `session` (CLI); `materialize: "lease"`; "session signing lease" | House term (env-epic rev 5). See mint/redeem/revoke. |
-| **token** | A wire-form credential (compact JWE) or the opaque in-process handle to authorized claims. | `--token` (CLI `exec`); `CapabilityToken` (the handle); "JWE token" | ⚠ OWNER-DECIDES: **token vs lease vs capability.** *Rec:* "token" = the JWE wire form + the opaque `CapabilityToken` handle; "lease" = the expiring/revocable capability as an issued artifact. A redeemed lease is *held as* a `CapabilityToken`. Consider whether `CapabilityToken` should read `LeaseHandle`. |
+| **lease** | A serialized, expiring, revocable capability presented back to the issuer to redeem. | `lease` (CLI namespace); `materialize: "lease"`; "signing lease"; `LeaseToken` (wire-form type, §3.3.1 r.7) | House term (env-epic rev 5), ratified §3.3.1 r.1. `session` retired (r.2). See issue/redeem/revoke. |
+| **token** | A wire-form credential (compact JWE) or the opaque in-process handle to authorized claims. | `--token` (CLI `run`); `LeaseToken` (né `CapabilityToken`, §3.3.1 r.7); "JWE token" | Resolved (§3.3.1 r.7): "token" = the JWE wire form; the lease's wire-form and in-process handle types are both `LeaseToken` (`CapabilityToken` renamed in the tiering batch). "lease" = the expiring/revocable capability as an issued artifact; a redeemed lease is *held as* a `LeaseToken`. |
 | **capability** | The abstract authority a token/lease confers; separately, a backend's advertised security feature. | `CapabilityToken`; `BackendCapabilities`, `backend capabilities` (CLI) | ⚠ OWNER-DECIDES: two senses (conferred authority vs backend feature-set) share the word. *Rec:* keep both, documented; they never co-occur ambiguously. |
 | **grant** | — | **BANNED as a vaultkeeper term** (retired for "lease", env-epic rev 5). | ⚠ OWNER-DECIDES the exception: "grant" is 1Password's own term for its Mach-port authorization (consolidation §2). *Rec:* allowed **only** when describing 1Password's external mechanism; never for a vaultkeeper artifact. Banned-terms lint (§3.4) encodes this scope. |
-| **mint / redeem / revoke** | The lease lifecycle verbs: create, present-to-use, kill. | `session mint`, `session redeem` (designed), `session revoke` | ⚠ OWNER-DECIDES: **mint vs issue vs create.** *Rec:* "mint" canonical (matches the minting-key term below). |
+| **issue / redeem / revoke** | The lease lifecycle verbs: issue (create), redeem (present back to the issuer for its accounted, at-most-once effect), revoke (kill). | `lease issue`, `lease redeem` (designed), `lease revoke` | Ratified §3.3.1 r.3 — `mint` replaced by `issue`; `redeem` names the effect at the issuer, not the gesture. |
 | **minting key** | The key that signs (mints) leases. | (no surface name yet) | ⚠ OWNER-DECIDES — **most ambiguous term.** Is the minting key the **vault key** (the AES/KeyManager key that seals leases) or a distinct signing key? *Rec:* define precisely before it reaches any surface; today the vault key both encrypts state and mints leases — if that stays, "minting key" = "vault key" and one term should win. |
 | **vault key** | The `KeyManager` key sealing key-state and lease JWEs. | internal; `rotate-key`, `revoke-key` (CLI) | See minting key. |
 | **signing key** | The Ed25519 key a signing lease authorizes use of (private half never leaves the backend). | `createSigningKey`, `authorizeSigningKey`, `SigningBackend`; `signingKey` (profile entry) | Distinct from vault key; keep separate. |
 | **presence** | A human-in-the-loop approval at the moment of an operation. | `--require-presence-per-use` (CLI, see B5); `PresenceOperation`, `PresenceCapableBackend`; `pres` claim | ⚠ OWNER-DECIDES: **presence vs `perApprovalAction`** (the assurance-claim field). *Rec:* "presence" is the user/product term; `perApprovalAction` is the assurance wire field — document them as the same concept at two layers. |
 | **backend** | A storage adapter for a specific OS/store. | `backend` (CLI noun); `SecretBackend`, `BackendRegistry` | Stable. |
-| **profile** | A named env-var binding set (var → source → materialization → policy). | `profile` (CLI noun); profile JSON | Stable. |
+| **profile** | The named, committable **policy contract** for a launched context (var → source → materialization → policy). | `profile` (CLI noun); profile YAML (`.json` accepted, §G9) | Ratified §3.3.1 r.8. Defines an environment; never the reverse. |
+| **environment** | The **resolved output** a profile produces at launch — the materialized var set. **Not** an artifact name. | (none — banned as an artifact name, §3.3.1 r.8) | "A profile defines an environment," one-directional. |
 | **entry** | One binding within a profile. | `--entry` (CLI); profile `entries` map | Stable. |
 | **materialize / materialization mode** | How an entry resolves: to a secret value or to a lease. | `materialize: "secret" \| "lease"` | Stable (env-epic rev 5). |
 | **rung** | A level of the adoption gradient (plaintext → resolved env → lease). | docs/product only | Internal framing term; ⚠ OWNER-DECIDES whether it appears in any user surface or stays product-doc-only. |
@@ -366,6 +444,34 @@ edits and ratifies each line.** Tensions are flagged **⚠ OWNER-DECIDES**, not 
    idiom collision). `--require-presence-per-use` unchanged.
 6. **Banned-terms additions** (§3.4 list): `mint`/`minting` and `session` banned from
    surface artifacts where lease vocabulary applies; `grant` ban stands.
+7. **`LeaseToken` — RATIFIED** as the name of the lease's **serialized wire-form** type
+   (consistent with the prior ruling that *token = the wire form*). The in-process handle
+   `CapabilityToken` **renames to `LeaseToken`** in the tiering batch (§2.3), so one name
+   spans the artifact's wire and handle forms and the retired "capability"-prefixed name goes
+   away. Until that batch lands, `CapabilityToken` is the deprecated spelling.
+8. **`profile` / `environment` — RATIFIED as a directional pair.** A **profile** is the named,
+   committable **policy contract** for a launched context (which secrets it draws, at what
+   trust, for how long). An **environment** is reserved for the **resolved output only** — the
+   materialized var set a profile produces at launch. The relation is one-directional: *a
+   profile defines an environment*, **never** the reverse. "environment" is therefore **banned
+   as an artifact name** (no `environment` file, type, or CLI noun); it names only the resolved
+   result. Added to the §3.4 banned-terms list.
+
+#### 3.3.2 Vocabulary in use
+
+The ratified vocabulary, shown in ordinary sentences — the register docs and help text should match:
+
+> Store your GitHub token as a secret once; from then on, run gives each tool a lease instead of the key.
+
+> A profile defines the environment a command launches with — which secrets it draws, at what trust, for how long.
+
+> At launch, vaultkeeper issued a signing lease under the vault key; the agent redeems it for each signature until it expires.
+
+> The lease had expired, so redemption was refused — launch again with presence to issue a new one.
+
+> lease revoke --key release-signer kills every outstanding lease under that key, instantly.
+
+> trust status ./deploy.sh reports whether trust is intact — the script still hashes to what you approved.
 
 ### 3.4 Vocabulary as lintable surface (SHOULD BE)
 
@@ -380,8 +486,9 @@ A `check:vocabulary` scan makes vocabulary drift fail CI the way surface drift d
   "grant", canonical = "lease", scope = "all", exception = "1[Pp]assword" }` encodes the §3.3 grant ruling.
 - **Failure = a named diff:** the check prints the artifact, line, banned term, and canonical replacement —
   the same reviewable-diff experience as the surface gates. New banned terms are added by the owner as
-  vocabulary decisions land (e.g. if `CapabilityToken` → `LeaseHandle` is ratified, `CapabilityToken` becomes
-  a deprecated term with a migration window).
+  vocabulary decisions land: the ratified `CapabilityToken` → `LeaseToken` rename (§3.3.1 r.7) makes
+  `CapabilityToken` a deprecated term with a migration window, and `environment` is banned as an *artifact*
+  name (§3.3.1 r.8) — flagged wherever it appears as a file/type/CLI-noun rather than the resolved output.
 
 ### 3.5 The overarching surface-artifact gate (NORMATIVE)
 
@@ -424,5 +531,5 @@ divergences with a disposition the owner approves, defers, or vetoes line by lin
 the glossary (§3.3) are vocabulary tensions surfaced for the owner to rule on, each with a recommendation he
 may accept or overturn — this is the artifact the amendment most wants him to author. **S\*** items (§3.6) are
 enforcement/glossary work, mechanical gates separated from owner-in-the-loop ratification. In-review CLI rows
-(`run`, `session redeem`) are proposals; they must satisfy the grammar *before* landing, which is the point of
+(`run`, `lease redeem`) are proposals; they must satisfy the grammar *before* landing, which is the point of
 reviewing them here rather than after.

--- a/docs/specs/001-surface-governance.md
+++ b/docs/specs/001-surface-governance.md
@@ -1,0 +1,360 @@
+# Specification: CLI & Library Surface Governance
+
+Status: draft for review · Applies to: `vaultkeeper-cli`, `@vaultkeeper/cli`, `vaultkeeper` (TS lib),
+`@vaultkeeper/wasm`, `vaultkeeper-core` · Authority: this document is the **design gate** for the programmatic
+integration surfaces. Feature work conforms to it; a surface change that is not also a diff to this spec is a
+review failure (§1.4, §2.5).
+
+Grounded in code read from `origin/main` @ `87c615f`: `crates/vaultkeeper-cli/src/main.rs` (clap definitions,
+authoritative for the CLI), `packages/vaultkeeper/api-report/vaultkeeper.api.md` and `src/index.ts` (library).
+Three registers are kept distinct throughout: **IS** (current inventory), **SHOULD BE** (normative rule),
+**BROKEN** (a divergence, §1.3).
+
+---
+
+## Part 1 — CLI Surface
+
+### 1.1 Command tree (normative inventory)
+
+Landed on `origin/main`. `stdin`/`stdout`/`stderr` columns state the contract; `exit` is the success/typed
+range. "Secrets" = does a secret value transit this command, and by what channel.
+
+| Command | Positional | Flags | stdin | stdout | Secrets | exit |
+|---|---|---|---|---|---|---|
+| `exec` | `COMMAND…` (trailing) | `--token <jwe>` | inherited by child | child's | value → child env (`VAULTKEEPER_SECRET`) | child's code |
+| `store` | — | `--name <n>`, `--require-presence-per-use` | **secret value** | status line | value ← stdin | 0 / 1 |
+| `delete` | — | `--name <n>`, `--require-presence-per-use` | — | status line | — | 0 / 1 |
+| `doctor` | — | — | — | check report | — | 0 ready / 1 not |
+| `approve` | — | `--path <p>` | — | confirmation | — | 0 / 1 |
+| `dev-mode` | — | `--path <p>`, `--enable` | — | confirmation | — | 0 / 1 |
+| `rotate-key` | — | — | — | confirmation | — | 0 / 1 |
+| `revoke-key` | — | — | — | confirmation | — | 0 / 1 |
+| `config init` | — | — | — | confirmation | — | 0 / 1 |
+| `config show` | — | — | — | config text | — | 0 / 1 |
+| `backend capabilities` | — | `--json` | — | text \| JSON array | — | 0 / 1 |
+| `profile init` | `NAME` | `--profile-file <p>` | — | confirmation | — | 0 / 1 |
+| `profile show` | `NAME?` | `--profile-file <p>` | — | shape+policy text | never prints values | 0 / 1 |
+| `profile list` | — | — | — | name list | — | 0 / 1 |
+| `profile lint` | `NAME?` | `--profile-file <p>` | — | warnings | never prints values | **always 0** (advisory) |
+| `session mint` | `PROFILE` | `--entry <e>` | — | **JWE lease → stdout** | lease (capability, not secret) | 0 / 1 |
+| `session revoke` | — | `--jti <j>` \| `--key <k>` (xor) | — | confirmation | — | 0 / 1 |
+
+**In review / designed, not landed** (env-epic-spec.md §4, lease lane #298–#300) — rows tracked here so the
+grammar review covers them before they land:
+
+| Command | Positional | Flags | Notes |
+|---|---|---|---|
+| `run` | `COMMAND…` (trailing) | `--profile <n>`, `--profile-file <p>`, `--set <VAR=SECRET>`, `--dry-run`, `--require-presence` | stdio/signal transparent; stdout is the child's alone; **in review** |
+| `session redeem` (shape TBD) | — | lease presenter | lease redemption over the #268 handle table; **designed, unscheduled** |
+
+### 1.2 Design grammar (SHOULD BE)
+
+**G1 — Noun-verb for resource families; bare verb for whole-vault process actions.** A command earns a
+**noun namespace** (`<noun> <verb>`) when it manages a *category of addressable resources* with more than one
+operation: `config`, `backend`, `profile`, `session`. A command is a **bare top-level verb** when it is a
+single process action against the vault as a whole with no sibling operations on a shared resource: `exec`,
+`run`, `doctor`, `approve`, `dev-mode`.
+
+**G2 — The primary subject is positional; modifiers are flags.** A command's required primary subject — the
+resource it acts on — is a **positional argument**. Options, policy toggles, and alternate sources are
+**flags**. `profile show NAME`, `session mint PROFILE`, `approve --path` (see BROKEN-4). A secret value is
+**never** a positional or a flag value (G6).
+
+**G3 — Flag naming is a stable vocabulary.** A concept has exactly one flag spelling across the whole surface.
+`--profile-file` for the explicit-path override, `--json` for machine output, `--profile`/`--entry` for
+profile addressing. The presence family is **one** name (see BROKEN-5).
+
+**G4 — stdout is data; stderr is diagnostics.** stdout carries *only* the command's payload — a JWE
+(`session mint`), a JSON value (`--json`), a name list, or the child's own stream (`exec`/`run`). Every
+human-facing message — progress, warnings, the file-only degradation notice, errors — goes to **stderr**.
+This is the #279 rule generalized to the whole surface, and it is what makes every data-producing command
+pipeable. `--dry-run` and human-report commands print their report to stdout (there is no child to protect),
+but a command that emits a machine artifact must never interleave diagnostics into it.
+
+**G5 — `--json` is opt-in and total.** Absent, output is human text. Present, stdout is a **single JSON
+value** and nothing else. `--json` is the only machine-output switch; no command invents a second one.
+
+**G6 — Secrets never appear in argv.** A CLI-surface invariant, not a per-command choice. A secret value
+enters only via **stdin** (`store`) and leaves only via **stdout** (`session mint` prints a lease, `exec`
+injects into a child's environment). No command accepts a secret as a positional or flag value; `--set
+VAR=SECRET` on `run` is the one deliberate exception and is documented as such, marked UNREVIEWED in
+`--dry-run`. (Backend implementations honor the same rule downstream, e.g. keychain `store` via `security
+-i` stdin.)
+
+**G7 — Exit-code taxonomy.** `0` success; `1` a typed operational failure (the `VaultError` surface, §2.1);
+`2` reserved for clap usage errors; `exec`/`run` **propagate the child's exit code**, and a signal-terminated
+child yields `128+N`. Advisory commands that cannot "fail" (`profile lint`) exit `0` on any successfully
+loaded input and signal concerns only through stderr warnings — this is deliberate and normative, not a bug.
+
+### 1.3 Inconsistencies (BROKEN) — the review surface
+
+Each row is a concrete divergence from §1.2 with a recommended disposition. **fix-now** = correct before the
+1.0 surface freeze; **legacy** = keep, document, and gate behind the deprecation path; **leave** = conforms
+on reflection, recorded to close the question.
+
+| # | Location | Violates | Divergence | Disposition |
+|---|---|---|---|---|
+| B1 | `store --name`, `delete --name` | G2 | The primary subject (the secret name) is a **flag**, while `profile`/`session` make the subject positional. | **fix-now**: `store NAME` / `delete NAME` positional; keep `--name` as a hidden deprecated alias for one minor. |
+| B2 | `store`, `delete`, `rotate-key`, `revoke-key` as bare verbs | G1 | These act on addressable resource categories (secrets; keys) but are top-level verbs. `store`/`delete`/(future `list`) are the CRUD of a `secret` noun; `rotate-key`/`revoke-key` are `key rotate`/`key revoke`. | **decide**: either promote to `secret <verb>` / `key <verb>` (grammar-pure, my lean) or record a documented exception for the highest-frequency verbs. Owner call — this is the single biggest grammar question. |
+| B3 | `dev-mode --enable` (a boolean subject-mode) | G2 | An enable/disable *mode* is a bare boolean flag; the natural shape is `dev-mode enable PATH` / `dev-mode disable PATH` or `dev-mode set --path --on/--off`. | **fix-now** or **legacy**: low traffic; align to `key`/`secret` decision in B2. |
+| B4 | `approve --path`, `dev-mode --path` | G2 | The path *is* the primary subject and should be positional (`approve PATH`), matching `profile show NAME`. | **fix-now**: positional `PATH`; `--path` deprecated alias. |
+| B5 | `store`/`delete` `--require-presence-per-use` vs `run` `--require-presence` | G3 | Two spellings for the presence family. | **fix-now**: pick one before `run` lands. Recommend `--require-presence-per-use` (precise; "presence" alone is ambiguous about scope) across all commands, or a shared `--require-presence[=per-use]`. Resolve **before** #279 merges so `run` ships correct. |
+| B6 | `session mint PROFILE --entry E` vs `profile show NAME` | G2 | Reviewed in #328: `mint` takes the profile positionally (consistent) but the *entry* — arguably a co-primary subject — is a flag. | **leave** (documented): the profile is the addressed resource; the entry is a selector within it, legitimately a flag. Recorded so the #328 question is closed, not reopened. |
+| B7 | `backend capabilities` is the only `backend` verb | G1 | A noun namespace with a single verb is defensible only if more verbs are foreseen. | **leave**: `backend list`/`backend test` are natural future siblings; the namespace is intentional headroom, not premature. |
+| B8 | `config`/`backend`/`profile` support `--json` unevenly | G5 | `backend capabilities` has `--json`; `config show`, `profile show/list` do not. | **fix-now (additive)**: any command whose output a script would consume gets `--json`. Audit `config show`, `profile show`, `profile list`, `doctor`. |
+
+### 1.4 Evolution policy (SHOULD BE)
+
+- **E1 — Spec-diff-in-PR.** A PR that adds, removes, or changes a command/subcommand/flag/exit-code **must**
+  edit §1.1 and, if it bends a rule, §1.3 in the same PR. A surface change without a spec diff is an
+  automatic review block. This is what makes drift visible as a reviewable diff rather than an archaeological
+  finding.
+- **E2 — Deprecation path.** A removed or renamed flag/command survives one minor release as a hidden alias
+  emitting a stderr deprecation notice (never on stdout — G4), then is removed at the next minor. Renames land
+  the new spelling and the alias together.
+- **E3 — Cross-implementation enforcement.** The native and TS CLIs are one surface; `crates/vaultkeeper-
+  conformance` is the mechanical proof of it. Every new command lands with conformance cases so the two CLIs
+  cannot diverge — the surface is enforced by test, not by discipline.
+
+---
+
+## Part 2 — Library Surface
+
+### 2.1 Organizing principles (SHOULD BE, normative)
+
+- **L1 — Everything through `index.ts`.** The public API is exactly the re-exports of `src/index.ts`; a
+  symbol not re-exported is not public regardless of file visibility. API Extractor's report is the mechanical
+  witness (§2.5).
+- **L2 — Capability-token opacity.** A `CapabilityToken` exposes no readable secret: the secret is reachable
+  only through a one-time `SecretAccessor.read()`, a signing key never egresses (sign happens backend-side),
+  and passing the wrong token kind to `getSecret`/`sign` is a typed refusal. This opacity is a load-bearing
+  security property, not an ergonomic detail — no future API may add a token accessor that returns claims.
+- **L3 — Typed failures only.** Every thrown error is a subclass of `VaultError`. Plain `Error` is never
+  thrown across the public boundary; new failure modes add a `VaultError` subclass, exported from `index.ts`.
+- **L4 — Minimal runtime dependency.** The `vaultkeeper` TS library's only runtime dependency is `jose`;
+  `@vaultkeeper/wasm` has none. New runtime deps require explicit owner approval (recorded in CLAUDE.md).
+- **L5 — Wire and type discipline.** Config/claim JSON is camelCase; public option shapes are
+  `exactOptionalPropertyTypes`-safe (no `undefined`-assignable optionals); no `as` casts in the surface.
+
+### 2.2 The surface by concept (IS)
+
+The 88 `@public` symbols group into coherent concepts. The owner reviews whether each grouping is complete and
+whether membership is intentional.
+
+- **Entry & lifecycle:** `VaultKeeper` (the façade class), `VaultKeeper.init`, `VaultKeeperOptions`,
+  `VaultResponse`.
+- **Setup / identity / trust:** `setup`, `SetupOptions` (a discriminated union enforcing exactly one of
+  `executablePath`/`skipTrust` — a craft high point, keep as the pattern), `SetupOptionsBase`,
+  `approveExecutable`, `checkExecutableTrust`, `setDevelopmentMode`, `ExecutableTrustStatus`,
+  `ExecutableTrustRequiredError`, `IdentityMismatchError`.
+- **Secrets & access tokens:** `store`, `delete`, `secretExists`, `authorize`, `getSecret`, `CapabilityToken`,
+  `SecretAccessor`, `SecretTokenMap`, `AccessorConsumedError`, `SecretNotFoundError`.
+- **Delegated access patterns:** `fetch`, `exec`, `FetchRequest`, `ExecRequest`, `ExecResult`,
+  `redactSecrets`, `REDACTED`, `FetchError`, `ExecError`.
+- **Signing & leases:** `createSigningKey`, `authorizeSigningKey`, `sign`, `exportPublicKey`,
+  `VaultKeeper.verify`, `SigningAlgorithm`, `SigningPublicKey`, `SignRequest`, `SignResult`, `VerifyRequest`,
+  `SigningBackend`, `isSigningBackend`, and the signing error family.
+- **Backends & registry:** `SecretBackend`, `ListableBackend`, `PresenceCapableBackend`, `BackendRegistry`,
+  `BackendConfig`, `BackendFactory`, `BackendSetupFactory`, `BackendCapabilities`, `getBackendCapabilities`,
+  `isListableBackend`, `isPresenceCapableBackend`, `defaultBackendType`, `platformNativeBackendType`,
+  `PresenceOperation`, `PresenceRequirementOptions`, the `Setup*` interactive types (`SetupQuestion`,
+  `SetupChoice`, `SetupResult`).
+- **Config & platform:** `VaultConfig`, `loadConfig`, `getDefaultConfigDir`, `getPlatformDefaultConfigDir`,
+  `TrustTier`, `KeyStatus`, `Platform`.
+- **Doctor:** `runDoctor` / `VaultKeeper.doctor`, `RunDoctorOptions`, `PreflightResult`, `PreflightCheck`,
+  `ScopedPreflightCheck`, `PreflightCheckError`, `PreflightCheckErrorKind`, `PreflightCheckStatus`.
+- **Error hierarchy:** `VaultError` plus ~30 subclasses — the sole failure surface (L3).
+
+**Completeness gap (BROKEN-L1):** there is **no profile / resolution surface in the TS library** — profile
+schema and `resolve_profile` live in `vaultkeeper-core` (and are reaching the CLI), but the embedding library
+persona (§2.4) has no typed entry point to load a profile or materialize a resolved environment. Under
+single-core consolidation (#234) this should surface as a host-layer API over the core. **Flag: design it,
+don't let it arrive by accretion when a consumer files for it.**
+
+### 2.3 Stability tiers (BROKEN — the accretion finding)
+
+**IS: 88 `@public`, 0 `@beta`, 0 `@alpha`.** The entire surface is committed-stable by default. That is
+accretion, not craft: a symbol is `@public` because it was exported, not because it was chosen for a 1.0
+compatibility promise. **SHOULD BE:**
+
+- `@public` — a 1.0 compatibility commitment; breaking it is a major-version event.
+- `@beta` — intended-public, shape may still change before promotion; opt-in acknowledged.
+- `@alpha` / `@internal` — not for external use; may change or vanish any release.
+- **Promotion policy:** `@alpha → @beta → @public` only by an explicit PR that names the symbol and updates
+  this spec; nothing reaches `@public` by default.
+
+**Named craft-vs-accretion judgment calls (owner adjudicates):**
+
+| Symbol(s) | Question | Recommendation |
+|---|---|---|
+| `BackendRegistry` (`@internal` methods visible in the class) | The class is `@public` but carries `@internal` members — a leaky boundary. | Split the public construction/registration API from internal dispatch; keep only the former `@public`. |
+| `Setup*` interactive types (`SetupQuestion`/`Choice`/`Result`, `BackendSetupFactory`) | Public because interactive backend setup needed them — a real but *unstable* extension surface. | `@beta` until the plugin-backend setup flow is 1.0-frozen. |
+| `is*Backend` type guards | Public convenience or committed contract? | `@public` — they are the sanctioned way to narrow a `SecretBackend`; keep, document. |
+| `TestDoubleMisuseError` | A test-shaped error in the main library surface. | Verify it is thrown by production paths; if only by test doubles, move to `@vaultkeeper/test-helpers`. |
+| `redactSecrets` / `REDACTED` | Internal helper or public utility? | `@public` — useful to embedders scrubbing their own logs; keep. |
+
+The tiering pass is a **pre-1.0 gate**: freezing 88 symbols as `@public` without this review commits us to
+compatibility on surface we never deliberately chose.
+
+### 2.4 Integration personas (SHOULD BE)
+
+| Persona (product brief) | Primary surface | Status |
+|---|---|---|
+| **Tool user** (unmodified tool via CLI) | Part 1 — `run`/`exec`/`store`/`profile` | served (pending `run`) |
+| **Library / tool author** (embeds vaultkeeper) | `VaultKeeper` façade + access patterns + `SecretBackend` for a custom store | served for secrets/signing; **gap: profile resolution (§2.2 BROKEN-L1)** |
+| **Backend author** (new OS/store) | `SecretBackend` + `BackendRegistry` + `Setup*` + capability/signing extension interfaces | served; stabilize `Setup*` (§2.3) |
+| **Redemption-endpoint consumer** (future, any language) | — | **no designed entry point.** The local redemption socket (env-epic §7) is the intended home; until it is specced, this persona has no surface. **Flag, do not improvise.** |
+
+### 2.5 Governance loop (SHOULD BE)
+
+Two gates, one rule.
+
+- **Mechanical gate (exists):** the per-package `api-report/*.api.md` is regenerated and diff-checked in CI; a
+  surface change that does not update the committed report fails the build. This catches *that* the surface
+  changed.
+- **Design gate (this spec):** §2.1–§2.4 (and Part 1 for the CLI) say *whether the change is well-formed*.
+- **The connecting rule (G-L):** a surface-changing PR updates **both** the api-report **and** this spec — the
+  mechanical diff proves the change happened; the spec diff proves it was designed. A PR that moves one
+  without the other fails review. This is the same E1 discipline as the CLI, applied to the library, and it is
+  what turns "the surface evolved organically" into "every surface change is a reviewed design decision."
+
+Part 3 completes the committed-artifact set this rule operates on (the Rust API listing and the help
+snapshots), adds the vocabulary dimension, and states the single overarching gate (§3.5) that generalizes this
+loop across every surface artifact.
+
+---
+
+## Part 3 — Enforcement artifacts & vocabulary governance
+
+The gates in §1.4/§2.5 rest on **committed surface artifacts** whose diffs make change visible. Part 3
+completes that artifact set (Rust API, help text), adds the product **glossary** the owner authors, and states
+the overarching rule that binds them.
+
+### 3.1 Rust public-API snapshot (SHOULD BE)
+
+The `api-report/*.api.md` gate covers only the TypeScript packages. The Rust core has no equivalent, so
+`vaultkeeper-core`'s public surface can drift silently — unacceptable under single-core consolidation (#234),
+where the core *is* the surface every host re-exposes.
+
+- **Tool: `cargo public-api`.** Evaluated against `cargo-semver-checks`: the latter is a *breaking-change
+  lint* (it explains why a change is semver-major) but does **not** emit a committed, reviewable listing;
+  `cargo public-api` produces exactly the "list the public API to a text file, diff it in CI, update via an
+  env var" workflow that mirrors `check:api-report`. **Pick `cargo public-api`** as the snapshot gate;
+  `cargo-semver-checks` is an optional *later* addition as a semver guard, not a substitute.
+- **Scope:** `vaultkeeper-core` (mandatory — the consolidation surface). `vaultkeeper-cli` has no library
+  surface to snapshot (it is a binary; its surface is the CLI, Part 1). The **wasm crate's exported bindings**
+  are already partly covered by the existing wasm-export-fingerprint script (env-epic/consolidation context) —
+  **integrate, do not duplicate**: the fingerprint script asserts the *set* of wasm exports; the
+  `@vaultkeeper/wasm` `api-report` covers the *TS* shape; `cargo public-api` need only cover the native Rust
+  crate. State this three-way split in the spec so no one adds a redundant fourth check.
+- **Artifact + script:** a committed `crates/vaultkeeper-core/public-api.txt`; `pnpm check:rust-api`
+  regenerates into a temp file and diffs (CI-enforced, exactly like `check:api-report`); `pnpm
+  generate:rust-api` updates the committed file.
+- **Operational cost, stated honestly:** `cargo public-api` builds rustdoc JSON, which requires a **pinned
+  nightly toolchain**. Pin it in a toolchain file (the repo already pins the wasm toolchain — same pattern,
+  precedent exists), so the snapshot is deterministic and a nightly bump is a deliberate, reviewed event.
+
+### 3.2 CLI help-text snapshots (SHOULD BE)
+
+`--help` output is the CLI's *rendered* surface — the wording a user reads. A flag rename, a description
+edit, or a reordered subcommand is invisible to the api-report gates but is a real surface change. Golden
+help snapshots make every such change a reviewable diff that fails CI until deliberately regenerated.
+
+- **Coverage:** `--help` for the top-level command and **every** subcommand, for both CLIs while the TS one
+  lives (its retirement removes its snapshots, itself a reviewable diff).
+- **Host: dedicated golden files, not the conformance corpus.** The conformance corpus is behavior cases
+  (argv/stdin → stdout/exit); help text is large multi-line rendered output better held as one golden file
+  per command, mirroring the `docs/api/` generate-and-diff pattern. Layout:
+  `crates/vaultkeeper-cli/tests/help/<command-path>.txt` (e.g. `session-mint.txt`).
+- **Determinism (the real engineering point):** clap renders width-dependently and embeds the crate version.
+  The regen and check **must** pin rendering: set a fixed terminal width (`COLUMNS`/clap `.term_width(80)`)
+  and **normalize the version token** to a placeholder (`<VERSION>`) before writing/diffing, so a version bump
+  or a CI terminal-width difference does not spuriously fail the gate. Without this the snapshots flap and get
+  disabled — specify it or the gate rots.
+- **Script:** `pnpm generate:cli-help` writes the goldens; `pnpm check:cli-help` regenerates to temp and
+  diffs. CI-enforced.
+
+### 3.3 Product glossary (NORMATIVE — owner-authored)
+
+The canonical vocabulary. Each term has a one-line definition and its **sanctioned surface names** (CLI nouns,
+API type names, claim fields). Drafted here from the de-facto usage in code and the frozen specs; **the owner
+edits and ratifies each line.** Tensions are flagged **⚠ OWNER-DECIDES**, not resolved silently.
+
+| Term | Definition | Sanctioned surface names | Notes / tension |
+|---|---|---|---|
+| **vaultkeeper** | The product and the semantic core. | product name; `VaultKeeper` (the orchestrator class) | ⚠ OWNER-DECIDES: is bare **"vault"** a sanctioned noun for the product, or only in compounds (`vault key`)? And is **"keeper"** ever standalone? *Rec:* product = "vaultkeeper"; `VaultKeeper` = the type; "vault" only adjectivally. |
+| **secret** | The protected value at rest/in a backend. | `secret` (CLI noun, see B2); `materialize: "secret"`; `SecretBackend`, `SecretNotFoundError` | ⚠ OWNER-DECIDES: **secret vs value.** `store(name, value)` uses "value" for the raw string. *Rec:* "secret" is the domain noun; "value" only as the raw-string parameter. |
+| **lease** | A serialized, expiring, revocable capability presented back to the issuer to redeem. | `session` (CLI); `materialize: "lease"`; "session signing lease" | House term (env-epic rev 5). See mint/redeem/revoke. |
+| **token** | A wire-form credential (compact JWE) or the opaque in-process handle to authorized claims. | `--token` (CLI `exec`); `CapabilityToken` (the handle); "JWE token" | ⚠ OWNER-DECIDES: **token vs lease vs capability.** *Rec:* "token" = the JWE wire form + the opaque `CapabilityToken` handle; "lease" = the expiring/revocable capability as an issued artifact. A redeemed lease is *held as* a `CapabilityToken`. Consider whether `CapabilityToken` should read `LeaseHandle`. |
+| **capability** | The abstract authority a token/lease confers; separately, a backend's advertised security feature. | `CapabilityToken`; `BackendCapabilities`, `backend capabilities` (CLI) | ⚠ OWNER-DECIDES: two senses (conferred authority vs backend feature-set) share the word. *Rec:* keep both, documented; they never co-occur ambiguously. |
+| **grant** | — | **BANNED as a vaultkeeper term** (retired for "lease", env-epic rev 5). | ⚠ OWNER-DECIDES the exception: "grant" is 1Password's own term for its Mach-port authorization (consolidation §2). *Rec:* allowed **only** when describing 1Password's external mechanism; never for a vaultkeeper artifact. Banned-terms lint (§3.4) encodes this scope. |
+| **mint / redeem / revoke** | The lease lifecycle verbs: create, present-to-use, kill. | `session mint`, `session redeem` (designed), `session revoke` | ⚠ OWNER-DECIDES: **mint vs issue vs create.** *Rec:* "mint" canonical (matches the minting-key term below). |
+| **minting key** | The key that signs (mints) leases. | (no surface name yet) | ⚠ OWNER-DECIDES — **most ambiguous term.** Is the minting key the **vault key** (the AES/KeyManager key that seals leases) or a distinct signing key? *Rec:* define precisely before it reaches any surface; today the vault key both encrypts state and mints leases — if that stays, "minting key" = "vault key" and one term should win. |
+| **vault key** | The `KeyManager` key sealing key-state and lease JWEs. | internal; `rotate-key`, `revoke-key` (CLI) | See minting key. |
+| **signing key** | The Ed25519 key a signing lease authorizes use of (private half never leaves the backend). | `createSigningKey`, `authorizeSigningKey`, `SigningBackend`; `signingKey` (profile entry) | Distinct from vault key; keep separate. |
+| **presence** | A human-in-the-loop approval at the moment of an operation. | `--require-presence-per-use` (CLI, see B5); `PresenceOperation`, `PresenceCapableBackend`; `pres` claim | ⚠ OWNER-DECIDES: **presence vs `perApprovalAction`** (the assurance-claim field). *Rec:* "presence" is the user/product term; `perApprovalAction` is the assurance wire field — document them as the same concept at two layers. |
+| **backend** | A storage adapter for a specific OS/store. | `backend` (CLI noun); `SecretBackend`, `BackendRegistry` | Stable. |
+| **profile** | A named env-var binding set (var → source → materialization → policy). | `profile` (CLI noun); profile JSON | Stable. |
+| **entry** | One binding within a profile. | `--entry` (CLI); profile `entries` map | Stable. |
+| **materialize / materialization mode** | How an entry resolves: to a secret value or to a lease. | `materialize: "secret" \| "lease"` | Stable (env-epic rev 5). |
+| **rung** | A level of the adoption gradient (plaintext → resolved env → lease). | docs/product only | Internal framing term; ⚠ OWNER-DECIDES whether it appears in any user surface or stays product-doc-only. |
+
+### 3.4 Vocabulary as lintable surface (SHOULD BE)
+
+A `check:vocabulary` scan makes vocabulary drift fail CI the way surface drift does.
+
+- **Scope: the committed surface artifacts only** — `api-report/*.api.md`, the §3.1 Rust API listing, and the
+  §3.2 help snapshots. **Not** arbitrary source or comments (too noisy; the goal is *surface* vocabulary, and
+  the surface artifacts are exactly the reviewed, canonical text). This keeps the check precise and its
+  failures meaningful.
+- **Banned-terms list — lives beside the glossary** (`docs/specs/vocabulary.banned.toml`), one row per rule:
+  `{ term, canonical, scope: "all" | <artifact-glob>, exception?: <regex/context> }`. Example: `{ term =
+  "grant", canonical = "lease", scope = "all", exception = "1[Pp]assword" }` encodes the §3.3 grant ruling.
+- **Failure = a named diff:** the check prints the artifact, line, banned term, and canonical replacement —
+  the same reviewable-diff experience as the surface gates. New banned terms are added by the owner as
+  vocabulary decisions land (e.g. if `CapabilityToken` → `LeaseHandle` is ratified, `CapabilityToken` becomes
+  a deprecated term with a migration window).
+
+### 3.5 The overarching surface-artifact gate (NORMATIVE)
+
+**Any PR whose diff touches a committed surface artifact — `api-report/*.api.md`, the Rust public-API listing,
+or a help snapshot — is *by definition* a surface change.** It therefore:
+
+1. **requires the corresponding spec section and/or glossary updated in the same PR** (Part 1 for a CLI
+   change, Part 2 for a library change, §3.3 for a vocabulary change), and
+2. **carries explicit owner-level review scrutiny** — a surface change is a design decision, reviewed as one.
+
+The snapshots make a surface change **impossible to do invisibly**; this rule makes it **impossible to do
+accidentally**. Together they are the whole governance intent: the surface evolves only by deliberate,
+reviewed, spec-tracked decisions.
+
+### 3.6 Decomposition (enforcement + glossary)
+
+Mechanical enforcement items (mid-tier) are separated from owner-in-the-loop glossary authoring, per the
+different kind of work each is.
+
+| # | Item | Kind | Flag |
+|---|---|---|---|
+| S1 | `cargo public-api` snapshot for `vaultkeeper-core` + `check:rust-api`/`generate:rust-api` + pinned nightly toolchain file; wire into CI beside `check:api-report` | mechanical | [M] |
+| S2 | CLI `--help` golden snapshots (both CLIs) + `check:cli-help`/`generate:cli-help` with pinned width + version normalization | mechanical | [M] |
+| S3 | `check:vocabulary` lint + `vocabulary.banned.toml` format, scoped to the surface artifacts (S1/S2 outputs + api-reports) | mechanical | [M] |
+| S4 | **Glossary authoring & ratification (§3.3)** — owner resolves each ⚠ OWNER-DECIDES tension; seeds the banned-terms list from the rulings | owner-in-the-loop | [S] |
+| S5 | Wire the §3.5 gate into the PR-review checklist / CODEOWNERS so a surface-artifact diff routes to owner review | mechanical | [M] |
+
+**Sequencing:** S1/S2 are independent and can land first (they only add gates, break nothing). S3 depends on
+S1/S2 existing (it scans their outputs) and on **S4** for its initial banned list — so S3 lands its
+*mechanism* early but its *rules* follow the owner's glossary rulings. S4 gates the vocabulary decisions the
+whole of §3.3/§3.4 encodes and is the item the owner most wants to own.
+
+---
+
+## Appendix — register key
+
+**IS** rows/tables are inventory from `origin/main` @ `87c615f`. **SHOULD BE** items (`G*`, `L*`, `E*`, and
+Part 3's rules) are normative rules feature work must satisfy. **BROKEN** rows (`B*`, `BROKEN-L*`) are current
+divergences with a disposition the owner approves, defers, or vetoes line by line. **⚠ OWNER-DECIDES** rows in
+the glossary (§3.3) are vocabulary tensions surfaced for the owner to rule on, each with a recommendation he
+may accept or overturn — this is the artifact the amendment most wants him to author. **S\*** items (§3.6) are
+enforcement/glossary work, mechanical gates separated from owner-in-the-loop ratification. In-review CLI rows
+(`run`, `session redeem`) are proposals; they must satisfy the grammar *before* landing, which is the point of
+reviewing them here rather than after.

--- a/docs/specs/001-surface-governance.md
+++ b/docs/specs/001-surface-governance.md
@@ -23,13 +23,14 @@ surface change.
 | Command | Purpose |
 |---|---|
 | `exec` *(deprecated → `run --token`)* | Legacy alias for single-token launching; folds into `run` and retires at 1.0 (B9). |
-| `store` | Save a secret into the active backend (value read from stdin — never from arguments). |
-| `delete` | Remove a secret from the active backend. |
+| `secret store` | Save a secret into the active backend (value read from stdin — never from arguments). *(was `store`, deprecated alias until 1.0)* |
+| `secret delete` | Remove a secret from the active backend. *(was `delete`)* |
 | `doctor` | Run preflight checks and report whether vaultkeeper is ready to use on this machine. |
-| `approve` | Pre-approve an executable by recording its hash in the trust manifest. |
-| `dev-mode` | Enable or disable relaxed identity verification for a script during development. |
-| `rotate-key` | Rotate the vault encryption key, re-sealing stored state under the new key. |
-| `revoke-key` | Emergency-revoke the vault encryption key, invalidating all outstanding tokens. |
+| `trust approve` | Trust an executable: record its hash in the trust manifest. *(was `approve`; PATH positional)* |
+| `trust dev-mode` | Enable or disable relaxed identity verification for a script during development. *(was `dev-mode`)* |
+| `trust check` *(designed)* | Report whether trust in an executable is intact right now — recomputed hash vs manifest, tier, dev-mode status; scriptable exit code. |
+| `key rotate` | Rotate the vault encryption key, re-sealing stored state under the new key. *(was `rotate-key`)* |
+| `key revoke` | Emergency-revoke the vault encryption key, invalidating all outstanding tokens. *(was `revoke-key`)* |
 | `config init` | Create a new configuration file with defaults. |
 | `config show` | Print the current effective configuration. |
 | `backend capabilities` | Report the active backend's security capabilities (e.g. per-use presence enforcement). |
@@ -123,9 +124,9 @@ on reflection, recorded to close the question.
 | # | Location | Violates | Divergence | Disposition |
 |---|---|---|---|---|
 | B1 | `store --name`, `delete --name` | G2 | The primary subject (the secret name) is a **flag**, while `profile`/`session` make the subject positional. | **fix-now**: `store NAME` / `delete NAME` positional; keep `--name` as a hidden deprecated alias for one minor. |
-| B2 | `store`, `delete`, `rotate-key`, `revoke-key` as bare verbs | G1 | These act on addressable resource categories (secrets; keys) but are top-level verbs. `store`/`delete`/(future `list`) are the CRUD of a `secret` noun; `rotate-key`/`revoke-key` are `key rotate`/`key revoke`. | **decide**: either promote to `secret <verb>` / `key <verb>` (grammar-pure, my lean) or record a documented exception for the highest-frequency verbs. Owner call — this is the single biggest grammar question. |
-| B3 | `dev-mode --enable` (a boolean subject-mode) | G2 | An enable/disable *mode* is a bare boolean flag; the natural shape is `dev-mode enable PATH` / `dev-mode disable PATH` or `dev-mode set --path --on/--off`. | **fix-now** or **legacy**: low traffic; align to `key`/`secret` decision in B2. |
-| B4 | `approve --path`, `dev-mode --path` | G2 | The path *is* the primary subject and should be positional (`approve PATH`), matching `profile show NAME`. | **fix-now**: positional `PATH`; `--path` deprecated alias. |
+| B2 | `store`, `delete`, `rotate-key`, `revoke-key` as bare verbs | G1 | These act on addressable resource categories (secrets; keys) but are top-level verbs. | **ADJUDICATED (owner)**: promote — `secret store NAME`, `secret delete NAME` (future `secret list`); `key rotate`, `key revoke` (future `key show`, `key generations`). Hyphenated/bare forms become deprecated aliases, removed at 1.0. |
+| B3 | `dev-mode` as a bare top-level verb with `--enable` | G1/G2 | Trust-manifest operation stranded outside any namespace. | **ADJUDICATED (owner)**: joins the `trust` namespace — `trust dev-mode PATH …` (exact enable/disable shape settled at implementation under G2/G3). Deprecated alias until 1.0. |
+| B4 | `approve --path` (and `dev-mode --path`) | G1/G2 | The subject is a flag, and the verb names the act without its noun: approving is a *trust* decision. `command`/`bin` rejected as the noun — "command" is already load-bearing (`run … -- COMMAND`) and "bin" misdescribes interpreted scripts. | **ADJUDICATED (owner)**: `trust approve PATH` (positional). The `trust` namespace matches the domain's own vocabulary (trust manifest, trust tiers) and gains designed future members: `trust check PATH` (recompute + compare now; `--json`; exit 0 intact / non-zero mismatch — a scriptable gate primitive and the first-class surface for TOFU-conflict reporting), `trust list`, `trust revoke PATH`. Deprecated aliases until 1.0. |
 | B5 | `store`/`delete` `--require-presence-per-use` vs `run` `--require-presence` | G3 | Two spellings for the presence family. | **fix-now**: pick one before `run` lands. Recommend `--require-presence-per-use` (precise; "presence" alone is ambiguous about scope) across all commands, or a shared `--require-presence[=per-use]`. Resolve **before** #279 merges so `run` ships correct. |
 | B6 | `session mint PROFILE --entry E` vs `profile show NAME` | G2 | Reviewed in #328: `mint` takes the profile positionally (consistent) but the *entry* — arguably a co-primary subject — is a flag. | **leave** (documented): the profile is the addressed resource; the entry is a selector within it, legitimately a flag. Recorded so the #328 question is closed, not reopened. |
 | B7 | `backend capabilities` is the only `backend` verb | G1 | A noun namespace with a single verb is defensible only if more verbs are foreseen. | **leave**: `backend list`/`backend test` are natural future siblings; the namespace is intentional headroom, not premature. |

--- a/docs/specs/001-surface-governance.md
+++ b/docs/specs/001-surface-governance.md
@@ -38,10 +38,10 @@ surface change.
 | `profile show` | Display a profile's entries and their policy — never secret values. |
 | `profile list` | List the available profiles. |
 | `profile lint` | Validate a profile and warn where its policy is looser than this machine's defaults (advisory). |
-| `session mint` | Mint a session signing lease for a profile entry, proving human presence at mint. |
-| `session revoke` | Revoke an outstanding lease by id, or every outstanding lease for a signing key. |
+| `lease issue` | Issue a signing lease for a profile entry, proving human presence at issuance. *(was `session mint`, deprecated alias until 1.0)* |
+| `lease revoke` | Revoke an outstanding lease by id, or every outstanding lease for a signing key. *(was `session revoke`)* |
 | `run` *(in review)* | Launch a command with one or more secrets available in its subshell — stdio- and signal-transparent. The source options (`--profile`, `--token`, `--set`) describe only *how many secrets and by what means they are populated*; the operation is one. (Owner-adjudicated: `run` is the single launcher verb.) |
-| `session redeem` *(designed)* | Redeem a signing lease into an in-process signing handle for non-interactive signing. |
+| `lease redeem` *(designed; library/core operation — CLI shape deliberately TBD)* | Redeem a signing lease into an in-process signing handle for non-interactive signing. *(né `session redeem`)* |
 
 ### 1.1 Command tree (normative inventory)
 
@@ -73,15 +73,15 @@ grammar review covers them before they land:
 
 | Command | Positional | Flags | Notes |
 |---|---|---|---|
-| `run` | `COMMAND…` (trailing) | `--profile <n>`, `--profile-file <p>`, `--set <VAR=SECRET>`, `--dry-run`, `--require-presence` | stdio/signal transparent; stdout is the child's alone; **in review** |
-| `session redeem` (shape TBD) | — | lease presenter | lease redemption over the #268 handle table; **designed, unscheduled** |
+| `run` | `COMMAND…` (trailing) | `--profile <n>`, `--profile-file <p>`, `--set <VAR=SECRET>`, `--dry-run`, `--require-presence-at-issuance` (per §3.3.1 r.5) | stdio/signal transparent; stdout is the child's alone; **in review** |
+| `lease redeem` (shape TBD) | — | lease presenter | lease redemption over the #268 handle table; **designed — library/core first, CLI surface TBD** |
 
 ### 1.2 Design grammar (SHOULD BE)
 
 **G1 — Noun-verb for resource families; bare verb for whole-vault process actions.** A command earns a
 **noun namespace** (`<noun> <verb>`) when it manages a *category of addressable resources* with more than one
-operation: `config`, `backend`, `profile`, `session`, and (post-B2/B3/B4 adjudication) `secret`, `key`,
-`trust`. A command is a **bare top-level verb** only when it is a single process action against the vault as
+operation: `config`, `backend`, `profile`, `lease` (né `session`, ruling §3.3.1), and (post-B2/B3/B4 adjudication)
+`secret`, `key`, `trust`. A command is a **bare top-level verb** only when it is a single process action against the vault as
 a whole with no sibling operations on a shared resource — after adjudication, exactly two qualify: `run`
 (the launcher) and `doctor` (the whole-machine check).
 
@@ -340,6 +340,32 @@ edits and ratifies each line.** Tensions are flagged **⚠ OWNER-DECIDES**, not 
 | **entry** | One binding within a profile. | `--entry` (CLI); profile `entries` map | Stable. |
 | **materialize / materialization mode** | How an entry resolves: to a secret value or to a lease. | `materialize: "secret" \| "lease"` | Stable (env-epic rev 5). |
 | **rung** | A level of the adoption gradient (plaintext → resolved env → lease). | docs/product only | Internal framing term; ⚠ OWNER-DECIDES whether it appears in any user surface or stays product-doc-only. |
+
+#### 3.3.1 Adjudicated rulings (owner, 2026-07-23) — supersede the ⚠ markers above where they overlap
+
+1. **`lease` — RATIFIED** as the artifact's name. Definition: *an encrypted, self-expiring,
+   issuer-revocable authorization that confers scoped use without possession, and has effect
+   only when redeemed back to the vault that issued it.* Rationale of record: self-expiry as
+   the inherent, default-safe property (CS lease prior art — DHCP, distributed-systems
+   leases), which no alternative (token/grant/ticket/pass/permit) carries intrinsically.
+   `capability` remains the *concept* one layer up; `lease` is the artifact.
+2. **`session` — RETIRED as a noun.** It named nothing in the system (no session object, id,
+   or state); every property it gestured at lives on the lease (`exp`, `pres`,
+   injected-at-launch). Docs may describe the launch-wrapper *pattern* in prose; no surface
+   name uses it. CLI namespace `session` → **`lease`**, deprecated aliases until 1.0.
+3. **Lease verb set — `issue` / `redeem` / `revoke`.** `mint` replaced by `issue`
+   (CLI: `lease issue`); `redeem` kept over "present" because it names the *effect at the
+   issuer* (accounted, at-most-once semantics), not the gesture; `revoke` unchanged
+   (`--jti` scalpel / `--key` guillotine).
+4. **`vault key` — RATIFIED as the single name** for the credential that seals stored state
+   and issues leases; **"minting key" retired** (it existed only to rhyme with the retired
+   verb, and was the glossary's flagged top ambiguity). "Issuing key" is likewise rejected —
+   one key, one name, and its role is self-explanatory in a project called vaultkeeper.
+5. **Presence-flag ripple (G3):** the scope-suffix family follows the verb change —
+   `--require-presence-at-issuance` (not `-at-mint`; "at-issue" rejected for the English
+   idiom collision). `--require-presence-per-use` unchanged.
+6. **Banned-terms additions** (§3.4 list): `mint`/`minting` and `session` banned from
+   surface artifacts where lease vocabulary applies; `grant` ban stands.
 
 ### 3.4 Vocabulary as lintable surface (SHOULD BE)
 

--- a/docs/specs/001-surface-governance.md
+++ b/docs/specs/001-surface-governance.md
@@ -22,7 +22,7 @@ surface change.
 
 | Command | Purpose |
 |---|---|
-| `exec` | Run a command with a single secret injected into its environment, by redeeming a capability token. |
+| `exec` *(deprecated → `run --token`)* | Legacy alias for single-token launching; folds into `run` and retires at 1.0 (B9). |
 | `store` | Save a secret into the active backend (value read from stdin — never from arguments). |
 | `delete` | Remove a secret from the active backend. |
 | `doctor` | Run preflight checks and report whether vaultkeeper is ready to use on this machine. |
@@ -39,7 +39,7 @@ surface change.
 | `profile lint` | Validate a profile and warn where its policy is looser than this machine's defaults (advisory). |
 | `session mint` | Mint a session signing lease for a profile entry, proving human presence at mint. |
 | `session revoke` | Revoke an outstanding lease by id, or every outstanding lease for a signing key. |
-| `run` *(in review)* | Resolve a profile and launch a command with that environment — stdio- and signal-transparent. |
+| `run` *(in review)* | Launch a command with one or more secrets available in its subshell — stdio- and signal-transparent. The source options (`--profile`, `--token`, `--set`) describe only *how many secrets and by what means they are populated*; the operation is one. (Owner-adjudicated: `run` is the single launcher verb.) |
 | `session redeem` *(designed)* | Redeem a signing lease into an in-process signing handle for non-interactive signing. |
 
 ### 1.1 Command tree (normative inventory)
@@ -130,6 +130,7 @@ on reflection, recorded to close the question.
 | B6 | `session mint PROFILE --entry E` vs `profile show NAME` | G2 | Reviewed in #328: `mint` takes the profile positionally (consistent) but the *entry* — arguably a co-primary subject — is a flag. | **leave** (documented): the profile is the addressed resource; the entry is a selector within it, legitimately a flag. Recorded so the #328 question is closed, not reopened. |
 | B7 | `backend capabilities` is the only `backend` verb | G1 | A noun namespace with a single verb is defensible only if more verbs are foreseen. | **leave**: `backend list`/`backend test` are natural future siblings; the namespace is intentional headroom, not premature. |
 | B8 | `config`/`backend`/`profile` support `--json` unevenly | G5 | `backend capabilities` has `--json`; `config show`, `profile show/list` do not. | **fix-now (additive)**: any command whose output a script would consume gets `--json`. Audit `config show`, `profile show`, `profile list`, `doctor`. |
+| B9 | `exec` vs `run` as separate launchers | G1 | Both launch a delegated command with secret(s) in its subshell; token-vs-profile is the *source*, not a different action — two verbs for one operation. | **fix-pre-1.0 (owner-adjudicated)**: `run` is the single launcher. `run --token <JWE> [--as VAR]` absorbs `exec` (`--as` defaults to `VAULTKEEPER_SECRET`); `exec` becomes a deprecated alias, removed at 1.0. Sequencing: land #279 as scoped (`--profile`), then fold `--token`/`--as` in as an immediate follow-up. One stdio-transparency contract lives in one command. |
 
 ### 1.4 Evolution policy (SHOULD BE)
 

--- a/docs/specs/001-surface-governance.md
+++ b/docs/specs/001-surface-governance.md
@@ -115,6 +115,17 @@ VAR=SECRET` on `run` is the one deliberate exception and is documented as such, 
 child yields `128+N`. Advisory commands that cannot "fail" (`profile lint`) exit `0` on any successfully
 loaded input and signal concerns only through stderr warnings — this is deliberate and normative, not a bug.
 
+**G8 — Analysis-verb vocabulary: `lint` judges what you wrote; `check` verifies what is** *(owner-adjudicated)*.
+`lint` is **advisory static analysis of an authored artifact** (a profile file): opinions about a document,
+never a verdict — and it always exits `0`, because its baseline (this machine's `config.json` defaults) is
+machine-relative, so gating on it would crown one machine's defaults as project authority. `check` is
+**pass/fail verification of live state against an objective baseline** (a recomputed hash vs the committed
+manifest): a machine-independent verdict with a meaningful exit code, safe for scripts and CI to gate on.
+The exit-code semantics *derive from the subject* — machine-relative baselines cannot gate; objective
+baselines must. `doctor` remains the bundled whole-machine check. New commands must pick the verb that
+matches their subject; near-synonyms (`validate`, `verify`, `audit`) are reserved — propose them through
+this spec, not ad hoc.
+
 ### 1.3 Inconsistencies (BROKEN) — the review surface
 
 Each row is a concrete divergence from §1.2 with a recommended disposition. **fix-now** = correct before the

--- a/docs/specs/001-surface-governance.md
+++ b/docs/specs/001-surface-governance.md
@@ -14,6 +14,34 @@ Three registers are kept distinct throughout: **IS** (current inventory), **SHOU
 
 ## Part 1 — CLI Surface
 
+### 1.0 Command purposes (normative one-liners)
+
+Each command's purpose, stated as the canonical one-liner — these are also the first line of
+each command's `--help` and are pinned by the help snapshots (§3.2). A purpose change is a
+surface change.
+
+| Command | Purpose |
+|---|---|
+| `exec` | Run a command with a single secret injected into its environment, by redeeming a capability token. |
+| `store` | Save a secret into the active backend (value read from stdin — never from arguments). |
+| `delete` | Remove a secret from the active backend. |
+| `doctor` | Run preflight checks and report whether vaultkeeper is ready to use on this machine. |
+| `approve` | Pre-approve an executable by recording its hash in the trust manifest. |
+| `dev-mode` | Enable or disable relaxed identity verification for a script during development. |
+| `rotate-key` | Rotate the vault encryption key, re-sealing stored state under the new key. |
+| `revoke-key` | Emergency-revoke the vault encryption key, invalidating all outstanding tokens. |
+| `config init` | Create a new configuration file with defaults. |
+| `config show` | Print the current effective configuration. |
+| `backend capabilities` | Report the active backend's security capabilities (e.g. per-use presence enforcement). |
+| `profile init` | Scaffold a new named environment profile. |
+| `profile show` | Display a profile's entries and their policy — never secret values. |
+| `profile list` | List the available profiles. |
+| `profile lint` | Validate a profile and warn where its policy is looser than this machine's defaults (advisory). |
+| `session mint` | Mint a session signing lease for a profile entry, proving human presence at mint. |
+| `session revoke` | Revoke an outstanding lease by id, or every outstanding lease for a signing key. |
+| `run` *(in review)* | Resolve a profile and launch a command with that environment — stdio- and signal-transparent. |
+| `session redeem` *(designed)* | Redeem a signing lease into an in-process signing handle for non-interactive signing. |
+
 ### 1.1 Command tree (normative inventory)
 
 Landed on `origin/main`. `stdin`/`stdout`/`stderr` columns state the contract; `exit` is the success/typed

--- a/docs/specs/001-surface-governance.md
+++ b/docs/specs/001-surface-governance.md
@@ -80,9 +80,10 @@ grammar review covers them before they land:
 
 **G1 — Noun-verb for resource families; bare verb for whole-vault process actions.** A command earns a
 **noun namespace** (`<noun> <verb>`) when it manages a *category of addressable resources* with more than one
-operation: `config`, `backend`, `profile`, `session`. A command is a **bare top-level verb** when it is a
-single process action against the vault as a whole with no sibling operations on a shared resource: `exec`,
-`run`, `doctor`, `approve`, `dev-mode`.
+operation: `config`, `backend`, `profile`, `session`, and (post-B2/B3/B4 adjudication) `secret`, `key`,
+`trust`. A command is a **bare top-level verb** only when it is a single process action against the vault as
+a whole with no sibling operations on a shared resource — after adjudication, exactly two qualify: `run`
+(the launcher) and `doctor` (the whole-machine check).
 
 **G2 — The primary subject is positional; modifiers are flags.** A command's required primary subject — the
 resource it acts on — is a **positional argument**. Options, policy toggles, and alternate sources are

--- a/docs/specs/002-verifier-visible-assurance.md
+++ b/docs/specs/002-verifier-visible-assurance.md
@@ -17,6 +17,15 @@ attestation does not *remove* trust; it *relocates* it to Yubico. Every basis is
 the model has two independent dimensions, and the verifier composes their own policy over both — we disclose
 facts, we don't rank for them.
 
+That relocation carries a **retention requirement**: relocating trust to Yubico is only real if a verifier can
+*re-check* Yubico's attestation independently. So at enrollment the **full attestation certificate chain —
+including the touch-policy extension (§2, OID `1.3.6.1.4.1.41482.3.8`) — is stored in the enrollment record and
+carried (or referenced) in the wire `evidence` field**, so any verifier can re-validate the chain to the
+pinned Yubico root at verification time, not just trust vaultkeeper's word that it once checked. This makes the
+rule general: **a party is only nameable if its evidence is retained and re-checkable.** Without retained,
+re-checkable evidence the claim degrades to `vouchedBy: vaultkeeper` — vaultkeeper can still assert what it
+observed, but it can no longer relocate the trust to another party it cannot prove.
+
 **Dimension 1 — `perApprovalAction` (boolean, the policy-bearing axis).** From vaultkeeper's perspective: did
 a fresh, human-originated approval action **have to occur, scoped to this individual approval request, applied
 at the moment of approval, with no possibility that an already-unlocked / already-authorized state satisfied
@@ -29,8 +38,10 @@ it?** The final clause is the definitional test. This is `presencePerUse` evalua
 Every freshness finding from the earlier specs (the op-CLI session cache, the SE fresh-context requirement,
 the touch-cached window) is now an *instance of this one rule*, not a per-mechanism caveat.
 
-**Dimension 2 — `attestedBy` (a named party, the disclosure axis).** The party vouching for the claim:
-`yubico`, `vaultkeeper`, `1password`, `apple` (future). **Not a rank — a name the verifier chooses to trust
+**Dimension 2 — `vouchedBy` (a named party, the disclosure axis).** *(Field renamed from `attestedBy` to
+`vouchedBy` to avoid a collision with the sibling project attest-it, whose "attest" vocabulary names a
+different concept; "vouches for" also reads more plainly as "a named party stands behind this claim.")* The
+party vouching for the claim: `yubico`, `vaultkeeper`, `1password`, `apple` (future). **Not a rank — a name the verifier chooses to trust
 or not.** The closed-enum discipline lives *here*: the **party list is the small closed set** verifiers must
 be exhaustive over (an unrecognized party fails closed); the **mechanism vocabulary stays open/append-only**
 (§3). Each party has, in the registry, a documented **evidence format** and one documented property:
@@ -44,9 +55,9 @@ This per-party `independentlyCheckable` property is where the old "proven vs rec
 now lives — as a **factual property of the attesting party, stated once in the registry**, never as a class
 that demotes a mechanism.
 
-**The two dimensions interact cleanly:** `attestedBy` determines *who vouches for `perApprovalAction`*. When
-`attestedBy = yubico`, the attestation cert independently establishes touch-always, so `perApprovalAction=true`
-is itself independently checkable. When `attestedBy = vaultkeeper`, `perApprovalAction=true` is vaultkeeper's
+**The two dimensions interact cleanly:** `vouchedBy` determines *who vouches for `perApprovalAction`*. When
+`vouchedBy = yubico`, the attestation cert independently establishes touch-always, so `perApprovalAction=true`
+is itself independently checkable. When `vouchedBy = vaultkeeper`, `perApprovalAction=true` is vaultkeeper's
 own assertion — fully usable, anchored in the party the user already trusts.
 
 ## §1 The claim, its two carriers, and the per-party forgery disclosure (AC 1)
@@ -60,12 +71,12 @@ class:
 - **Payload-bound carrier:** the claim is bound into the signed payload (the env-epic §5 `pres` seed), for
   presence that is a per-event fact vaultkeeper witnessed (web approval). Covered by the vault signature.
 
-Both yield the same `{ perApprovalAction, mechanism, attestedBy, evidence?, enrollmentVerification? }`.
+Both yield the same `{ perApprovalAction, mechanism, vouchedBy, evidence?, enrollmentVerification? }`.
 
 **Forgery disclosure — factual, per attesting party, not ranked.** Can an attacker forge a claim bearing this
 party's attestation? (✗ = cannot; ✓ = can.)
 
-| Attacker / compromise | `attestedBy: yubico` | `attestedBy: vaultkeeper` |
+| Attacker / compromise | `vouchedBy: yubico` | `vouchedBy: vaultkeeper` |
 |---|---|---|
 | Same-UID code execution | ✗ — hardware refuses to sign without a live touch | `perApprovalAction=true` was proven **at mint**, but a same-UID attacker rides the non-interactive redemption inside the lease window (env-epic §6) |
 | Stolen laptop (token/biometric absent) | ✗ — no physical token | ✓ if the vault key is readable on the stolen disk |
@@ -90,21 +101,21 @@ is *possible* differs by system, grounded in real capability:
 - **YubiKey PIV — Yubico can attest.** `ykman piv keys attest <slot>` emits an attestation cert signed by a
   Yubico intermediate chaining to a Yubico root; touch/PIN policy is in extension **OID
   `1.3.6.1.4.1.41482.3.8`** (touch `02` = always). Enrollment verifies the chain to the pinned Yubico root and
-  asserts touch `== 02` → `perApprovalAction=true`, `attestedBy=yubico`, `independentlyCheckable`. Records the
+  asserts touch `== 02` → `perApprovalAction=true`, `vouchedBy=yubico`, `independentlyCheckable`. Records the
   cert as `evidence`.
 - **WebAuthn / passkey — the authenticator attests per assertion.** The **User Verification (UV)** bit in
   `authenticatorData` proves a biometric/PIN ceremony for *that* assertion → `perApprovalAction=true`,
-  `attestedBy` = the authenticator/party per its AAGUID attestation, independently checkable per signature.
+  `vouchedBy` = the authenticator/party per its AAGUID attestation, independently checkable per signature.
 - **Secure Enclave biometric — vaultkeeper attests; `apple` is not (yet) an available party.** Verified
   limitation: **there is no macOS API for an app to obtain an Apple-signed attestation of a Secure-Enclave
   key's access-control policy** (App Attest attests app+device, not a `SecKey`'s biometric gating). So the key
   is created with `.biometryCurrentSet` (fresh-context biometric → `perApprovalAction=true`) and enrolled as
-  `attestedBy=vaultkeeper`. **This is not a downgrade — it is fully usable**, anchored in the party the user
+  `vouchedBy=vaultkeeper`. **This is not a downgrade — it is fully usable**, anchored in the party the user
   trusts. The "no Apple attestation" fact is recorded in `enrollmentVerification` as *why `apple` is not an
   available attesting party for this key*; if Apple ever ships such an API, the same key **promotes
-  automatically** to `attestedBy=apple, independentlyCheckable` with no re-enrollment of the human.
+  automatically** to `vouchedBy=apple, independentlyCheckable` with no re-enrollment of the human.
 - **Authenticated web approval / IdP — vaultkeeper attests a witnessed event.** No key policy to attest;
-  `perApprovalAction=true`, `attestedBy=vaultkeeper`, payload-bound carrier, optional IdP `evidence`.
+  `perApprovalAction=true`, `vouchedBy=vaultkeeper`, payload-bound carrier, optional IdP `evidence`.
 
 **`enrollmentVerification` — how vaultkeeper knows `perApprovalAction`, recorded honestly.** This is where
 the enrollment-attested-vs-TOFU distinction survives — *within Dimension 1's derivation*, as an evidence note,
@@ -115,7 +126,7 @@ verified; apple attestation unavailable"). record-with-honest-downgrade stays: t
 
 **Refusal is reserved for contradiction, not for the unverifiable.** SE-biometric is recorded, not refused —
 refusing it would push users to weaker setups. Enrollment **fails closed only when a claim of an
-independently-checkable party is contradicted**: an enrollment asserting `attestedBy=yubico` whose chain fails,
+independently-checkable party is contradicted**: an enrollment asserting `vouchedBy=yubico` whose chain fails,
 whose root isn't Yubico, or whose touch ≠ `02`. A false checkable claim is worse than an honest
 vaultkeeper-anchored one.
 
@@ -125,7 +136,7 @@ Three fields, three openness policies:
 
 - **`mechanism` — open, append-only registry (descriptive):** `hardware-touch`, `biometric`, `passkey-uv`,
   `web-approval`, extended without a schema or verifier-code change — the e-signature breadth #320 wants.
-- **`attestedBy` — closed party set (decision-bearing):** verifiers are exhaustive over it; an unknown party
+- **`vouchedBy` — closed party set (decision-bearing):** verifiers are exhaustive over it; an unknown party
   fails closed. New parties are added deliberately, each with its evidence format and `independentlyCheckable`
   property.
 - **`perApprovalAction` — boolean:** the one policy-bearing value; a new mechanism maps to `true`/`false` by
@@ -134,9 +145,12 @@ Three fields, three openness policies:
 ## §4 Verifier vocabulary
 
 A verifier resolves a signature (via key-custody attribute or bound assertion) to
-`AssuranceClaim { perApprovalAction, mechanism, attestedBy, evidence?, enrollmentVerification? }`, then
-evaluates a policy that **composes over both dimensions** — e.g. `perApprovalAction == true AND attestedBy ∈
-{yubico, vaultkeeper}`, or a stricter `attestedBy.independentlyCheckable == true` for a high-stakes gate. This
+`AssuranceClaim { perApprovalAction, mechanism, vouchedBy, evidence?, enrollmentVerification? }`, then
+evaluates a policy that **composes over both dimensions** — e.g. `perApprovalAction == true AND vouchedBy ∈
+{yubico, vaultkeeper}`, or a stricter `parties[claim.vouchedBy].independentlyCheckable == true` for a
+high-stakes gate. Note the indirection: `vouchedBy` carries the party **name**, and `independentlyCheckable`
+is a property of that party's **registry entry** — the verifier looks the party up in the party registry
+(`parties[…]`) to read it, it is not a field on the claim itself. This
 is generic and consumer-independent — exactly the misconfiguration-proof predicate attest-it#150 weighs. The
 verifier draws the strength conclusion; the spec supplies the two orthogonal facts.
 
@@ -144,7 +158,7 @@ verifier draws the strength conclusion; the spec supplies the two orthogonal fac
 
 **Cross-repo consultation recorded: attest-it#150.** It leans consumer-side convention but states a
 vaultkeeper custody attribute "would age better." **I concur and recommend vaultkeeper originate it**, because
-`perApprovalAction` and `attestedBy` are stable properties of *key custody* attest-it already tracks per
+`perApprovalAction` and `vouchedBy` are stable properties of *key custody* attest-it already tracks per
 identity — encode once at the identity layer, not re-derived per consumer. A seal cannot carry assurance today
 (neither policy nor seal schema has the field), so the schema change is **attest-it's call**; this spec
 proposes shapes and freezes nothing.
@@ -154,7 +168,7 @@ proposes shapes and freezes nothing.
 "assurance": {
   "perApprovalAction": true,
   "mechanism": "hardware-touch",
-  "attestedBy": "yubico",
+  "vouchedBy": "yubico",
   "evidence": { "type": "yubico-piv-attestation", "certChain": ["<base64…>"], "touchPolicy": "always" },
   "enrollmentVerification": { "method": "hardware-attestation", "verifiedAt": 1770000000 }
 }
@@ -163,12 +177,12 @@ proposes shapes and freezes nothing.
 "assurance": {
   "perApprovalAction": true,
   "mechanism": "biometric",
-  "attestedBy": "vaultkeeper",
+  "vouchedBy": "vaultkeeper",
   "enrollmentVerification": { "method": "tofu-recorded", "notes": "policy recorded; apple attestation unavailable" }
 }
 ```
 
-`attestedBy` (+ its registry `independentlyCheckable`) and `perApprovalAction` are the two fields a verifier's
+`vouchedBy` (+ its registry `independentlyCheckable`) and `perApprovalAction` are the two fields a verifier's
 policy may key on; `mechanism` is descriptive; `evidence` lets a verifier re-derive an independently-checkable
 party's claim. **Open question for #150:** does a "requires presence" gate predicate live in attest-it's
 policy schema (generic, misconfig-proof — my lean) or stay consumer convention?
@@ -177,8 +191,8 @@ policy schema (generic, misconfig-proof — my lean) or stay consumer convention
 
 Keys enrolled before assurance carry **no `assurance` claim → `perApprovalAction` unknown → they satisfy no
 `perApprovalAction==true` gate** (absence is never presence — fail closed, §7). Upgrade is **explicit
-re-enrollment**, never silent: YubiKey keys run the attestation check (`attestedBy=yubico`); SE keys are
-re-recorded (`attestedBy=vaultkeeper`, `tofu-recorded`); others stay unbacked. No existing signature's meaning
+re-enrollment**, never silent: YubiKey keys run the attestation check (`vouchedBy=yubico`); SE keys are
+re-recorded (`vouchedBy=vaultkeeper`, `tofu-recorded`); others stay unbacked. No existing signature's meaning
 changes retroactively.
 
 ## §7 Test-artifact discipline (from product-brief §7)
@@ -192,22 +206,22 @@ applied to this artifact class. Negative tests assert a marked claim is rejected
 
 Substrate: the lease/presence lane (**#298–#300**, env-epic §5) and the handle table (**#268**). `[S]`/`[M]`.
 
-1. **`AssuranceClaim` model — `perApprovalAction` boolean + closed `attestedBy` party registry (each with
+1. **`AssuranceClaim` model — `perApprovalAction` boolean + closed `vouchedBy` party registry (each with
    evidence format + `independentlyCheckable`) + open `mechanism` registry** — core types, serde; encode the
    §0 rule that `perApprovalAction` derives from the definitional test and an unknown party fails closed.
    **[S]** (the two-dimension schema is the contract). *Deps:* env-epic §5 `pres` seed.
-2. **YubiKey enrollment → `attestedBy=yubico`** — verify `ykman piv keys attest` chain to a pinned Yubico
+2. **YubiKey enrollment → `vouchedBy=yubico`** — verify `ykman piv keys attest` chain to a pinned Yubico
    root, assert touch `== 02` → `perApprovalAction=true`; fail closed on a contradicted checkable claim.
    **[S]**. *Deps:* 1; #288 yubikey port.
-3. **Secure-Enclave enrollment → `attestedBy=vaultkeeper`, `perApprovalAction=true`, `tofu-recorded`** —
+3. **Secure-Enclave enrollment → `vouchedBy=vaultkeeper`, `perApprovalAction=true`, `tofu-recorded`** —
    `.biometryCurrentSet`; record the apple-unavailable note; **auto-promote hook** if an Apple attestation API
    ever appears. **[M]**. *Deps:* 1.
 4. **`perApprovalAction` derivation at signing time + payload-bound carrier** — evaluate the §0 definitional
    test against the active backend/session (touch-always vs cached, fresh vs reused context), and bind the
-   `assurance` object into the payload under the vault key for `attestedBy=vaultkeeper` mechanisms
+   `assurance` object into the payload under the vault key for `vouchedBy=vaultkeeper` mechanisms
    (`biometric`, `web-approval`). **[S]** (touches the sign path + §5 claim). *Deps:* 1; #299/#300; #268.
 5. **Verifier vocabulary + two-dimension policy predicate** — resolve a signature to an `AssuranceClaim`
-   (either carrier); evaluate a predicate over `perApprovalAction` × `attestedBy` (incl.
+   (either carrier); evaluate a predicate over `perApprovalAction` × `vouchedBy` (incl.
    `independentlyCheckable`); re-verify checkable-party evidence. **[M]**. *Deps:* 1, 2, 4.
 6. **Migration + fail-closed defaults + test-artifact refusal** — unenrolled keys assert nothing;
    re-enrollment explicit; marked test assurance refused in production (§6, §7). **[M]**. *Deps:* 1, 5.
@@ -223,14 +237,14 @@ thin adapter.
 
 1. **Gate predicate placement (#150):** in attest-it's policy model (generic, misconfig-proof — my lean) vs.
    consumer convention?
-2. **Is `attestedBy` a single party or a set per key?** A key could carry both a Yubico attestation *and* a
-   vaultkeeper record; modeling `attestedBy` as a set lets a verifier pick the strongest party *they* trust.
+2. **Is `vouchedBy` a single party or a set per key?** A key could carry both a Yubico attestation *and* a
+   vaultkeeper record; modeling `vouchedBy` as a set lets a verifier pick the strongest party *they* trust.
    Slightly more schema; more future-proof. I lean single-party value on a set-capable shape for v1.
 3. **SE re-enrollment on biometric reset:** `.biometryCurrentSet` invalidates the key when Face/Touch ID is
    re-enrolled — a natural revocation signal but an availability footgun. Treat invalidation as automatic
    assurance-revocation (fail closed)? Confirm.
 4. **`independentlyCheckable` for `1password`:** the DesktopAuth dylib grant is per-process (consolidation
-   epic §2) but yields no verifier-checkable evidence — so `attestedBy=1password` would be
+   epic §2) but yields no verifier-checkable evidence — so `vouchedBy=1password` would be
    `independentlyCheckable: false` (vaultkeeper-equivalent trust). Confirm 1Password earns a distinct party
    name vs folding under `vaultkeeper` until it can produce checkable evidence.
 

--- a/docs/specs/002-verifier-visible-assurance.md
+++ b/docs/specs/002-verifier-visible-assurance.md
@@ -1,0 +1,241 @@
+# Architecture Spec — Verifier-Visible Assurance (issue #320)
+
+Contract read in full: **#320** (OPEN, its five ACs are this spec's charter), product-brief §7
+(claims-only-if-enforced; test artifacts self-announcing, production refuses them) and §9 (assurance is a
+committed 1.0 pillar), the PRFAQ "Can a signature prove a human was present?" answer, the frozen env-epic §5
+`pres`-claim (assertion seed), and **attest-it#150** (consumer side; leans convention, notes a vaultkeeper
+custody attribute "would age better"). Enrollment-attestation capabilities verified against real systems
+(sources at end), not assumed. **Rev 2** reframes the model onto two orthogonal dimensions (owner direction);
+the facts, forgery analysis, and reality-check all carry forward.
+
+## §0 The model: two orthogonal dimensions, no strength hierarchy
+
+Assurance is **not** a single strength axis. An earlier draft ranked "hardware-attested" above
+"vault-asserted" — that quietly treats *trusting vaultkeeper* as a liability, which is wrong: **vaultkeeper is
+the product's trust anchor.** A user who won't trust it shouldn't let it govern their secrets at all. YubiKey
+attestation does not *remove* trust; it *relocates* it to Yubico. Every basis is "trust some named party." So
+the model has two independent dimensions, and the verifier composes their own policy over both — we disclose
+facts, we don't rank for them.
+
+**Dimension 1 — `perApprovalAction` (boolean, the policy-bearing axis).** From vaultkeeper's perspective: did
+a fresh, human-originated approval action **have to occur, scoped to this individual approval request, applied
+at the moment of approval, with no possibility that an already-unlocked / already-authorized state satisfied
+it?** The final clause is the definitional test. This is `presencePerUse` evaluated at signing time.
+
+- `true`: Touch ID in a fresh context, YubiKey touch-**always**, 1Password `per-access` fresh-process grant.
+- `false`: an open/unlocked vault, session-mode caching, YubiKey touch-**cached** (15s window), a reused
+  `LAContext`.
+
+Every freshness finding from the earlier specs (the op-CLI session cache, the SE fresh-context requirement,
+the touch-cached window) is now an *instance of this one rule*, not a per-mechanism caveat.
+
+**Dimension 2 — `attestedBy` (a named party, the disclosure axis).** The party vouching for the claim:
+`yubico`, `vaultkeeper`, `1password`, `apple` (future). **Not a rank — a name the verifier chooses to trust
+or not.** The closed-enum discipline lives *here*: the **party list is the small closed set** verifiers must
+be exhaustive over (an unrecognized party fails closed); the **mechanism vocabulary stays open/append-only**
+(§3). Each party has, in the registry, a documented **evidence format** and one documented property:
+
+> **`independentlyCheckable`** — can a verifier confirm this party's attestation *without trusting
+> vaultkeeper*? `yubico`: **yes** (verify the Yubico attestation cert chain). `vaultkeeper`: **no** (the
+> evidence *is* the vault signature — trusting it is trusting the anchor). `1password`/`apple`: per the
+> party's evidence format if/when available.
+
+This per-party `independentlyCheckable` property is where the old "proven vs recorded-and-trusted" honesty
+now lives — as a **factual property of the attesting party, stated once in the registry**, never as a class
+that demotes a mechanism.
+
+**The two dimensions interact cleanly:** `attestedBy` determines *who vouches for `perApprovalAction`*. When
+`attestedBy = yubico`, the attestation cert independently establishes touch-always, so `perApprovalAction=true`
+is itself independently checkable. When `attestedBy = vaultkeeper`, `perApprovalAction=true` is vaultkeeper's
+own assertion — fully usable, anchored in the party the user already trusts.
+
+## §1 The claim, its two carriers, and the per-party forgery disclosure (AC 1)
+
+There is **one** artifact — an `AssuranceClaim` — with **two carriers**, an encoding choice, *not* a strength
+class:
+
+- **Key-custody carrier:** the claim is a property of the enrolled public key (e.g. a YubiKey whose touch
+  policy Yubico attests, or an SE key whose policy vaultkeeper records). Verifier resolves signer → key →
+  claim. Nothing per-signature.
+- **Payload-bound carrier:** the claim is bound into the signed payload (the env-epic §5 `pres` seed), for
+  presence that is a per-event fact vaultkeeper witnessed (web approval). Covered by the vault signature.
+
+Both yield the same `{ perApprovalAction, mechanism, attestedBy, evidence?, enrollmentVerification? }`.
+
+**Forgery disclosure — factual, per attesting party, not ranked.** Can an attacker forge a claim bearing this
+party's attestation? (✗ = cannot; ✓ = can.)
+
+| Attacker / compromise | `attestedBy: yubico` | `attestedBy: vaultkeeper` |
+|---|---|---|
+| Same-UID code execution | ✗ — hardware refuses to sign without a live touch | `perApprovalAction=true` was proven **at mint**, but a same-UID attacker rides the non-interactive redemption inside the lease window (env-epic §6) |
+| Stolen laptop (token/biometric absent) | ✗ — no physical token | ✓ if the vault key is readable on the stolen disk |
+| **Compromised vault key** | ✗ — the vault key cannot produce the hardware signature (the key never entered the vault) | ✓ — can mint a claim for presence that never occurred |
+
+The verifier reads this as disclosure and draws their own line: *a party whose signatures survive a
+compromised vault key* (yubico) *is what I require for high-stakes gates; for everyday approvals the anchor I
+already trust* (vaultkeeper) *is sufficient.* We state the facts; we do not tell them one is "the strong
+mechanism." Two honesty points hold regardless of party:
+
+1. **Presence proves a human was in the loop, never *which* human.** A thief who steals laptop *and* YubiKey
+   and touches it produces a valid `perApprovalAction=true` signature. Assurance is not authentication of a
+   specific person — said wherever the claim appears (§7 discipline).
+2. **`perApprovalAction=false` is a first-class, self-documenting value.** An automation signer is exactly
+   `perApprovalAction=false` — no special "automation" class needed (re-answers the earlier open Q).
+
+## §2 Enrollment: deriving `perApprovalAction` and the available attesting party (AC 2)
+
+Enrollment does two things — establish `perApprovalAction` and determine which party can attest it — and what
+is *possible* differs by system, grounded in real capability:
+
+- **YubiKey PIV — Yubico can attest.** `ykman piv keys attest <slot>` emits an attestation cert signed by a
+  Yubico intermediate chaining to a Yubico root; touch/PIN policy is in extension **OID
+  `1.3.6.1.4.1.41482.3.8`** (touch `02` = always). Enrollment verifies the chain to the pinned Yubico root and
+  asserts touch `== 02` → `perApprovalAction=true`, `attestedBy=yubico`, `independentlyCheckable`. Records the
+  cert as `evidence`.
+- **WebAuthn / passkey — the authenticator attests per assertion.** The **User Verification (UV)** bit in
+  `authenticatorData` proves a biometric/PIN ceremony for *that* assertion → `perApprovalAction=true`,
+  `attestedBy` = the authenticator/party per its AAGUID attestation, independently checkable per signature.
+- **Secure Enclave biometric — vaultkeeper attests; `apple` is not (yet) an available party.** Verified
+  limitation: **there is no macOS API for an app to obtain an Apple-signed attestation of a Secure-Enclave
+  key's access-control policy** (App Attest attests app+device, not a `SecKey`'s biometric gating). So the key
+  is created with `.biometryCurrentSet` (fresh-context biometric → `perApprovalAction=true`) and enrolled as
+  `attestedBy=vaultkeeper`. **This is not a downgrade — it is fully usable**, anchored in the party the user
+  trusts. The "no Apple attestation" fact is recorded in `enrollmentVerification` as *why `apple` is not an
+  available attesting party for this key*; if Apple ever ships such an API, the same key **promotes
+  automatically** to `attestedBy=apple, independentlyCheckable` with no re-enrollment of the human.
+- **Authenticated web approval / IdP — vaultkeeper attests a witnessed event.** No key policy to attest;
+  `perApprovalAction=true`, `attestedBy=vaultkeeper`, payload-bound carrier, optional IdP `evidence`.
+
+**`enrollmentVerification` — how vaultkeeper knows `perApprovalAction`, recorded honestly.** This is where
+the enrollment-attested-vs-TOFU distinction survives — *within Dimension 1's derivation*, as an evidence note,
+**not** as a class that demotes the claim. `{ method: "hardware-attestation" | "tofu-recorded", verifiedAt,
+notes }`: YubiKey is `hardware-attestation`; SE is `tofu-recorded` ("policy recorded, not independently
+verified; apple attestation unavailable"). record-with-honest-downgrade stays: the flag **informs** the
+`vaultkeeper`-attested claim's evidence, it does not move it to a lower tier.
+
+**Refusal is reserved for contradiction, not for the unverifiable.** SE-biometric is recorded, not refused —
+refusing it would push users to weaker setups. Enrollment **fails closed only when a claim of an
+independently-checkable party is contradicted**: an enrollment asserting `attestedBy=yubico` whose chain fails,
+whose root isn't Yubico, or whose touch ≠ `02`. A false checkable claim is worse than an honest
+vaultkeeper-anchored one.
+
+## §3 Extensible vocabulary (AC 3)
+
+Three fields, three openness policies:
+
+- **`mechanism` — open, append-only registry (descriptive):** `hardware-touch`, `biometric`, `passkey-uv`,
+  `web-approval`, extended without a schema or verifier-code change — the e-signature breadth #320 wants.
+- **`attestedBy` — closed party set (decision-bearing):** verifiers are exhaustive over it; an unknown party
+  fails closed. New parties are added deliberately, each with its evidence format and `independentlyCheckable`
+  property.
+- **`perApprovalAction` — boolean:** the one policy-bearing value; a new mechanism maps to `true`/`false` by
+  the §0 definitional test, never a new tier.
+
+## §4 Verifier vocabulary
+
+A verifier resolves a signature (via key-custody attribute or bound assertion) to
+`AssuranceClaim { perApprovalAction, mechanism, attestedBy, evidence?, enrollmentVerification? }`, then
+evaluates a policy that **composes over both dimensions** — e.g. `perApprovalAction == true AND attestedBy ∈
+{yubico, vaultkeeper}`, or a stricter `attestedBy.independentlyCheckable == true` for a high-stakes gate. This
+is generic and consumer-independent — exactly the misconfiguration-proof predicate attest-it#150 weighs. The
+verifier draws the strength conclusion; the spec supplies the two orthogonal facts.
+
+## §5 Wire-format proposal — proposed, not frozen (AC 4)
+
+**Cross-repo consultation recorded: attest-it#150.** It leans consumer-side convention but states a
+vaultkeeper custody attribute "would age better." **I concur and recommend vaultkeeper originate it**, because
+`perApprovalAction` and `attestedBy` are stable properties of *key custody* attest-it already tracks per
+identity — encode once at the identity layer, not re-derived per consumer. A seal cannot carry assurance today
+(neither policy nor seal schema has the field), so the schema change is **attest-it's call**; this spec
+proposes shapes and freezes nothing.
+
+```jsonc
+// Key-custody carrier (attest-it identity layer) — e.g. a YubiKey identity
+"assurance": {
+  "perApprovalAction": true,
+  "mechanism": "hardware-touch",
+  "attestedBy": "yubico",
+  "evidence": { "type": "yubico-piv-attestation", "certChain": ["<base64…>"], "touchPolicy": "always" },
+  "enrollmentVerification": { "method": "hardware-attestation", "verifiedAt": 1770000000 }
+}
+
+// Payload-bound carrier (seeded by env-epic §5 `pres`) — e.g. a Secure-Enclave or web-approval signer
+"assurance": {
+  "perApprovalAction": true,
+  "mechanism": "biometric",
+  "attestedBy": "vaultkeeper",
+  "enrollmentVerification": { "method": "tofu-recorded", "notes": "policy recorded; apple attestation unavailable" }
+}
+```
+
+`attestedBy` (+ its registry `independentlyCheckable`) and `perApprovalAction` are the two fields a verifier's
+policy may key on; `mechanism` is descriptive; `evidence` lets a verifier re-derive an independently-checkable
+party's claim. **Open question for #150:** does a "requires presence" gate predicate live in attest-it's
+policy schema (generic, misconfig-proof — my lean) or stay consumer convention?
+
+## §6 Migration for existing enrolled keys
+
+Keys enrolled before assurance carry **no `assurance` claim → `perApprovalAction` unknown → they satisfy no
+`perApprovalAction==true` gate** (absence is never presence — fail closed, §7). Upgrade is **explicit
+re-enrollment**, never silent: YubiKey keys run the attestation check (`attestedBy=yubico`); SE keys are
+re-recorded (`attestedBy=vaultkeeper`, `tofu-recorded`); others stay unbacked. No existing signature's meaning
+changes retroactively.
+
+## §7 Test-artifact discipline (from product-brief §7)
+
+A presence simulator or any test aid must be **structurally unable to emit a production-honored assurance
+claim**: test-emitted claims carry an unmistakable marker and the verifier **refuses marked assurance in
+production** — the same self-announcing / production-refuses rule the brief mandates for leases and tokens,
+applied to this artifact class. Negative tests assert a marked claim is rejected.
+
+## §8 Decomposition (AC 5)
+
+Substrate: the lease/presence lane (**#298–#300**, env-epic §5) and the handle table (**#268**). `[S]`/`[M]`.
+
+1. **`AssuranceClaim` model — `perApprovalAction` boolean + closed `attestedBy` party registry (each with
+   evidence format + `independentlyCheckable`) + open `mechanism` registry** — core types, serde; encode the
+   §0 rule that `perApprovalAction` derives from the definitional test and an unknown party fails closed.
+   **[S]** (the two-dimension schema is the contract). *Deps:* env-epic §5 `pres` seed.
+2. **YubiKey enrollment → `attestedBy=yubico`** — verify `ykman piv keys attest` chain to a pinned Yubico
+   root, assert touch `== 02` → `perApprovalAction=true`; fail closed on a contradicted checkable claim.
+   **[S]**. *Deps:* 1; #288 yubikey port.
+3. **Secure-Enclave enrollment → `attestedBy=vaultkeeper`, `perApprovalAction=true`, `tofu-recorded`** —
+   `.biometryCurrentSet`; record the apple-unavailable note; **auto-promote hook** if an Apple attestation API
+   ever appears. **[M]**. *Deps:* 1.
+4. **`perApprovalAction` derivation at signing time + payload-bound carrier** — evaluate the §0 definitional
+   test against the active backend/session (touch-always vs cached, fresh vs reused context), and bind the
+   `assurance` object into the payload under the vault key for `attestedBy=vaultkeeper` mechanisms
+   (`biometric`, `web-approval`). **[S]** (touches the sign path + §5 claim). *Deps:* 1; #299/#300; #268.
+5. **Verifier vocabulary + two-dimension policy predicate** — resolve a signature to an `AssuranceClaim`
+   (either carrier); evaluate a predicate over `perApprovalAction` × `attestedBy` (incl.
+   `independentlyCheckable`); re-verify checkable-party evidence. **[M]**. *Deps:* 1, 2, 4.
+6. **Migration + fail-closed defaults + test-artifact refusal** — unenrolled keys assert nothing;
+   re-enrollment explicit; marked test assurance refused in production (§6, §7). **[M]**. *Deps:* 1, 5.
+7. **Wire-format finalization with attest-it (#150)** — **BLOCKED on attest-it's response**; do not freeze the
+   seal/policy schema unilaterally. Land 1–6 against the *proposed* shape behind an internal boundary so
+   attest-it's decision changes one adapter, not the core. **[S]**. *Deps:* 1–6; attest-it#150.
+
+**Sequencing:** 1 gates all; 2/3/4 parallelize after 1; 5 after 2+4. **Item 7 is the only cross-repo freeze
+and must not front-run #150** — everything else ships against the proposed shape so the eventual schema is a
+thin adapter.
+
+## §9 Open questions for the owner / attest-it
+
+1. **Gate predicate placement (#150):** in attest-it's policy model (generic, misconfig-proof — my lean) vs.
+   consumer convention?
+2. **Is `attestedBy` a single party or a set per key?** A key could carry both a Yubico attestation *and* a
+   vaultkeeper record; modeling `attestedBy` as a set lets a verifier pick the strongest party *they* trust.
+   Slightly more schema; more future-proof. I lean single-party value on a set-capable shape for v1.
+3. **SE re-enrollment on biometric reset:** `.biometryCurrentSet` invalidates the key when Face/Touch ID is
+   re-enrolled — a natural revocation signal but an availability footgun. Treat invalidation as automatic
+   assurance-revocation (fail closed)? Confirm.
+4. **`independentlyCheckable` for `1password`:** the DesktopAuth dylib grant is per-process (consolidation
+   epic §2) but yields no verifier-checkable evidence — so `attestedBy=1password` would be
+   `independentlyCheckable: false` (vaultkeeper-equivalent trust). Confirm 1Password earns a distinct party
+   name vs folding under `vaultkeeper` until it can produce checkable evidence.
+
+---
+
+**Sources (enrollment-attestation reality check):**
+- [Yubico — Verifying the PIN/Touch policy of the PIV slots](https://support.yubico.com/hc/en-us/articles/4711638123932-Verifying-the-PIN-Touch-policy-of-the-PIV-slots) and [yk-attest-verify](https://github.com/joemiller/yk-attest-verify) — touch policy in ext OID `1.3.6.1.4.1.41482.3.8`, verifiable via the Yubico attestation cert chain.
+- [Private Key Attestation on macOS (SecureW2)](https://www.securew2.com/blog/key-attestation-macos) and [blink SE-SSH discussion](https://github.com/blinksh/blink/discussions/1892) — no macOS API for Apple-signed attestation of a Secure-Enclave key's access-control policy; `.biometryCurrentSet` gating and its reset-invalidation behavior.


### PR DESCRIPTION
Establishes `docs/specs/` and lands the two normative specs the 1.0 documents committed to.

**001 — Surface governance.** The CLI and library surfaces as designed artifacts. The review targets, in rough order of leverage:
- **§3.3 the glossary** — 16 terms, 9 carrying an ⚠ OWNER-DECIDES marker (token/lease/capability boundaries, the "minting key" ambiguity, grant's ban scope, vault-vs-keeper, mint/issue/create). Each has a recommendation to accept or overturn; rulings feed the banned-terms lint.
- **§1.3 the inconsistency table** — 8 grammar breaks with dispositions; B2 (promoting `store`/`delete`/`rotate-key`/`revoke-key` into `secret` and `key` noun namespaces) is the largest call. B5 (presence-flag family) is already adjudicated: scope-suffixed names.
- **§2.3 stability tiering** — 88 `@public` symbols, zero `@beta`: the tiering pass is proposed as a pre-1.0 gate.
- **§3 enforcement** — `cargo public-api` snapshot for the core crate, committed `--help` goldens (width-pinned, version-normalized), `check:vocabulary` over the surface artifacts, and the governance rule: a PR touching any committed surface artifact must update this spec in the same diff.

**002 — Verifier-visible assurance.** The two-dimension model: `perApprovalAction` (did a fresh human-originated approval have to occur for this request, with no already-unlocked state satisfying it) × `attestedBy` (a named party — yubico, vaultkeeper — with independently-checkable as a per-party property, not a rank). Includes the per-party forgery matrix, the enrollment reality check (YubiKey PIV touch is cryptographically attestable; Secure Enclave biometric is recorded-and-trusted, stated honestly), and a wire-shape proposal explicitly unfrozen pending cross-repo review.

Docs-only; no changeset.