### PR TITLE
Close public HandleTable::insert_signing bypass of the #282 signing-handle gate

### DIFF
--- a/crates/vaultkeeper-core/src/identity/handles.rs
+++ b/crates/vaultkeeper-core/src/identity/handles.rs
@@ -159,7 +159,7 @@ pub const HANDLE_TABLE_MAX_SIZE: usize = 10_000;
 
 /// Opaque handle identifier returned by [`HandleTable::insert_secret`] or by
 /// the crate-internal signing-handle insertion path (see
-/// [`crate::vault::VaultKeeper::register_signing_handle`], the sole gated
+/// `crate::vault::VaultKeeper::register_signing_handle`, the sole gated
 /// entry point for signing handles — issue #282).
 ///
 /// Carries no claims data itself — it is a bare, unguessable (UUID v4)

--- a/crates/vaultkeeper-core/src/identity/handles.rs
+++ b/crates/vaultkeeper-core/src/identity/handles.rs
@@ -157,8 +157,10 @@ use crate::util::time::now_secs;
 /// (release/expiry/usage-limit are).
 pub const HANDLE_TABLE_MAX_SIZE: usize = 10_000;
 
-/// Opaque handle identifier returned by [`HandleTable::insert_secret`] /
-/// [`HandleTable::insert_signing`].
+/// Opaque handle identifier returned by [`HandleTable::insert_secret`] or by
+/// the crate-internal signing-handle insertion path (see
+/// [`crate::vault::VaultKeeper::register_signing_handle`], the sole gated
+/// entry point for signing handles — issue #282).
 ///
 /// Carries no claims data itself — it is a bare, unguessable (UUID v4)
 /// lookup key. **It is bearer capability material, not a public
@@ -439,7 +441,24 @@ impl HandleTable {
 
     /// Register a signing-key handle. Carries no secret — a signing-key
     /// handle's `read_secret` is always refused (see [`wrong_kind_error`]).
-    pub fn insert_signing(&mut self, claims: SigningClaims, expires_at: Option<u64>) -> HandleId {
+    ///
+    /// Deliberately `pub(crate)`, not `pub`, even though [`HandleTable`]
+    /// itself is re-exported from this crate's root (`vaultkeeper-core` is
+    /// published to crates.io). This method performs no `expires_at`
+    /// validation of its own — [`crate::vault::VaultKeeper::register_signing_handle`]
+    /// is the sole gate that refuses a never-expiring (`None`) signing
+    /// handle (issue #282). If this method were `pub`, any downstream crate
+    /// could construct a bare [`HandleTable`] and call it directly with
+    /// `expires_at: None`, minting the exact durable ambient signing
+    /// capability that gate exists to prevent — bypassing
+    /// `register_signing_handle` entirely rather than merely calling it. Keep
+    /// this crate-internal until the issuance-side principal check (issue
+    /// #261) makes a public, ungated `insert_signing` safe to expose again.
+    pub(crate) fn insert_signing(
+        &mut self,
+        claims: SigningClaims,
+        expires_at: Option<u64>,
+    ) -> HandleId {
         self.insert(StoredClaims::Signing(claims), None, expires_at)
     }
 


### PR DESCRIPTION
## Summary

Issue #282's core ask — gate `VaultKeeper::register_signing_handle` behind an
issuance-side check — was already fully implemented on `main` by #283 (and
reinforced by #330's `redeem_signing_lease`, which routes through the same
gate). That prior work already:

- Rejects `expires_at: None` for signing handles with a typed
  `VaultError::AuthorizationDenied`.
- Narrows `register_signing_handle` to `pub(crate)`.
- Rewords the `crate::identity::handles` module docs and the method doc from
  "long-lived non-interactive signing is fully supported" to "deliberately
  out of scope for now, gated on the issuance-side principal check tracked in
  #261", while explicitly distinguishing non-extractability of key material
  (already handled by `SigningBackend`) from non-invocability by an untrusted
  caller (not yet handled).
- Has a regression test (`register_signing_handle_tests::none_expiry_signing_handle_is_gated`
  and `vault_keeper::redeem_signing_lease_cannot_bypass_the_finite_expiry_gate`)
  proving a `None`-expiry registration is refused.

While verifying the issue's "no public path can mint a never-expiring or
unlimited-use signing handle" acceptance criterion against the *current*
state of `main`, I found one residual gap the prior PRs didn't close:
`HandleTable::insert_signing` was still a plain `pub fn` on `HandleTable`,
which is re-exported from `vaultkeeper-core`'s crate root — and
`vaultkeeper-core` is published to crates.io. That means any downstream
crate could construct a bare `HandleTable::new()` and call
`insert_signing(claims, None)` directly, minting the exact durable ambient
signing capability the `register_signing_handle` gate exists to prevent —
bypassing the gate entirely rather than merely calling it un-gated.

This PR closes that one remaining public path: `HandleTable::insert_signing`
is now `pub(crate)`, consistent with the #283 precedent for
`register_signing_handle` itself. No other crate in the workspace
(`vaultkeeper-cli`, `vaultkeeper-wasm`, `vaultkeeper-conformance`) calls
`insert_signing`, so this is not observably breaking within the repo. I also
fixed the resulting `rustdoc` `private_intra_doc_links` warning on
`HandleId`'s doc comment (it linked to the now-private `insert_signing`).

## Scope note

Per the issue's hard-scope framing, this PR does **not** touch `sign()` or
any signing operation — signing-use accounting is tracked separately in
#345. It also does not implement the issuance-side principal check itself
(#261) — that remains the open product decision this gate exists to wait
for.

## Acceptance criteria mapping

1. *"No long-lived / unlimited / never-expiring signing handle class should
   be mintable until an invocation-time principal check exists"* — already
   covered by `register_signing_handle`'s `None`-expiry refusal (#283); this
   PR additionally closes the `HandleTable::insert_signing` bypass so the
   gate can't be sidestepped by a caller that skips `VaultKeeper` entirely.
   Covered by the pre-existing `none_expiry_signing_handle_is_gated` and
   `redeem_signing_lease_cannot_bypass_the_finite_expiry_gate` tests, plus
   the fact that `cargo build`/`cargo test`/`cargo clippy` all pass with
   `insert_signing` now `pub(crate)` and zero external callers.
2. *"Reword the module + method docs..."* — already done on `main` (#283);
   verified unchanged and still accurate by this PR (`handles.rs` module
   docs § "Why `expires_at` must stay caller-supplied... issue #282").
3. *"Distinguish non-extractability of key material from non-invocability by
   an untrusted caller"* — already present in the module docs (#283);
   verified unchanged by this PR.

## Test plan

- [x] `cargo test` (workspace) — all green (425+ core unit tests, 88
      `vault_keeper`/integration tests, plus CLI/wasm/conformance suites).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo doc -p vaultkeeper-core --no-deps` — no new warnings (fixed the
      one introduced by narrowing `insert_signing`'s visibility).
- No WASM rebuild needed — `insert_signing`/`HandleTable` are not part of
  the surface `vaultkeeper-wasm` wraps.

Refs #282
