### PR TITLE
Fix YubiKey delete() overclaiming presence-per-use coverage

### DIFF
--- a/crates/vaultkeeper-core/src/backend/yubikey.rs
+++ b/crates/vaultkeeper-core/src/backend/yubikey.rs
@@ -50,7 +50,7 @@ use zeroize::{Zeroize, Zeroizing};
 use crate::backend::file::hex_encode;
 use crate::backend::types::{
     BackendCapabilities, ExecOptions, HostPlatform, ListableBackend, PresenceCapableBackend,
-    SecretBackend,
+    PresenceOperation, SecretBackend,
 };
 use crate::errors::VaultError;
 
@@ -589,13 +589,31 @@ impl ListableBackend for YubikeyBackend {
 /// `getCapabilities` exactly: the answer always comes from the
 /// operator-declared configuration, never derived from the backend type
 /// alone.
+///
+/// **Operation coverage (issue #326):** the touch-per-operation policy only
+/// actually fires for `store()` and `retrieve()` — both perform the
+/// HMAC-SHA1 challenge-response (`ykman otp calculate 2 ...`) that demands
+/// the physical tap. [`SecretBackend::delete`] only calls `require_device()`
+/// (a presence *probe*: is a YubiKey plugged in at all) plus a filesystem
+/// unlink — it never invokes challenge-response, so it never actually
+/// demands a fresh touch. Reporting `presence_enforced_operations: None`
+/// (meaning "all keyed operations") would therefore be dishonest: a caller
+/// relying on `presencePerUse` to mean "deleting this secret requires a
+/// physical touch" would be misled. This reports
+/// `Some([PresenceOperation::Read, PresenceOperation::Store])`, excluding
+/// `Delete`, so a `--require-presence-per-use` delete fails closed via
+/// [`crate::vault::enforce_presence_requirement`] instead of silently
+/// succeeding with no touch. `Sign` does not apply — this backend does not
+/// implement `SigningBackend`.
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl PresenceCapableBackend for YubikeyBackend {
     async fn get_capabilities(&self) -> Result<BackendCapabilities, VaultError> {
         Ok(BackendCapabilities {
             presence_per_use: self.require_touch,
-            presence_enforced_operations: None,
+            presence_enforced_operations: self
+                .require_touch
+                .then(|| vec![PresenceOperation::Read, PresenceOperation::Store]),
         })
     }
 }
@@ -1279,6 +1297,51 @@ mod tests {
         let no_touch_backend = YubikeyBackend::new(host, false);
         let caps = no_touch_backend.get_capabilities().await.unwrap();
         assert!(!caps.presence_per_use);
+    }
+
+    /// Regression test for issue #326: `delete()` never performs
+    /// challenge-response — it only probes device presence
+    /// (`require_device`) and unlinks the entry — so `get_capabilities` must
+    /// not claim `Delete` is presence-enforced when `require_touch` is set.
+    /// Before the fix, `presence_enforced_operations` was `None`, which
+    /// `BackendCapabilities::enforces` treats as "every keyed operation is
+    /// covered" — silently misrepresenting `delete` as touch-gated. This
+    /// asserts the honest, operation-scoped contract: `Read` and `Store` are
+    /// covered (both perform challenge-response), `Delete` is not.
+    #[tokio::test]
+    async fn get_capabilities_excludes_delete_from_presence_enforced_operations_issue_326() {
+        let host = TestHost::new();
+        let backend = YubikeyBackend::new(host, true);
+        let caps = backend.get_capabilities().await.unwrap();
+
+        assert!(caps.presence_per_use);
+        assert_eq!(
+            caps.presence_enforced_operations,
+            Some(vec![PresenceOperation::Read, PresenceOperation::Store])
+        );
+        assert!(caps.enforces(PresenceOperation::Read));
+        assert!(caps.enforces(PresenceOperation::Store));
+        assert!(!caps.enforces(PresenceOperation::Delete));
+    }
+
+    /// Regression test for issue #326: a `--require-presence-per-use` delete
+    /// must fail closed via `enforce_presence_requirement` rather than
+    /// silently succeeding with no touch, now that `delete` is correctly
+    /// excluded from `presence_enforced_operations`.
+    #[tokio::test]
+    async fn require_presence_per_use_delete_fails_closed_issue_326() {
+        let host = TestHost::new();
+        let backend = YubikeyBackend::new(host, true);
+
+        let err = crate::vault::enforce_presence_requirement(
+            &backend,
+            PresenceOperation::Delete,
+            Some(true),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, VaultError::NotCapable { .. }));
     }
 
     #[tokio::test]

--- a/docs/api/vaultkeeper.backendcapabilities.md
+++ b/docs/api/vaultkeeper.backendcapabilities.md
@@ -58,7 +58,7 @@ readonly [PresenceOperation](./vaultkeeper.presenceoperation.md)<!-- -->\[\]
 
 </td><td>
 
-_(Optional)_ The keyed operations for which this instance actually forces a fresh per-use human action. When \*\*omitted\*\*, a `presencePerUse: true` instance is taken to force presence for \*\*all\*\* keyed operations — the default for a touch device (e.g. a YubiKey whose challenge-response touch fires on every `store`<!-- -->/`retrieve`<!-- -->/`delete`<!-- -->).
+_(Optional)_ The keyed operations for which this instance actually forces a fresh per-use human action. When \*\*omitted\*\*, a `presencePerUse: true` instance is taken to force presence for \*\*all\*\* keyed operations — appropriate only for a device whose per-use action genuinely fires on every keyed operation. Note that a touch-configured YubiKey is \*not\* such a device: its `delete` never performs the challenge-response that demands a touch, so `YubikeyBackend` lists `['read', 'store']` explicitly.
 
 A backend that can force presence for only \*some\* operations must list exactly those, so a `--require-presence-per-use` request for an \*\*uncovered\*\* operation fails closed with a `NotCapableError` rather than silently passing without a fresh action. For example, 1Password `per-access` forces a fresh biometric on reads (`setup`<!-- -->/`exec`<!-- -->) but routes `store`<!-- -->/`delete` through the cached session client, so it reports `['read']` — a flagged `store`<!-- -->/`delete` is then correctly refused.
 

--- a/docs/api/vaultkeeper.backendcapabilities.presenceenforcedoperations.md
+++ b/docs/api/vaultkeeper.backendcapabilities.presenceenforcedoperations.md
@@ -4,7 +4,7 @@
 
 ## BackendCapabilities.presenceEnforcedOperations property
 
-The keyed operations for which this instance actually forces a fresh per-use human action. When \*\*omitted\*\*, a `presencePerUse: true` instance is taken to force presence for \*\*all\*\* keyed operations — the default for a touch device (e.g. a YubiKey whose challenge-response touch fires on every `store`<!-- -->/`retrieve`<!-- -->/`delete`<!-- -->).
+The keyed operations for which this instance actually forces a fresh per-use human action. When \*\*omitted\*\*, a `presencePerUse: true` instance is taken to force presence for \*\*all\*\* keyed operations — appropriate only for a device whose per-use action genuinely fires on every keyed operation. Note that a touch-configured YubiKey is \*not\* such a device: its `delete` never performs the challenge-response that demands a touch, so `YubikeyBackend` lists `['read', 'store']` explicitly.
 
 A backend that can force presence for only \*some\* operations must list exactly those, so a `--require-presence-per-use` request for an \*\*uncovered\*\* operation fails closed with a `NotCapableError` rather than silently passing without a fresh action. For example, 1Password `per-access` forces a fresh biometric on reads (`setup`<!-- -->/`exec`<!-- -->) but routes `store`<!-- -->/`delete` through the cached session client, so it reports `['read']` — a flagged `store`<!-- -->/`delete` is then correctly refused.
 

--- a/docs/manual-tests/presence-per-use.md
+++ b/docs/manual-tests/presence-per-use.md
@@ -39,6 +39,15 @@ sets `{ "type": "yubikey", "enabled": true, "options": { "touchPolicy": "require
 4. Reconfigure the slot **without** a touch policy (`touchPolicy` absent) → the
    `yubikey` row now shows `presencePerUse: false`, and `--require-presence-per-use`
    fails with `NotCapableError` before any device access.
+5. **`delete` is not touch-enforced (issue #326).** Even with the slot's touch
+   policy `required`, `delete()` never performs challenge-response — it only
+   probes that a YubiKey is connected, then unlinks the entry file. Store a
+   secret, then run `vaultkeeper delete --name S --require-presence-per-use`.
+   Expect it to fail immediately with `NotCapableError` (exit 1) — no tap
+   prompt, no device access — because `presenceEnforcedOperations` for this
+   instance covers `read`/`store` only, never `delete`. Confirm the secret
+   still exists afterward (`vaultkeeper delete --name S` without the flag
+   removes it normally).
 
 ## 1Password (per-access mode)
 

--- a/packages/vaultkeeper/src/backend/types.ts
+++ b/packages/vaultkeeper/src/backend/types.ts
@@ -156,9 +156,11 @@ export interface BackendCapabilities {
   /**
    * The keyed operations for which this instance actually forces a fresh per-use
    * human action. When **omitted**, a `presencePerUse: true` instance is taken
-   * to force presence for **all** keyed operations — the default for a touch
-   * device (e.g. a YubiKey whose challenge-response touch fires on every
-   * `store`/`retrieve`/`delete`).
+   * to force presence for **all** keyed operations — appropriate only for a
+   * device whose per-use action genuinely fires on every keyed operation.
+   * Note that a touch-configured YubiKey is *not* such a device: its `delete`
+   * never performs the challenge-response that demands a touch, so
+   * `YubikeyBackend` lists `['read', 'store']` explicitly.
    *
    * A backend that can force presence for only *some* operations must list
    * exactly those, so a `--require-presence-per-use` request for an **uncovered**

--- a/packages/vaultkeeper/src/backend/yubikey-backend.ts
+++ b/packages/vaultkeeper/src/backend/yubikey-backend.ts
@@ -300,16 +300,36 @@ export class YubikeyBackend implements ListableBackend, PresenceCapableBackend {
    *
    * @remarks
    * `presencePerUse` is `true` only when the configured slot enforces a
-   * touch-per-operation policy (`requireTouch`), in which case every
-   * challenge-response — and therefore every `store`/`retrieve`/`delete` — forces
-   * a fresh physical tap that cannot be satisfied from any cached state. A slot
-   * without a touch policy reports `false`; the answer is never derived from the
-   * backend `type` alone. Truth-basis: the reported value comes from the
+   * touch-per-operation policy (`requireTouch`). A slot without a touch
+   * policy reports `false`; the answer is never derived from the backend
+   * `type` alone. Truth-basis: the reported value comes from the
    * operator-declared `touchPolicy` configuration; confirm it matches the
    * physical slot with `ykman otp info` (a manual verification).
+   *
+   * **Operation coverage (issue #326):** the touch-per-operation policy only
+   * actually fires for {@link YubikeyBackend.store} and
+   * {@link YubikeyBackend.retrieve} — both perform the HMAC-SHA1
+   * challenge-response (`ykman otp calculate 2 ...`) that demands the
+   * physical tap. {@link YubikeyBackend.delete} only calls
+   * `requireDevice()` (a presence *probe*: is a YubiKey plugged in at all)
+   * plus a filesystem unlink — it never invokes challenge-response, so it
+   * never actually demands a fresh touch. Reporting
+   * `presenceEnforcedOperations` omitted (meaning "all keyed operations")
+   * would therefore be dishonest: a caller relying on `presencePerUse` to
+   * mean "deleting this secret requires a physical touch" would be misled.
+   * This reports `presenceEnforcedOperations: ['read', 'store']`, excluding
+   * `'delete'`, so a `--require-presence-per-use` delete fails closed
+   * instead of silently succeeding with no touch. `'sign'` does not apply —
+   * this backend does not implement signing.
    */
   getCapabilities(): Promise<BackendCapabilities> {
-    return Promise.resolve({ presencePerUse: this.#requireTouch })
+    if (this.#requireTouch) {
+      return Promise.resolve({
+        presencePerUse: true,
+        presenceEnforcedOperations: ['read', 'store'],
+      })
+    }
+    return Promise.resolve({ presencePerUse: false })
   }
 
   async isAvailable(): Promise<boolean> {

--- a/packages/vaultkeeper/test/integration/presence-enforcement.test.ts
+++ b/packages/vaultkeeper/test/integration/presence-enforcement.test.ts
@@ -21,6 +21,7 @@ import {
   DeviceNotPresentError,
 } from '../../src/errors.js'
 import { MockPresenceBackend } from '../helpers/presence-backend.js'
+import { YubikeyBackend } from '../../src/backend/yubikey-backend.js'
 
 async function vaultWith(backend: MockPresenceBackend): Promise<VaultKeeper> {
   return VaultKeeper.init({ skipDoctor: true, backend })
@@ -283,6 +284,26 @@ describe('operation-aware, fail-closed enforcement (1Password per-access shape)'
     expect(typeof jwe).toBe('string')
     // One action for the seed store, one for the presence-gated read.
     expect(backend.freshActionDemands).toBe(2)
+  })
+})
+
+describe('YubikeyBackend delete is not presence-enforced (regression, issue #326)', () => {
+  it('a --require-presence-per-use delete against a touch-configured YubiKey backend fails closed with NotCapableError', async () => {
+    // Regression for issue #326: delete() never performs challenge-response
+    // (it only probes device presence and unlinks the entry), so
+    // getCapabilities() correctly excludes 'delete' from
+    // presenceEnforcedOperations. Before the fix, that field was omitted
+    // entirely, which the shared enforcement contract reads as "every keyed
+    // operation is covered" — so a requirePresencePerUse delete would have
+    // silently passed enforcement instead of failing closed. Enforcement
+    // runs before any backend touch, so no real YubiKey/ykman is needed
+    // here: the refusal must happen before device I/O is attempted.
+    const backend = new YubikeyBackend('/tmp/vk-issue-326-yubikey', true)
+    const vault = await VaultKeeper.init({ skipDoctor: true, backend })
+
+    await expect(vault.delete('k', { requirePresencePerUse: true })).rejects.toBeInstanceOf(
+      NotCapableError,
+    )
   })
 })
 

--- a/packages/vaultkeeper/test/unit/backend/capabilities.test.ts
+++ b/packages/vaultkeeper/test/unit/backend/capabilities.test.ts
@@ -73,8 +73,25 @@ describe('per-backend truth basis (AC2)', () => {
     // same type differ purely by their configured touch policy.
     const withTouch = new YubikeyBackend('/tmp/vk-caps-yk', true)
     const withoutTouch = new YubikeyBackend('/tmp/vk-caps-yk', false)
-    await expect(withTouch.getCapabilities()).resolves.toEqual({ presencePerUse: true })
+    await expect(withTouch.getCapabilities()).resolves.toEqual({
+      presencePerUse: true,
+      presenceEnforcedOperations: ['read', 'store'],
+    })
     await expect(withoutTouch.getCapabilities()).resolves.toEqual({ presencePerUse: false })
+  })
+
+  it('YubiKey excludes delete from presenceEnforcedOperations (regression, issue #326)', async () => {
+    // delete() never performs challenge-response — it only probes device
+    // presence (requireDevice) and unlinks the entry — so a touch-configured
+    // slot must not claim `delete` is presence-enforced. Before the fix,
+    // getCapabilities omitted `presenceEnforcedOperations` entirely, which
+    // the shared capability contract treats as "every keyed operation is
+    // covered" — silently misrepresenting `delete` as touch-gated.
+    const withTouch = new YubikeyBackend('/tmp/vk-caps-yk', true)
+    const caps = await withTouch.getCapabilities()
+    expect(caps.presencePerUse).toBe(true)
+    expect(caps.presenceEnforcedOperations).toEqual(['read', 'store'])
+    expect(caps.presenceEnforcedOperations).not.toContain('delete')
   })
 
   it('YubiKey defaults to false when no touch policy is configured', async () => {


### PR DESCRIPTION
## Summary

`YubikeyBackend.get_capabilities()`/`getCapabilities()` reported `presence_enforced_operations: None` (Rust) / omitted `presenceEnforcedOperations` (TS) whenever the configured slot enforces touch — which the shared capability contract reads as "every keyed operation is covered." But `delete()` never performs the HMAC-SHA1 challenge-response that actually demands the physical tap; it only probes device presence (`require_device()`/`requireDevice()`) and unlinks the entry file. A caller relying on `presencePerUse` to mean "deleting this secret requires a physical touch" was misled, and a `--require-presence-per-use` delete silently succeeded with no touch.

This implements option (b) from the issue: both implementations now report `presenceEnforcedOperations` scoped to `read`/`store` only (the two operations that actually invoke challenge-response), excluding `delete`. `sign` does not apply — this backend does not implement signing. This lets `enforce_presence_requirement`/`#enforcePresenceRequirement` fail closed for a `--require-presence-per-use` delete via the operation-scoped machinery from #258, instead of silently succeeding.

## Acceptance criteria mapping

1. **Rust `get_capabilities()` excludes Delete when `require_touch` is set** — `crates/vaultkeeper-core/src/backend/yubikey.rs::tests::get_capabilities_excludes_delete_from_presence_enforced_operations_issue_326`
2. **TS/Rust lockstep contract** — same shape (`['read', 'store']` / `[Read, Store]`, omitting delete) implemented in both `crates/vaultkeeper-core/src/backend/yubikey.rs` and `packages/vaultkeeper/src/backend/yubikey-backend.ts`; covered by `packages/vaultkeeper/test/unit/backend/capabilities.test.ts::YubiKey excludes delete from presenceEnforcedOperations (regression, issue #326)` mirroring the Rust test above
3. **`--require-presence-per-use` delete fails closed** — Rust: `crates/vaultkeeper-core/src/backend/yubikey.rs::tests::require_presence_per_use_delete_fails_closed_issue_326`. TS: `packages/vaultkeeper/test/integration/presence-enforcement.test.ts::YubikeyBackend delete is not presence-enforced (regression, issue #326) > a --require-presence-per-use delete against a touch-configured YubiKey backend fails closed with NotCapableError` — both drive the real `YubikeyBackend`/`get_capabilities` through the shared enforcement path (`enforce_presence_requirement`/`VaultKeeper.delete`), not a hand-built approximation. Enforcement runs before any backend touch, so no real device/`ykman` is required.
4. **Regression tests referencing #326, failing pre-fix** — the four named tests above all assert `Some([Read, Store])` / `['read', 'store']` (Rust/TS) and a `NotCapable`/`NotCapableError` refusal; against unmodified code `presence_enforced_operations` was `None`/omitted, so `enforces(Delete)` was `true` and the enforcement test would have observed the delete proceed rather than being refused.
5. **Cross-implementation parity** — the Rust unit-test suite in `crates/vaultkeeper-core/src/backend/yubikey.rs` and the TS suites in `packages/vaultkeeper/test/unit/backend/capabilities.test.ts` / `packages/vaultkeeper/test/integration/presence-enforcement.test.ts` are the existing mirrored (ported) test suites for this contract (see the module-level doc comments referencing each other) and were extended in lockstep with equivalent regression tests in both languages.
6. **Capability docs updated** — doc comments on both `PresenceCapableBackend for YubikeyBackend` impls now explain the operation-scoped rationale; `docs/manual-tests/presence-per-use.md` YubiKey section gained a new manual-verification step (5) documenting that `delete` is not touch-enforced even with a required touch policy.
7. **Standard gates green** — `pnpm check`, `pnpm test`, `cargo test --workspace`, `cargo clippy --workspace --all-targets`, `cargo fmt --all -- --check`, and `pnpm exec prettier --check` on touched files all pass locally.

## Notes

- No public API surface change: `YubikeyBackend` is `@internal` in the TS package, so `pnpm generate:api-report`/`generate:api-docs` produced no diff (`pnpm check`'s `check:api-report` passed as part of `pnpm check`).
- Per the dispatch brief, changes are confined to the yubikey backend files, their tests, and capability docs — no edits to `types.rs`, `errors.ts`, or CI workflow files.

Refs #326, #258, #324
